### PR TITLE
Fix banner validation

### DIFF
--- a/Sylvan Elves.cat
+++ b/Sylvan Elves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6c38-38de-1739-441a" revision="93" gameSystemId="7e6fb76e-1bec-b992-2c43-e797a6758b13" gameSystemRevision="10" battleScribeVersion="1.15" name="Sylvan Elves" books="v1.0.0" authorName="Bombastian, Karanadon" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6c38-38de-1739-441a" revision="94" gameSystemId="7e6fb76e-1bec-b992-2c43-e797a6758b13" gameSystemRevision="10" battleScribeVersion="1.15" name="Sylvan Elves" books="v1.0.0" authorName="Bombastian, Karanadon" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="809d-5db9-ae9c-1313" name="Blade Dancers" points="0.0" categoryId="5370656369616c23232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="3" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
@@ -5665,7 +5665,7 @@ neverjoinanyunitn​orbejoinedbyanyotherCharacter.​</description>
       <modifiers/>
       <links/>
     </entryGroup>
-    <entryGroup id="3fa5-6dd5-6e46-88c5" name="Magic Banners (25 pts)" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entryGroup id="3fa5-6dd5-6e46-88c5" name="Magic Banners (25 pts)" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="d6e7-71f9-b4ba-e11f" name="Banner of Discipline" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>
@@ -5784,7 +5784,7 @@ neverjoinanyunitn​orbejoinedbyanyotherCharacter.​</description>
       <modifiers/>
       <links/>
     </entryGroup>
-    <entryGroup id="f7a0-d9b1-f60e-a7dd" name="Magic Banners (50 pts)" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+    <entryGroup id="f7a0-d9b1-f60e-a7dd" name="Magic Banners (50 pts)" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries>
         <entry id="250c-6044-b421-e44c" name="Banner of Discipline" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries/>


### PR DESCRIPTION
Allow more than one 25 or 50 point banner in the roster, the restriction should only apply to veteran banners