### PR TITLE
Multiple fixes

### DIFF
--- a/Dwarven Holds 2.0 Beta.cat
+++ b/Dwarven Holds 2.0 Beta.cat
@@ -3710,7 +3710,7 @@ Each Runic Smith may select up to three different Battle Runes during Spell Sele
                 <characteristic name="HP" characteristicTypeId="f381-7850-7fa8-3440" value="1"/>
                 <characteristic name="Def" characteristicTypeId="160d-4624-273f-2114" value="4"/>
                 <characteristic name="Res" characteristicTypeId="ec15-bc66-645e-db5d" value="4"/>
-                <characteristic name="Arm" characteristicTypeId="597b-8735-3dd1-0e70" value="5+"/>
+                <characteristic name="Arm" characteristicTypeId="597b-8735-3dd1-0e70" value="0"/>
               </characteristics>
             </profile>
             <profile id="f73d-9015-5258-44ff" name="Miner Offence" hidden="false" profileTypeId="154c-6605-1486-e1da" profileTypeName="3 Offensive">

--- a/Dwarven Holds 2.0 Beta.cat
+++ b/Dwarven Holds 2.0 Beta.cat
@@ -2175,9 +2175,17 @@ Each Runic Smith may select up to three different Battle Runes during Spell Sele
               </conditions>
               <conditionGroups/>
             </modifier>
+            <modifier type="decrement" field="ed8e-9c82-8033-fc9b" value="1">
+              <repeats>
+                <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="840e-1af6-bc54-4f39" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed8e-9c82-8033-fc9b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e5-4b31-29cf-f884" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -2239,7 +2247,7 @@ Each Runic Smith may select up to three different Battle Runes during Spell Sele
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="ab53-7b6d-178e-63fb" name="Throwing Weapons (5+)" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+            <infoLink id="ab53-7b6d-178e-63fb" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2553,9 +2561,17 @@ Each Runic Smith may select up to three different Battle Runes during Spell Sele
               </conditions>
               <conditionGroups/>
             </modifier>
+            <modifier type="decrement" field="efe7-795d-4ec7-e748" value="1">
+              <repeats>
+                <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e0b-6dd0-c9e7-2109" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efe7-795d-4ec7-e748" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf6-cf1c-ff65-f409" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -5328,7 +5344,6 @@ Each Runic Smith may select up to three different Battle Runes during Spell Sele
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe4-58ff-9316-10e5" type="max"/>
-            <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08bc-cbaf-2a54-c69f" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>

--- a/Infernal Dwarves 2.0 Beta.cat
+++ b/Infernal Dwarves 2.0 Beta.cat
@@ -7091,7 +7091,15 @@ At the start of a friendly Player Turn, if there aren’t any friendly units wit
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="2f04-adf4-8e79-d1ab" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f001-5206-a99b-a94a" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="HP" characteristicTypeId="f381-7850-7fa8-3440" value="7"/>
             <characteristic name="Def" characteristicTypeId="160d-4624-273f-2114" value="3"/>
@@ -7150,7 +7158,33 @@ At the start of a friendly Player Turn, if there aren’t any friendly units wit
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="f001-5206-a99b-a94a" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules>
+            <rule id="0f6e-495a-bd3e-fb62" name="Big Brother" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>The model&apos;s Health Points are set to 8, and its base size is changed to 75x100mm.
+The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0666-5cc9-e760-ea20" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="2f10-f316-1b9e-993e" name="Melee Weapon" hidden="false" collective="false">
           <profiles/>

--- a/Ogre Khans 2.0 Beta.cat
+++ b/Ogre Khans 2.0 Beta.cat
@@ -5666,7 +5666,15 @@ Enemy units within 9” of one or more Frost Mammoths suffer -3 Agility. The rol
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="2cc3-0dfb-c6c3-a7b8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5e64-c970-158c-0c63" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="HP" characteristicTypeId="f381-7850-7fa8-3440" value="7"/>
             <characteristic name="Def" characteristicTypeId="160d-4624-273f-2114" value="3"/>
@@ -5719,7 +5727,33 @@ The model is a Musician. The range of the Giant&apos;s March to the Beat, and to
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="5e64-c970-158c-0c63" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules>
+            <rule id="eae7-6243-8859-343b" name="Big Brother" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>The model&apos;s Health Points are set to 8, and its base size is changed to 75x100mm.
+The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cfd-b705-2bf4-f4a8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="cef4-f608-2fc2-2ed7" name="Weapon" hidden="false" collective="false">
           <profiles/>

