### PR TITLE
Updated VC to 0.99.6

### DIFF
--- a/Vampire Covenant.cat
+++ b/Vampire Covenant.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2c4f-2485-9386-ab13" revision="31" gameSystemId="7e6fb76e-1bec-b992-2c43-e797a6758b13" gameSystemRevision="0" battleScribeVersion="1.15" name="Vampire Covenant" books="Vampire Covenant - v0.99.6" authorName="Toreador13 and duxbuse" authorContact="Toreador13@gmail.com" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2c4f-2485-9386-ab13" revision="91" gameSystemId="7e6fb76e-1bec-b992-2c43-e797a6758b13" gameSystemRevision="0" battleScribeVersion="1.15" name="Vampire Covenant" books="Vampire Covenant - v0.99.6" authorName="Toreador13 and duxbuse" authorContact="Toreador13@gmail.com" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="2eb7-fb68-4747-cd09" name="Altar of Undeath" points="200.0" categoryId="5261726523232344415441232323" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="2" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
@@ -7858,8 +7858,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
           <profiles>
             <profile id="014e-3d13-db6f-6fbc" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Staff of Gerhard the Black" hidden="false" book="Vampire Covenant">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="An army containing this item may reroll failed Channelling attempts. When the bearer casts the Invocation of the Undead Spell it may, for each target, reroll the a single D6 or D3 used to determine the number of Raised Wounds.
-"/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="An army containing this item may reroll failed Channelling attempts. When the bearer casts the Invocation of the Undead Spell it may, for each target, reroll the a single D6 or D3 used to determine the number of Raised Wounds. "/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -9216,6 +9215,11 @@ Leadership instead of its Toughness.
 </description>
       <modifiers/>
     </rule>
+    <rule id="2f08-0229-2f20-122a" name="Lightning Reflexes" hidden="false">
+      <description>Model parts with this special rule have +1 to hit with their Close Combat Attacks. This does not apply if the model part would be striking at initiative 0 (for example due to a Great Weapon or the Mesmeric Allure spell).Ifthis is the case, it strikes at its own Initiative instead.
+</description>
+      <modifiers/>
+    </rule>
     <rule id="0032-bb4f-66b3-2b32" name="Magical Attacks" hidden="false">
       <description>Attacks with this Special Rule or Attacks made by parts of models with this Special Rule normally don’t have any special effect. However, they interact with other rules (such as Ethereal). Models with this Special Rule apply it to all their attacks, including Special Attacks such as Stomps, Impact Hits, and Breath Attacks (unless stated otherwise). If a multipart model has this rule, then the rule is only applied to the part of the model that has the rule. All damage from Spells, Miscast hits and Magic Items cause Magical Attacks.
 </description>
@@ -9319,11 +9323,6 @@ regain its loose formation, keep the unit in tight formation until the first pla
 </description>
       <modifiers/>
     </rule>
-    <rule id="2f08-0229-2f20-122a" name="Lightning Reflexes" hidden="false">
-      <description>Model parts with this special rule have +1 to hit with their Close Combat Attacks. This does not apply if the model part would be striking at initiative 0 (for example due to a Great Weapon or the Mesmeric Allure spell).Ifthis is the case, it strikes at its own Initiative instead.
-</description>
-      <modifiers/>
-    </rule>
     <rule id="3ddf-107e-b6a0-05a2" name="Swiftstride" hidden="false">
       <modifiers/>
     </rule>
@@ -9402,13 +9401,13 @@ At the end of each Close Combat Phase, unitswith this special rule can make Vamp
       <description>Ward Saves are special saves, taken after failed Armour Saves. The value of the save will be stated in brackets. Ward Saves cannot be taken alongside Regeneration Saves (if a model has both, it must choose which one to use).</description>
       <modifiers/>
     </rule>
-    <rule id="0219-bcf9-3c5b-b19d" name="Wizard Conlclave" hidden="false">
-      <description>A Champion of a Unit with the Wizard Conclave Special Rule receives +1 Wound in addition to the normal Characteristics increases associated with being a Champion, and are Wizards of the Wizard Level given within brackets. This Champion knows predetermined spells, which are defined within the brackets. For example, a Champion of a Wizard Conclave (level 1, Blue Fire, Pink Fire) would be a level 1 Wizard with two predetermined spells (Blue Fire and Pink Fire). The Champion has a +1 to cast for each 5 models (excluding other Characters) in the Unit above their minimum starting Unit size, up to a maximum of +4 (including the bonus from their Wizard Level).
+    <rule id="b426-952e-f321-d6e2" name="Weapon Master" hidden="false">
+      <description>At the beginning of each Round of Combat, model parts with this special rule may choose which weapon they fight with. This includes selecting to use a Hand Weapon even if they have other weapons. If armed with a Magical Weapon, the model must still use it.
 </description>
       <modifiers/>
     </rule>
