### PR TITLE
WDG - Exalted Herald Manifestations not mandatory

### DIFF
--- a/Warriors of the Dark Gods 2.0 Beta.cat
+++ b/Warriors of the Dark Gods 2.0 Beta.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.0 Beta" revision="2" battleScribeVersion="2.01" authorName="Mikel2311" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.0 Beta" revision="3" battleScribeVersion="2.01" authorName="Mikel2311" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -215,7 +215,7 @@
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eca2-7e87-2315-b140" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104a-cb7e-d6db-511f" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104a-cb7e-d6db-511f" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>


### PR DESCRIPTION
version 2 of the wdgcatz file has manifestations set as min 2 making them mandatory upon army list creation.

The rules state that manifestations are selected _during spell selection_ thus they shouldn't be mandatory but rather optional so you can add them jit before playing while keeping the selections open during army swap.

**Manifestation: Universal Rule.**
During Spell Selection, each Exalted Herald must choose two Manifestations from the list below and apply the
effects during the game. The model knows the spells indicated on the chosen Manifestations. This replaces the
normal rules for Spell Selection connected to being a Wizard Adept or Master.