### PR TITLE
WDG Double Count towards Characters fixes

### DIFF
--- a/Warriors of the Dark Gods 2.0 Beta.cat
+++ b/Warriors of the Dark Gods 2.0 Beta.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods" revision="31" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods" revision="32" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="25f6-6ecf-2669-118b" name="8 Manifestation">
       <characteristicTypes>
@@ -1067,9 +1067,6 @@ The model part gains Battle Focus when in a unit that has R&amp;F models with Ba
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f5d-b35f-89cb-7a83" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c039-b327-1184-9047" type="min"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="9ecc-d680-680d-864c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink id="940d-5539-9246-4ad6" name="Army General" hidden="false" collective="false" targetId="c30a-4220-8c73-d69b" type="selectionEntry"/>
           </entryLinks>
@@ -1081,9 +1078,6 @@ The model part gains Battle Focus when in a unit that has R&amp;F models with Ba
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c2-2bd6-c413-0126" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="5e11-7393-6c24-f785" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="8853-7cb3-714d-be44" name="Special Equipment" hidden="false" collective="false">
               <modifiers>

--- a/Warriors of the Dark Gods 2.0 Beta.cat
+++ b/Warriors of the Dark Gods 2.0 Beta.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods" revision="30" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods" revision="31" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="25f6-6ecf-2669-118b" name="8 Manifestation">
       <characteristicTypes>
@@ -5273,9 +5273,6 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="365a-83c5-289c-e33c" type="max"/>
       </constraints>
-      <categoryLinks>
-        <categoryLink id="3e24-fd80-bdad-d6f0" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="0f75-f510-3156-5775" name="Titanic Might" hidden="false" collective="false" type="upgrade">
           <constraints>

--- a/Warriors of the Dark Gods 2.0 Beta.cat
+++ b/Warriors of the Dark Gods 2.0 Beta.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods" revision="32" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods" revision="33" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="25f6-6ecf-2669-118b" name="8 Manifestation">
       <characteristicTypes>
@@ -2497,9 +2497,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="9512-ce2b-33c4-1e21" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="d27d-d1c6-2659-d396" name="Favour of Kuulima, Goddess of Envy" hidden="false" collective="false" targetId="4048-12e5-aaa9-fbea" type="selectionEntry">
               <modifiers>
@@ -2509,9 +2506,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="e4e0-7e4e-6c63-3a62" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="c2e5-0eef-4be6-67c2" name="Favour of Savar, God of Pride" hidden="false" collective="false" targetId="fd2a-be20-2128-92bd" type="selectionEntry">
               <modifiers>
@@ -2521,9 +2515,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="150a-be65-89a4-21c9" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="04fd-6a2e-1898-cb23" name="Favour of Vanadra, Goddess of Wrath" hidden="false" collective="false" targetId="7385-45d2-bf5f-b8ea" type="selectionEntry">
               <modifiers>
@@ -2533,9 +2524,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="425a-c720-1651-923d" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="23e5-453d-a657-0724" name="Favour of Sugulag, God of Greed" hidden="false" collective="false" targetId="ef34-5da0-4123-c9de" type="selectionEntry">
               <modifiers>
@@ -2545,9 +2533,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="c549-188e-efd3-85d3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="8c8a-5f27-e405-c54a" name="Favour of Nukuja, Goddess of Sloth" hidden="false" collective="false" targetId="517a-afbb-9d04-5381" type="selectionEntry">
               <modifiers>
@@ -2557,9 +2542,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="2ca7-add8-f8c2-349a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="25c6-1508-cbc6-20ab" name="Favour of Cibaresh, God of Lust" hidden="false" collective="false" targetId="d299-ca1e-7b60-c9fd" type="selectionEntry">
               <modifiers>
@@ -2569,9 +2551,6 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
                   </repeats>
                 </modifier>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="e436-dafe-c8ee-4e0c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -2661,57 +2640,36 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="2774-3438-1411-0264" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="0c5a-2fca-eea9-8458" name="Favour of Kuulima, Goddess of Envy" hidden="false" collective="false" targetId="4048-12e5-aaa9-fbea" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="331a-b682-46e4-c35c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="c9b5-9a69-76e1-3613" name="Favour of Savar, God of Pride" hidden="false" collective="false" targetId="fd2a-be20-2128-92bd" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="a0d9-c362-10eb-6cb4" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="cee8-0aac-f8bd-3884" name="Favour of Vanadra, Goddess of Wrath" hidden="false" collective="false" targetId="7385-45d2-bf5f-b8ea" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="0"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="b472-7703-2a46-86b3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="cfa6-2dcf-1b45-f8f8" name="Favour of Sugulag, God of Greed" hidden="false" collective="false" targetId="ef34-5da0-4123-c9de" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="10"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="26c5-b105-9ac6-87d3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="6213-ccab-88a7-ad71" name="Favour of Nukuja, Goddess of Sloth" hidden="false" collective="false" targetId="517a-afbb-9d04-5381" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="60"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="38a9-e67d-9f94-b346" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="f2d2-b645-f060-d986" name="Favour of Cibaresh, God of Lust" hidden="false" collective="false" targetId="d299-ca1e-7b60-c9fd" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="2513-0a39-2561-ad3d" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-              </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>


### PR DESCRIPTION
* Fixed double count of Feldrak Ancestor Enchantments towards character limit
* Fixed double count of Barbarian Chief Equipment towards character limit
* Fixed counting Chosen Favours towards character limit

This fixes issue #255 