--- a/Orcs and Goblins 2.0 Beta.cat
+++ b/Orcs and Goblins 2.0 Beta.cat
@@ -9168,7 +9168,15 @@ Break Tests taken by units within 6” of one or more friendly Engaged Great Gre
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="2926-86d3-f605-c0f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="009d-b5d4-2b93-4394" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="HP" characteristicTypeId="f381-7850-7fa8-3440" value="7"/>
             <characteristic name="Def" characteristicTypeId="160d-4624-273f-2114" value="3"/>
@@ -9220,7 +9228,31 @@ Break Tests taken by units within 6” of one or more friendly Engaged Great Gre
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="009d-b5d4-2b93-4394" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules>
+            <rule id="4b26-5492-4458-4607" name="Big Brother" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>The model&apos;s Health Points are set to 8, and its base size is changed to 75x100mm.
+The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f2a5-b162-b70b-e081" name="Weapon" hidden="false" collective="false">
           <profiles/>

--- a/Orcs and Goblins 2.0 Beta.cat
+++ b/Orcs and Goblins 2.0 Beta.cat
@@ -9243,7 +9243,9 @@ The roll for the number of hits from its Stomp Attacks is subject to Maximised R
           </rules>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b97f-0dde-9729-35fa" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>

--- a/Vampire Covenant 2.0 Beta.cat
+++ b/Vampire Covenant 2.0 Beta.cat
@@ -6760,7 +6760,9 @@ Additionally, all R&amp;F models in friendly units from Core within 6” of one 
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e1e0-7e6d-9fc6-9392" name="Shrieking Horror" hidden="false" collective="false" type="model">
       <profiles>
@@ -7618,7 +7620,9 @@ Regardless of whether it is used as a Shooting or Melee Attack, the Chilling Shr
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5873-24de-7db3-02e7" name="Fell Wraith - Monstrous Revenant" hidden="false" collective="false" type="model">
       <profiles>
@@ -8949,7 +8953,9 @@ Additionally, all R&amp;F models in friendly units from Core within 6” of one 
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="f61d-df40-9fcf-4e06" name="Strigoi Bloodline" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -9206,7 +9212,7 @@ Additionally, all R&amp;F models in friendly units from Core within 6” of one 
           </rules>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="hidden" value="false">
               <repeats/>
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>

--- a/Warriors of the Dark Gods 2.0 Beta.cat
+++ b/Warriors of the Dark Gods 2.0 Beta.cat
@@ -3572,7 +3572,9 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -3589,7 +3591,9 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="88e1-6131-9dfa-b790" name="Warrior Knights" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -5493,7 +5497,9 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
           <categoryLinks/>
         </entryLink>
       </entryLinks>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="8eea-d70f-9bbc-89dd" name="Wretched Ones" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -9306,7 +9312,9 @@ At the end of your Movement Phase, you may choose an unengaged enemy unit within
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -9661,7 +9669,7 @@ At the end of your Movement Phase, you may choose an unengaged enemy unit within
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2c0-d219-ad53-5b4e" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b6e-e5b9-4fa1-151d" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b6e-e5b9-4fa1-151d" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -9689,7 +9697,6 @@ At the end of your Movement Phase, you may choose an unengaged enemy unit within
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d36-98ef-b132-60de" type="max"/>
-            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="133b-19dd-6b34-05ca" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>

--- a/Warriors of the Dark Gods 2.0 Beta.cat
+++ b/Warriors of the Dark Gods 2.0 Beta.cat
@@ -1849,20 +1849,6 @@ Weapon Enchantments and Armour Enchantments carried by models in units that are 
                 </categoryLink>
               </categoryLinks>
             </entryLink>
-            <entryLink id="de48-a305-67f9-272b" name="War Dais" hidden="false" targetId="b168-546c-9ddc-a9b9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="90">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
             <entryLink id="46e3-1ebc-c065-f85a" name="Wasteland Behemoth" hidden="false" targetId="46d6-395a-e95c-848b" type="selectionEntry">
               <profiles/>
               <rules/>


### PR DESCRIPTION
DH:
* Miners Arm statline was wrong (5+ instead of zero)
* Forge Wardens can pick any Standart
* Limit of 0-1 for Vanguard between Clan Warriors and Greybeards
VC:
* Storm Caller was not part of Von Karstein Bloodline (#219)
WotDG:
* Fixed limit of Zealot Banner (#218)
* Fixed limit of Wasteland Torch
* No War Dais for Sorcerer (#217)
ID
* Giant has now Big Brother option (#221)
OnG
* Giant has now Big Brother option (#215)
OK
* Giant has now Big Brother option