-    <rule id="b426-952e-f321-d6e2" name="Weapon Master" hidden="false">
-      <description>At the beginning of each Round of Combat, model parts with this special rule may choose which weapon they fight with. This includes selecting to use a Hand Weapon even if they have other weapons. If armed with a Magical Weapon, the model must still use it.
+    <rule id="0219-bcf9-3c5b-b19d" name="Wizard Conlclave" hidden="false">
+      <description>A Champion of a Unit with the Wizard Conclave Special Rule receives +1 Wound in addition to the normal Characteristics increases associated with being a Champion, and are Wizards of the Wizard Level given within brackets. This Champion knows predetermined spells, which are defined within the brackets. For example, a Champion of a Wizard Conclave (level 1, Blue Fire, Pink Fire) would be a level 1 Wizard with two predetermined spells (Blue Fire and Pink Fire). The Champion has a +1 to cast for each 5 models (excluding other Characters) in the Unit above their minimum starting Unit size, up to a maximum of +4 (including the bonus from their Wizard Level).
 </description>
       <modifiers/>
     </rule>

--- a/Vampire Covenant.cat
+++ b/Vampire Covenant.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2c4f-2485-9386-ab13" revision="30" gameSystemId="7e6fb76e-1bec-b992-2c43-e797a6758b13" gameSystemRevision="0" battleScribeVersion="1.15" name="Vampire Covenant" books="Vampire Covenant - v0.99.5" authorName="Toreador13 and duxbuse" authorContact="Toreador13@gmail.com" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2c4f-2485-9386-ab13" revision="31" gameSystemId="7e6fb76e-1bec-b992-2c43-e797a6758b13" gameSystemRevision="0" battleScribeVersion="1.15" name="Vampire Covenant" books="Vampire Covenant - v0.99.6" authorName="Toreador13 and duxbuse" authorContact="Toreador13@gmail.com" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="2eb7-fb68-4747-cd09" name="Altar of Undeath" points="200.0" categoryId="5261726523232344415441232323" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="2" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
@@ -1270,7 +1270,7 @@ chosen before the battle.
         <link id="8044-ae6f-687b-968b" targetId="42ff-db03-1efb-37d7" linkType="entry">
           <modifiers/>
         </link>
-        <link id="da39-2125-73df-dbc9" targetId="a7c9-81ec-0fa6-2eb5" linkType="rule">
+        <link id="da39-2125-73df-dbc9" targetId="8db6-5208-786b-6fa1" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value="(5+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions/>
@@ -1291,20 +1291,7 @@ chosen before the battle.
     <entry id="8457-9cf7-5623-fae2" name="Dark Coach" points="190.0" categoryId="5261726523232344415441232323" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="4f1e-dd9a-2808-0823" name="Dark Coach" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="2e06-a67e-acfe-c3a4" name="Heavy Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="d1e2-5790-d7f1-271b" targetId="5f22-3e9e-2b65-5c82" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -1330,9 +1317,9 @@ chosen before the battle.
             </profile>
           </profiles>
           <links>
-            <link id="8c4c-f8f1-d669-6301" targetId="a7c9-81ec-0fa6-2eb5" linkType="rule">
+            <link id="8c4c-f8f1-d669-6301" targetId="8db6-5208-786b-6fa1" linkType="rule">
               <modifiers>
-                <modifier type="append" field="name" value="(6+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="append" field="name" value="(4+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -2587,11 +2574,7 @@ Wounds Caused        Bonus
         </link>
         <link id="6c6d-6dc9-c55d-93ad" targetId="3af5-2a35-3a8b-c07b" linkType="rule">
           <modifiers>
-            <modifier type="append" field="name" value=" (D6+3)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="append" field="name" value="(D3+3)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="append" field="name" value="(D3)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -2846,31 +2829,6 @@ Wounds Caused        Bonus
     </entry>
     <entry id="172a-8c4e-16a5-b1e0" name="Vampire Count" points="205.0" categoryId="b2e4-176b-505b-1d2a" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="3" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
-        <entry id="1711-c690-e796-fa23" name="Shield" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition parentId="roster" childId="c261-832b-3491-9b96" field="selections" type="at least" value="1.0"/>
-                    <condition parentId="roster" childId="1b65-630e-1182-fadf" field="selections" type="at least" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5e7d-7a5b-7fcd-b2e1" targetId="f378-5311-1555-b3d9" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
         <entry id="598e-240b-a2f7-add2" name="Mount" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
           <entryGroups>
@@ -2986,10 +2944,16 @@ Wounds Caused        Bonus
                 <link id="7040-7f6a-4886-3573" targetId="f106-fbd5-1c1c-5705" linkType="entry group">
                   <modifiers>
                     <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions>
-                        <condition parentId="172a-8c4e-16a5-b1e0" childId="552a-6a33-9606-00c2" field="selections" type="equal to" value="1.0"/>
-                      </conditions>
-                      <conditionGroups/>
+                      <conditions/>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition parentId="172a-8c4e-16a5-b1e0" childId="ccb0-01ee-0dd0-f902" field="selections" type="equal to" value="1.0"/>
+                            <condition parentId="172a-8c4e-16a5-b1e0" childId="552a-6a33-9606-00c2" field="selections" type="equal to" value="1.0"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                 </link>
@@ -3125,7 +3089,7 @@ Wounds Caused        Bonus
             <entry id="07e5-1f10-8c33-805c" name="Level 2 Wizard ​Apprentice" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups>
-                <entryGroup id="8788-6a6b-c5be-dda6" name="Path of Magic" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="8788-6a6b-c5be-dda6" name="Path of Magic" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
@@ -3239,7 +3203,7 @@ Wounds Caused        Bonus
             <entry id="1a87-567b-a8e8-4d57" name="Level 3 Wizard ​Master" points="90.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups>
-                <entryGroup id="5eb6-30ce-ff73-9834" name="Path of Magic" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="5eb6-30ce-ff73-9834" name="Path of Magic" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
@@ -3439,6 +3403,12 @@ Wounds Caused        Bonus
                   </conditions>
                   <conditionGroups/>
                 </modifier>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="172a-8c4e-16a5-b1e0" childId="ccb0-01ee-0dd0-f902" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
               </modifiers>
               <rules/>
               <profiles/>
@@ -3494,7 +3464,23 @@ Wounds Caused        Bonus
               </modifiers>
               <rules/>
               <profiles/>
-              <links/>
+              <links>
+                <link id="6847-e8a3-c5ac-739b" targetId="0ba5-2137-af18-aeb9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="0735-f692-46b8-9bf5" name="Shield" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="10cd-f377-15b6-ef9a" targetId="f378-5311-1555-b3d9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
             </entry>
           </entries>
           <entryGroups/>
@@ -3516,7 +3502,7 @@ Wounds Caused        Bonus
         </entryGroup>
         <entryGroup id="0134-8902-e614-e565" name="May take one of the following" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="fe71-5de4-04a0-9421" name="Additional Hand Weapon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="fe71-5de4-04a0-9421" name="Paired Weapons" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -3568,10 +3554,16 @@ Wounds Caused        Bonus
           <entryGroups/>
           <modifiers>
             <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="172a-8c4e-16a5-b1e0" childId="552a-6a33-9606-00c2" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="172a-8c4e-16a5-b1e0" childId="ccb0-01ee-0dd0-f902" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="172a-8c4e-16a5-b1e0" childId="552a-6a33-9606-00c2" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <links/>
@@ -3716,7 +3708,7 @@ Wounds Caused        Bonus
             </modifier>
             <modifier type="increment" field="5723232344415441232323" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="1.0"/>
+                <condition parentId="172a-8c4e-16a5-b1e0" childId="37d2-b1de-7a50-5957" field="selections" type="equal to" value="1.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -3744,6 +3736,12 @@ Wounds Caused        Bonus
               </conditions>
               <conditionGroups/>
             </modifier>
+            <modifier type="set" field="5479706523232344415441232323" value="Monsterous Infantry" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="172a-8c4e-16a5-b1e0" childId="552a-6a33-9606-00c2" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
           </modifiers>
         </profile>
       </profiles>
@@ -3754,7 +3752,15 @@ Wounds Caused        Bonus
         <link id="9cd1-b2c1-22c5-ff46" targetId="868d-580d-07cf-9ba9" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value="(6+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
+              <conditions>
+                <condition parentId="172a-8c4e-16a5-b1e0" childId="f501-9bbc-62b2-de95" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="append" field="name" value="(2+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="172a-8c4e-16a5-b1e0" childId="f501-9bbc-62b2-de95" field="selections" type="equal to" value="1.0"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
@@ -3778,6 +3784,23 @@ Wounds Caused        Bonus
         </link>
         <link id="08fa-ed34-ab3e-7f3c" targetId="a289-d6e5-74e0-b43d" linkType="entry">
           <modifiers/>
+        </link>
+        <link id="d080-3a36-4b73-4d1c" targetId="521c-9338-a13f-5b81" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="172a-8c4e-16a5-b1e0" childId="e516-b88e-b1ad-32e5" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="172a-8c4e-16a5-b1e0" childId="413b-932e-4286-fb79" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="172a-8c4e-16a5-b1e0" childId="14f8-595f-a9ad-6961" field="selections" type="equal to" value="0.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </link>
       </links>
     </entry>
@@ -3897,7 +3920,14 @@ Wounds Caused        Bonus
                   </modifiers>
                 </link>
                 <link id="cc48-07d5-efb8-21fc" targetId="f106-fbd5-1c1c-5705" linkType="entry group">
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                      <conditions>
+                        <condition parentId="951e-6eba-73f2-2f4a" childId="2cb2-5053-15b3-245f" field="selections" type="equal to" value="1.0"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                 </link>
                 <link id="801c-8934-b8fd-d36b" targetId="bb1c-24fa-f80b-49f2" linkType="entry group">
                   <modifiers/>
@@ -3957,7 +3987,11 @@ Wounds Caused        Bonus
               </modifiers>
               <rules/>
               <profiles/>
-              <links/>
+              <links>
+                <link id="4618-5b75-1ea2-7ec1" targetId="0ba5-2137-af18-aeb9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
             </entry>
           </entries>
           <entryGroups/>
@@ -4029,7 +4063,14 @@ Wounds Caused        Bonus
             </entry>
           </entries>
           <entryGroups/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="951e-6eba-73f2-2f4a" childId="2cb2-5053-15b3-245f" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <links/>
         </entryGroup>
         <entryGroup id="107f-edc2-818a-e1d2" name="Wizard Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -4151,7 +4192,7 @@ Wounds Caused        Bonus
             <entry id="7949-bf8a-1184-ecc9" name="Level 2 Wizard Apprentice" points="55.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups>
-                <entryGroup id="1621-ee6f-a222-9811" name="Path of Magic" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                <entryGroup id="1621-ee6f-a222-9811" name="Path of Magic" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
@@ -4245,6 +4286,12 @@ Wounds Caused        Bonus
                   </conditionGroups>
                 </modifier>
                 <modifier type="set" field="points" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="951e-6eba-73f2-2f4a" childId="2cb2-5053-15b3-245f" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
                     <condition parentId="951e-6eba-73f2-2f4a" childId="2cb2-5053-15b3-245f" field="selections" type="equal to" value="1.0"/>
                   </conditions>
@@ -4412,7 +4459,7 @@ Wounds Caused        Bonus
             </modifier>
             <modifier type="increment" field="5723232344415441232323" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions>
-                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="1.0"/>
+                <condition parentId="951e-6eba-73f2-2f4a" childId="df71-c88c-5782-5a80" field="selections" type="equal to" value="1.0"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -4443,7 +4490,15 @@ Wounds Caused        Bonus
         <link id="63c4-b1c0-55e9-cb1c" targetId="868d-580d-07cf-9ba9" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value="(6+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
+              <conditions>
+                <condition parentId="951e-6eba-73f2-2f4a" childId="f501-9bbc-62b2-de95" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="append" field="name" value="(2+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="951e-6eba-73f2-2f4a" childId="f501-9bbc-62b2-de95" field="selections" type="equal to" value="1.0"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
@@ -4453,6 +4508,23 @@ Wounds Caused        Bonus
         </link>
         <link id="d031-81fe-4b4b-bf95" targetId="f223-0181-cb79-cf54" linkType="entry">
           <modifiers/>
+        </link>
+        <link id="bda6-17c3-15d4-d376" targetId="521c-9338-a13f-5b81" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="951e-6eba-73f2-2f4a" childId="0bbf-deeb-a64c-e665" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="951e-6eba-73f2-2f4a" childId="929f-301b-0372-4317" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="951e-6eba-73f2-2f4a" childId="d1aa-42d1-74f0-9243" field="selections" type="equal to" value="0.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
         </link>
       </links>
     </entry>
@@ -5610,7 +5682,8 @@ the range of the Battle Standard Bearer’s Hold your Ground.
                   <modifiers/>
                   <rules>
                     <rule id="52d2-2780-364a-8a30" name="Ancient Blood Power: Crimson Rage" hidden="false">
-                      <description>Every unsaved wound caused by the Vampire with normal attacks generates another attack at the same Initiative step. These do not generate further attacks.
+                      <description>Every unsaved wound caused by the Vampire with normal attacks (before applying Multiple Wounds) generates another attack at the same Initiative step. Resolve these attacks before removing any casualties. These do not generate further attacks.
+
 </description>
                       <modifiers/>
                     </rule>
@@ -5656,7 +5729,7 @@ the range of the Battle Standard Bearer’s Hold your Ground.
                   <entryGroups>
                     <entryGroup id="99fa-ab2f-9525-afae" name="Weapons" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                       <entries>
-                        <entry id="79cb-870b-ad02-4b7a" name="Additional Hand Weapon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                        <entry id="79cb-870b-ad02-4b7a" name="Paired Weapons" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
                           <entries/>
                           <entryGroups/>
                           <modifiers/>
@@ -5730,7 +5803,14 @@ the range of the Battle Standard Bearer’s Hold your Ground.
                     </rule>
                   </rules>
                   <profiles/>
-                  <links/>
+                  <links>
+                    <link id="9cee-7b27-8482-79dd" targetId="b653-c887-921e-4e34" linkType="rule">
+                      <modifiers/>
+                    </link>
+                    <link id="f16d-3c5f-160c-b326" targetId="b426-952e-f321-d6e2" linkType="rule">
+                      <modifiers/>
+                    </link>
+                  </links>
                 </entry>
               </entries>
               <entryGroups/>
@@ -5759,7 +5839,7 @@ the range of the Battle Standard Bearer’s Hold your Ground.
       </modifiers>
       <rules>
         <rule id="70dc-7aec-204b-1541" name="Brotherhood of the Dragon Bloodline" hidden="false">
-          <description>The Vampire gains +2 Weapon Skill andwears PlateArmour.Itis restricted to purchasing only one additional magic Level and may only use Path of Necromancy. The Vampire cannot refuse challenges and must issue one whenever possible, unless another character does it first.
+          <description>The Vampire gains +2 Weapon Skill and wears Plate Armour.It is restricted to purchasing only one additional magic Level and may only use Path of Necromancy. The Vampire cannot refuse challenges and must issue one whenever possible, unless another character does it first.
 </description>
           <modifiers/>
         </rule>
@@ -5978,70 +6058,6 @@ the range of the Battle Standard Bearer’s Hold your Ground.
         </link>
       </links>
     </entry>
-    <entry id="9266-132c-3111-942d" name="Colossal Zombie Dragon" points="310.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d013-475d-060b-875e" profileTypeId="4d6f64656c23232344415441232323" name="Colossal Zombie Dragon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="4d23232344415441232323" name="M" value="6"/>
-            <characteristic characteristicId="575323232344415441232323" name="WS" value="5"/>
-            <characteristic characteristicId="425323232344415441232323" name="BS" value="0"/>
-            <characteristic characteristicId="5323232344415441232323" name="S" value="6"/>
-            <characteristic characteristicId="5423232344415441232323" name="T" value="6"/>
-            <characteristic characteristicId="5723232344415441232323" name="W" value="6"/>
-            <characteristic characteristicId="4923232344415441232323" name="I" value="2"/>
-            <characteristic characteristicId="4123232344415441232323" name="A" value="5"/>
-            <characteristic characteristicId="4c4423232344415441232323" name="LD" value="4"/>
-            <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave"/>
-            <characteristic characteristicId="576172645361766523232344415441232323" name="WardSave"/>
-            <characteristic characteristicId="4d5223232344415441232323" name="MR"/>
-            <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Monster"/>
-            <characteristic characteristicId="b268-8d89-a887-0d3b" name="Base Size" value="100x150mm"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="ddd3-e77e-df23-a005" targetId="331d-1426-6647-d594" linkType="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (7)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="8e58-670e-3aca-4632" targetId="8db6-5208-786b-6fa1" linkType="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (3+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="5017-2593-3632-c496" targetId="521c-9338-a13f-5b81" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="221a-2084-dd0c-c3cf" targetId="ab62-9d2c-9c12-57a8" linkType="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (Strength 2, Armour Piercing (6))" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="49fa-f337-ffd1-2668" targetId="a6f2-05a8-21b6-84be" linkType="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (6+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
     <entry id="2252-8130-d29f-809e" name="Court of the Damned​" points="140.0" categoryId="5370656369616c23232344415441232323" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="2" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="93ea-5b81-76bc-0f39" name="Ghost Steed" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -6174,9 +6190,6 @@ the range of the Battle Standard Bearer’s Hold your Ground.
         <link id="2fa7-712d-2885-383c" targetId="eeea-cfd1-e63d-8d4c" linkType="rule">
           <modifiers/>
         </link>
-        <link id="61b1-6117-2665-6028" targetId="3249-3d9e-5d02-f7c9" linkType="rule">
-          <modifiers/>
-        </link>
         <link id="1c28-3930-381e-992e" targetId="fc37-afc2-2043-4c9a" linkType="rule">
           <modifiers/>
         </link>
@@ -6194,7 +6207,7 @@ the range of the Battle Standard Bearer’s Hold your Ground.
         <link id="c670-2545-c0c8-08ea" targetId="42ff-db03-1efb-37d7" linkType="entry">
           <modifiers/>
         </link>
-        <link id="85f4-eb31-bfbb-fc93" targetId="a7c9-81ec-0fa6-2eb5" linkType="rule">
+        <link id="85f4-eb31-bfbb-fc93" targetId="8db6-5208-786b-6fa1" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value="(5+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions/>
@@ -6230,7 +6243,7 @@ the range of the Battle Standard Bearer’s Hold your Ground.
     <entry id="7b84-6284-7ba5-b428" name="Lamia Bloodline" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
       <entries/>
       <entryGroups>
-        <entryGroup id="8fcb-8edb-1a3b-25c4" name="Blood Powers" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="8fcb-8edb-1a3b-25c4" name="Blood Powers" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="2c77-823a-8b98-5d1c" name="Blood Power: Mesmerizing Gaze" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
@@ -6327,7 +6340,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
       </rules>
       <profiles/>
       <links>
-        <link id="cbac-f407-b337-e5ad" targetId="2f08-0229-2f20-122a" linkType="rule">
+        <link id="51a5-8801-2533-746e" targetId="2f08-0229-2f20-122a" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -6520,7 +6533,14 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
             <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Monstrous Beast"/>
             <characteristic characteristicId="b268-8d89-a887-0d3b" name="Base Size" value="50x50mm"/>
           </characteristics>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="b268-8d89-a887-0d3b" value="60x100" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="61d2-0536-c01f-2069" childId="bfc6-856f-22b2-6234" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </profile>
       </profiles>
       <links>
@@ -6531,6 +6551,9 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
           <modifiers/>
         </link>
         <link id="1038-4d38-4c46-e7a1" targetId="c125-f776-f14d-5b30" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e680-7fe3-00ff-25c8" targetId="eeea-cfd1-e63d-8d4c" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -6856,7 +6879,8 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
               <modifiers/>
               <rules>
                 <rule id="4880-eace-2d88-3af8" name="Ancient Blood Power:  Blood Magic" hidden="false">
-                  <description>The Vampire always counts as having one less MDU when suffering a Miscast. Immediately after rolling Magic Flux in the controlling player’s turn, the player may choose one ofthe Magic Flux dice and reroll it.If used,the modelwith this Power suffers a wound with no saves of any kind allowed at the end of the Magic Phase.
+                  <description>The Vampire always counts as having used one less Magic Dice when suffering a Miscast. Immediately after rolling Magic Flux in a friendly Player Turn,the player may reroll one of the Magic Flux dice. If used, the model with this Power suffers a wound with no saves of any kind allowed at the end of the Magic Phase.
+
 </description>
                   <modifiers/>
                 </rule>
@@ -7006,7 +7030,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
           <characteristics>
             <characteristic characteristicId="4d23232344415441232323" name="M" value="6"/>
             <characteristic characteristicId="575323232344415441232323" name="WS" value="4"/>
-            <characteristic characteristicId="425323232344415441232323" name="BS" value="2"/>
+            <characteristic characteristicId="425323232344415441232323" name="BS" value="0"/>
             <characteristic characteristicId="5323232344415441232323" name="S" value="5"/>
             <characteristic characteristicId="5423232344415441232323" name="T" value="6"/>
             <characteristic characteristicId="5723232344415441232323" name="W" value="6"/>
@@ -7026,9 +7050,6 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
         <link id="137e-5574-4c9d-ceac" targetId="eeea-cfd1-e63d-8d4c" linkType="rule">
           <modifiers/>
         </link>
-        <link id="06ca-5e1e-79cb-5b66" targetId="3249-3d9e-5d02-f7c9" linkType="rule">
-          <modifiers/>
-        </link>
         <link id="270b-2265-c944-fefb" targetId="331d-1426-6647-d594" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value=" (8)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
@@ -7040,7 +7061,15 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
         <link id="4599-e353-62fc-5b8d" targetId="a6f2-05a8-21b6-84be" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value=" (6+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
+              <conditions>
+                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="append" field="name" value="(5+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="1.0"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
@@ -7050,6 +7079,40 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
         </link>
         <link id="698f-d97e-f38e-dc53" targetId="1d3c-61f5-bbc2-5ce6" linkType="entry">
           <modifiers/>
+        </link>
+        <link id="a703-bf5d-0b3b-8f86" targetId="8d66-892b-7ed1-d6d8" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="cfac-bac7-6de0-87d3" targetId="f061-7400-a1c9-3d80" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="6511-cae3-85ff-6603" targetId="9ea6-7407-9159-bd26" linkType="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(1)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="roster" childId="6883-09c0-6a82-5ec2" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </link>
       </links>
     </entry>
@@ -7118,6 +7181,9 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
             </modifier>
           </modifiers>
         </link>
+        <link id="c5da-3bd6-86c0-bbb6" targetId="eeea-cfd1-e63d-8d4c" linkType="rule">
+          <modifiers/>
+        </link>
       </links>
     </entry>
     <entry id="d7e4-da94-4db0-ad47" name="Spectral Steed" points="55.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -7156,6 +7222,17 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
         <link id="9b05-06bc-2e31-7e37" targetId="331d-1426-6647-d594" linkType="rule">
           <modifiers>
             <modifier type="append" field="name" value="(8)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="c99f-321d-f2f4-7a8c" targetId="eeea-cfd1-e63d-8d4c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1ad2-88ac-c056-15b3" targetId="a7c9-81ec-0fa6-2eb5" linkType="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(6+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -7277,7 +7354,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
       </modifiers>
       <rules>
         <rule id="8c3b-c1cf-c1bc-6c7c" name="Strigoi Bloodline" hidden="false">
-          <description>The Vampire and its mount have Regeneration (5+) and Hatred. The Vampire has +1 Wound and cannot select any mount exceptfor a Shrieking Horror, may not wear any kind of Armour
+          <description>The Vampire and its mount have Regeneration (5+) and Hatred. The Vampire has +1 Wound and cannot select any mount except for a Shrieking Horror, may not wear any kind of Armour
 (excluding Mount’s Protection), can only purchase a single additional Magic Level, and must use the Path of Wilderness or the Path of Necromancy.
 
 </description>
@@ -7355,7 +7432,8 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
               <modifiers/>
               <rules>
                 <rule id="1672-8b1a-c232-b778" name="Ancient Blood Power: Storm Caller" hidden="false">
-                  <description>The Vampire can cast Thunderbolt (Path of Heavens) as a Bound Spell Power Level 4, and all units within 12” of the Vampire gain Hard Target. Once per game, the Vampire may grant Lightning Attacks and Lightning Reflexes to itself and to all Rank­and­File models in its unit until the end of that Combat Round.
+                  <description>The Vampire can cast Thunderbolt from the Path of Heavens as a Bound Spell (Power Level 4). All units within 12” of the Vampire gain Hard Target. Once per game, at the start of any Round of Combat, the Vampire may grant Lightning Attacks and Lightning Reflexes to itself and to all Rank­and­File models in its unit until the end of that Combat Round.
+
 </description>
                   <modifiers/>
                 </rule>
@@ -7388,8 +7466,8 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
               <entryGroups/>
               <modifiers/>
               <rules>
-                <rule id="7870-43b2-8bd0-824d" name="Thin Blood Power: Hour of the Wolf" hidden="false">
-                  <description>The Vampire and all models in the same unit as the Vampire have Swiftstride. Other Characters with the Vampiric special rule are not affected. The Vampire gains Awaken (Zombies, Direwolves, Bat Swarms, Great Bats).
+                <rule id="7870-43b2-8bd0-824d" name="Blood Power: Hour of the Wolf" hidden="false">
+                  <description>The Vampire and all models in the same unit as the Vampire gains Swiftstride. Other Characters with the Vampiric special rule are not affected. The Vampire gains Awaken (Zombies, Direwolves, Bat Swarms, Great Bats).
 </description>
                   <modifiers/>
                 </rule>
@@ -7411,7 +7489,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
               <entryGroups/>
               <modifiers/>
               <rules>
-                <rule id="dea4-ee85-2459-7267" name="Thin Blood Power: Refined Taste" hidden="false">
+                <rule id="dea4-ee85-2459-7267" name="Blood Power: Refined Taste" hidden="false">
                   <description>The Vampire has the Vampiric (2+)
 </description>
                   <modifiers/>
@@ -7489,7 +7567,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
             <characteristic characteristicId="4923232344415441232323" name="I" value="2"/>
             <characteristic characteristicId="4123232344415441232323" name="A" value="5"/>
             <characteristic characteristicId="4c4423232344415441232323" name="LD" value="4"/>
-            <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave"/>
+            <characteristic characteristicId="41726d6f75725361766523232344415441232323" name="ArmourSave" value="4+"/>
             <characteristic characteristicId="576172645361766523232344415441232323" name="WardSave"/>
             <characteristic characteristicId="4d5223232344415441232323" name="MR"/>
             <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Monster"/>
@@ -7508,6 +7586,12 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
               </conditions>
               <conditionGroups/>
             </modifier>
+            <modifier type="set" field="41726d6f75725361766523232344415441232323" value="3+" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="f847-7f2d-6117-b911" childId="1156-945d-9d28-072f" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
           </modifiers>
         </profile>
       </profiles>
@@ -7521,20 +7605,7 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
           </modifiers>
         </link>
         <link id="039e-9e48-e962-d340" targetId="8db6-5208-786b-6fa1" linkType="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (4+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="f847-7f2d-6117-b911" childId="1156-945d-9d28-072f" field="selections" type="equal to" value="0.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="append" field="name" value=" (3+)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="f847-7f2d-6117-b911" childId="1156-945d-9d28-072f" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
         </link>
         <link id="ad22-f6c9-8679-7e69" targetId="521c-9338-a13f-5b81" linkType="rule">
           <modifiers/>
@@ -7787,7 +7858,8 @@ Whenever the target takes a Leadership test, it rolls an additional dice and dis
           <profiles>
             <profile id="014e-3d13-db6f-6fbc" profileTypeId="417263616e6520616e6420456e6368616e746564204974656d23232344415441232323" name="Staff of Gerhard the Black" hidden="false" book="Vampire Covenant">
               <characteristics>
-                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="An army containing this item may reroll failed Channelling attempts. Furthermore, when the bearer casts the ‘Invocation of the Undead’ spell the owning player may reroll the dice for Raising Wounds on all units affected. "/>
+                <characteristic characteristicId="4d616769632050726f706572747923232344415441232323" name="Magic Property" value="An army containing this item may reroll failed Channelling attempts. When the bearer casts the Invocation of the Undead Spell it may, for each target, reroll the a single D6 or D3 used to determine the number of Raised Wounds.
+"/>
               </characteristics>
               <modifiers/>
             </profile>
@@ -9247,7 +9319,9 @@ regain its loose formation, keep the unit in tight formation until the first pla
 </description>
       <modifiers/>
     </rule>
-    <rule id="2f08-0229-2f20-122a" name="Supernatural Reflexes" hidden="false">
+    <rule id="2f08-0229-2f20-122a" name="Lightning Reflexes" hidden="false">
+      <description>Model parts with this special rule have +1 to hit with their Close Combat Attacks. This does not apply if the model part would be striking at initiative 0 (for example due to a Great Weapon or the Mesmeric Allure spell).Ifthis is the case, it strikes at its own Initiative instead.
+</description>
       <modifiers/>
     </rule>
     <rule id="3ddf-107e-b6a0-05a2" name="Swiftstride" hidden="false">
@@ -9330,6 +9404,11 @@ At the end of each Close Combat Phase, unitswith this special rule can make Vamp
     </rule>
     <rule id="0219-bcf9-3c5b-b19d" name="Wizard Conlclave" hidden="false">
       <description>A Champion of a Unit with the Wizard Conclave Special Rule receives +1 Wound in addition to the normal Characteristics increases associated with being a Champion, and are Wizards of the Wizard Level given within brackets. This Champion knows predetermined spells, which are defined within the brackets. For example, a Champion of a Wizard Conclave (level 1, Blue Fire, Pink Fire) would be a level 1 Wizard with two predetermined spells (Blue Fire and Pink Fire). The Champion has a +1 to cast for each 5 models (excluding other Characters) in the Unit above their minimum starting Unit size, up to a maximum of +4 (including the bonus from their Wizard Level).
+</description>
+      <modifiers/>
+    </rule>
+    <rule id="b426-952e-f321-d6e2" name="Weapon Master" hidden="false">
+      <description>At the beginning of each Round of Combat, model parts with this special rule may choose which weapon they fight with. This includes selecting to use a Hand Weapon even if they have other weapons. If armed with a Magical Weapon, the model must still use it.
 </description>
       <modifiers/>
     </rule>


### PR DESCRIPTION
Bloodlines
- Brotherhood of the Dragon Bloodline
-- Plate Armour not shown
-- update "Ancient Blood Power: Crimson Rage" rule
- Von Karnstein Bloodline
-- update "Ancient Blood Power: Storm Caller"
- Lamia Bloodline
-- add "Lightning Reflexes" rule
-- remove "Supernatural Reflexes" rule
-- should have "Distracting" if not wearing any Armour
- Strigoi Bloodline
-- +1 Wound is not added
-- Mount should also get Regeneration (5+)
-- "Ancient Blood Power: Beastial Bulk" should change Troop Type to
Monstrous Infantry
- Nosferatu Bloodline
-- may not wield a mundane Weapon
-- make Wizard Level choice a must
-- update "Ancient Blood Power: Blood Magic" rule

Blood Powers
- Perfect Warrior
-- add "Weapon Master" and "Lethal Strike" rules
- Ghoul Lord
-- may add Poisoned Attacks and Armour Piercing (1)
- Hour of the Wolf
-- update rule
- Refined Taste
-- add "Vampiric (2+)"

LORDS
- Vampire Count
-- rename "Additional Hand Weapon" option
-- change Armour selection
-- Spectral Steed
--- add "Mount’s Protection (6+)"
--- add "Undead"
-- Monstrous Revenant
--- add "Options (max 2)"
--- should change in base size at "Great Monstrous Revenant" (60x100)
--- add "Undead"
-- Zombie Dragon
--- shows "Innate Defense (Colossal Zombie Dragon)"
-- Court of the Damned
--- no "Ashes to Ashes"
-- Shrieking Horror
--- no "Ashes to Ashes"
--- has BS2, should be BS0

HEROES
- Vampire Courtier
-- no warning if Level 2 Wizard takes no Path

v0.99.6
Monstrous revenant, max 2 options
Staff of Gerhard the Black, clarification
court of the damned, innate defence instead of mounts protection
Phantom Host, invocation value
Dark Coach, armour