### PR TITLE
Rework force and category entries

### DIFF
--- a/asklanders.cat
+++ b/asklanders.cat
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6f32-70a5-e6b1-a536" name="Åsklanders 2.2" revision="3" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6f32-70a5-e6b1-a536" name="Åsklanders 2.2" revision="4" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="d224-066a-e928-c28c" name="Legendary Beasts (local)" hidden="false"/>
+    <categoryEntry id="d224-066a-e928-c28c" name="Legendary Beasts" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="889b-e861-771b-956b" name="Åsklanders (local)" hidden="false">
+    <forceEntry id="889b-e861-771b-956b" name="Åsklanders" hidden="false">
       <categoryLinks>
         <categoryLink id="eba3-6fbf-bda1-e65f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -1689,9 +1689,6 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0167-1de9-ee72-9deb" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="8e79-2d43-ed7d-aa8a" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="cdc8-5052-9c32-5b9a" name="Giant Club" hidden="false" collective="false" type="upgrade">
               <constraints>
@@ -1706,9 +1703,6 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="08d5-9706-ceb8-4720" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
               </costs>
@@ -1729,9 +1723,6 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
               <infoLinks>
                 <infoLink id="4b3d-3546-19cf-896e" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="d3f4-76fe-962b-0501" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
               </costs>
@@ -1749,9 +1740,6 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="8ba5-735b-c288-4926" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
               </costs>

--- a/asklanders.cat
+++ b/asklanders.cat
@@ -1,0 +1,2475 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="6f32-70a5-e6b1-a536" name="Åsklanders 2.2" revision="3" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="d224-066a-e928-c28c" name="Legendary Beasts (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="889b-e861-771b-956b" name="Åsklanders (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="eba3-6fbf-bda1-e65f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="8554-f95e-4515-390f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8b04-0208-5d18-21b4" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="1874-f8cf-dfb3-2911" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d0d2-9d78-bd88-3cee" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="e64c-0e17-4956-d402" name="Legendary Beasts (local)" hidden="false" targetId="d224-066a-e928-c28c" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="b322-f4c0-3fb4-a213" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="6de7-3d7b-8973-aa1c" name="Seidhkennar" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="8d23-2026-a495-efaa" name="Seidhkennar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="580a-c784-47fc-fc19" name="Seidhkennar Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e94e-b2f9-b1e6-1e96" name="Seidhkennar Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="bc03-0a3c-a3cc-511f" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0b75-ee8f-892b-8cf7" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d289-06aa-9dc4-24fb" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeed-7049-3235-bf24" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0ed-3aa3-92c1-79ad" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="5ba7-3ae8-f0a7-829e" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="d518-9862-2270-7ccf" name="Army General" hidden="false" collective="false" targetId="c30a-4220-8c73-d69b" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c77f-1b4c-c32e-1a3d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa8a-fff7-8f2b-80c4" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="292d-f985-9696-da69" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4961-0e52-691c-a32c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="123e-d587-f998-a353" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0d25-8611-da36-7393" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="4148-a419-dc00-5054" name="Armour Enchantments" hidden="false" collective="false" targetId="f975-dd5b-da67-142e" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="10a0-406f-bb8c-045b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="faa6-1f52-45e7-9d0c" name="Weapon Enchantments" hidden="false" collective="false" targetId="cb21-fc0e-6fbe-9a3b" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="8a24-4eb4-b517-e560" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="b1ae-b0eb-839c-e313" name="Artefacts" hidden="false" collective="false" targetId="17df-ad66-db37-0a37" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="4710-3d29-25ab-1d87" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6a5e-733a-d650-59ac" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07ec-e9ea-5896-5ad6" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a3fa-743d-ecc1-cd21" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="14b7-74a7-e866-5324" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5260-5ef4-1f61-1b71" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f5c-f379-7b62-fe45" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0ae1-d845-54f2-341a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="ff34-f101-8130-6f96" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f214-ce78-dc3e-ce5e" name="Dark Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b732-96dd-64fb-6b62" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d03f-7ee5-f4bb-8864" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="7d8b-368e-d7b0-9697">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97dc-0a2a-0921-5a99" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af50-b581-d9c7-c609" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="0e17-15c2-73fa-c206" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="382e-3632-b0d4-9d81" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02d5-0998-f37e-d0e2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="896a-5a8a-f6b6-25ee" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="9e56-ca49-a9e9-8028" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1075-c047-962c-4a3e" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b64-208e-f188-94a8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="09ab-29f1-0672-c4a1" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="ecc6-b640-758e-bf6c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7d8b-368e-d7b0-9697" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ea8-287e-acd0-383d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ce35-393e-608c-cc5b" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="61c7-89ed-8829-1e4f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="dae8-e584-148c-03e6" name="Path of Magic" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="increment" field="0306-d94a-1af8-3e57" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="71de-c992-e6a4-5d3c" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0306-d94a-1af8-3e57" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71de-c992-e6a4-5d3c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="35c5-36a5-194e-97d3" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28f1-358d-b304-c23a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bacb-b36a-7976-3fab" name="Witchcraft" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bed8-2449-115e-98ac" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c556-524d-7cd0-3c6f" name="Thaumaturgy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c43-efd0-0479-81db" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="75a4-d324-24a1-59ba" name="Åsklander Chief" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2c60-03a7-8dab-52e4" name="Åsklander Chief Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="69db-ce5a-7d76-92b0" name="Åsklander Chief Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="67ac-73d1-448a-55de" name="Åsklander Chief Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="d567-637d-3671-274e" name="Deeds not Words" hidden="false">
+          <description>Attack Attribute - Melee.
+The model part gains Battle Focus when in a unit that has R&amp;F models with Battle Fever.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3be7-f444-3271-17c1" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="275f-1ca9-f28d-e25b" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d616-fa3a-7362-c3ee" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7aaa-769d-e759-0893" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="faf6-284f-65c1-1113" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c5f-b007-95f6-fab4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f5d-b35f-89cb-7a83" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c039-b327-1184-9047" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="9ecc-d680-680d-864c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="940d-5539-9246-4ad6" name="Army General" hidden="false" collective="false" targetId="c30a-4220-8c73-d69b" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3c5f-b007-95f6-fab4" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="faf6-284f-65c1-1113" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d31b-297a-e4b9-378f" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="cef5-c10e-4aee-1cca" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="0f05-9daa-710e-8e60" name="Battle Standard Bearer" hidden="false" collective="false" targetId="50b0-92f9-2390-fe6b" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3aae-74a2-893f-ba5a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c2-2bd6-c413-0126" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="5e11-7393-6c24-f785" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8853-7cb3-714d-be44" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="5438-04a2-ef67-acbe" value="150">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="faf6-284f-65c1-1113" type="equalTo"/>
+                        <condition field="selections" scope="75a4-d324-24a1-59ba" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f3f-b0dd-49d8-9cfa" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5438-04a2-ef67-acbe" value="200">
+                  <conditions>
+                    <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f3f-b0dd-49d8-9cfa" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5438-04a2-ef67-acbe" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="8d03-5861-226e-f33c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="b8e8-74a5-e073-de8d" name="Armour Enchantments" hidden="false" collective="false" targetId="f975-dd5b-da67-142e" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="78c6-3954-49b6-3deb" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="2eca-9493-ee1e-d4d9" name="Weapon Enchantments" hidden="false" collective="false" targetId="cb21-fc0e-6fbe-9a3b" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="5e83-4b5e-4626-fb3a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="8324-7582-79a5-9b9f" name="Banner Enchantments" hidden="true" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3c5f-b007-95f6-fab4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="7c23-f7e2-e8ad-eb43" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="3aae-74a2-893f-ba5a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2eca-9493-ee1e-d4d9" type="equalTo"/>
+                            <condition field="selections" scope="3aae-74a2-893f-ba5a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8e8-74a5-e073-de8d" type="equalTo"/>
+                            <condition field="selections" scope="3aae-74a2-893f-ba5a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0dbc-ad14-e093-434e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <categoryLinks>
+                    <categoryLink id="1243-1f28-0991-aa4a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="0dbc-ad14-e093-434e" name="Artefacts" hidden="false" collective="false" targetId="17df-ad66-db37-0a37" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="dda9-608e-79f6-ab80" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="56db-96dd-7487-0b3b" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a08a-39b3-3b1f-bcdf" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="af32-f13b-db87-fb8a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="1ebe-baa6-732a-25ea" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b256-ea5e-e595-09ad" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a78-d939-182d-d3fd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5d6e-9f25-f76a-36a2" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="5d58-1a5c-fc13-db34" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9f3f-b0dd-49d8-9cfa" name="Jarl" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="75a4-d324-24a1-59ba" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="faf6-284f-65c1-1113" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef5d-6e70-90bb-0165" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="7c2a-e393-6640-6007" name="Jarl" hidden="false">
+              <description>The Åsklander Chief gains +1 Discipline, +2 Attack Value, and may take Special Equipment for an additional 50 pts.</description>
+            </rule>
+          </rules>
+          <categoryLinks>
+            <categoryLink id="7e35-ce31-b693-8605" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d71-401e-1300-5b19" name="Longship Raid" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a1c-6d58-b396-d7ff" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cc3-b97d-de34-5db6" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="2ed8-d5f9-73a8-8e75" name="Longship Raid" hidden="false">
+              <description>Universal Rule
+The model gains Ambush. During step 8 of the Pre- ​Game Sequence nominate a unit of Åsklanders, Huskarls, or Berserkers that is no more than 30 models if Åsklanders and 20 models if Huskarls or Berserkers. This unit gains Ambush and the model with Longship Raid must be deployed within this unit. Units using Longship Raid to Ambush gain +2 modifier to the dice roll to see if they enter the Battlefield, and all units using Longship Raid must arrive from the same Board Edge.</description>
+            </rule>
+          </rules>
+          <categoryLinks>
+            <categoryLink id="6376-8287-7660-9ec4" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d616-fa3a-7362-c3ee" name="Replace Heavy Armour with Shield and Berserker&apos;s Bear Pelt" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="75a4-d324-24a1-59ba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5a1-b3e7-51f1-0825" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ac0-909d-d725-3f8e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="44b9-d0d4-d4ff-da61" name="Berserker&apos;s Bear Pelt" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+              <characteristics>
+                <characteristic name="Type" typeId="017b-143b-0520-bdc1">Light Armour</characteristic>
+                <characteristic name="Save" typeId="4ca3-2498-f356-f056">+1</characteristic>
+                <characteristic name="Rules" typeId="f269-16dd-a614-0f90">Follows the rules for Light Armour (can be enchanted as Light armor). In addition, at the start of any of your Player Turns all models with Berserker’s Bear Pelt in a unit may choose to lose its Shield and gain ​Frenzy ​, Fearless ​, ​Battle Focus ​, ​Lightning Reflexes ​, and ​+1 Strength ​. Effects lasts for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d388-d4d7-814b-c628" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="1c28-6450-ace3-153d" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b5a1-b3e7-51f1-0825" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6027-6255-771a-8497" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f89d-8519-7da2-f605" name="War Dais" hidden="false" collective="false" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a579-15fc-17a0-cc17" name="Shadow Chaser" hidden="false" collective="false" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1c9b-b0e7-710a-8756" name="Black Steed" hidden="false" collective="false" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e46e-7457-4fa4-d51e" name="Dark Chariot" hidden="false" collective="false" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0d0b-54c7-9d0e-4e2e" name="Chimera" hidden="false" collective="false" type="upgrade">
+              <categoryLinks>
+                <categoryLink id="6ffd-8df5-6418-0d26" name="Legendary Beasts (local)" hidden="false" targetId="d224-066a-e928-c28c" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="165.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b47c-af41-55aa-d513" name="Wasteland Behemoth" hidden="false" collective="false" type="upgrade">
+              <categoryLinks>
+                <categoryLink id="14de-e990-005a-3cc7" name="Legendary Beasts (local)" hidden="false" targetId="d224-066a-e928-c28c" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="375.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6d5d-9499-3ffa-f85e" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c33-b6d0-377d-38da" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="fb9f-6faf-e990-6d77" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="16d6-19b4-5b0d-826d" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caea-b800-ad08-9956" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9556-6422-7717-6c83" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="11ea-97eb-3835-162c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="10d3-9094-3e5d-043c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5984-8c89-48bf-d0a5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d267-a52d-9389-3d94" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="fe9a-a6a1-2fd7-d18a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b7d2-89a3-7eb9-541c" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ca0-8971-7628-3d25" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9d5a-ff42-9915-98e2" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="563d-2eb5-e1aa-c431" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0ee6-acd7-190b-0951" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="75a4-d324-24a1-59ba" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b5a1-b3e7-51f1-0825" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebab-35ce-cdf2-7239" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6a51-f23f-b184-0f90" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d898-683c-0dd4-2f29" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f450-8724-b2d2-876b" name="Warriors" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6dcc-741d-a5c6-a412" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7fdd-1867-bedc-e49c" name="Warriors Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="986a-420b-bdd5-f107" name="Warriors Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e77a-1409-a7bf-3d05" name="Warriors Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a80b-c3b2-7ab1-3bfe" name="Hell-Forged Armour" hidden="false" targetId="4b6e-450b-00c6-c6e9" type="profile"/>
+        <infoLink id="9eaf-57c9-823b-c273" name="Path of the Favoured" hidden="false" targetId="ad22-35cb-7d05-aea3" type="rule"/>
+        <infoLink id="9636-b5a7-e68d-69e8" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="188f-36fd-c50e-a38a" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d860-188f-d8f2-79ba" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2342-65ab-28c9-38a2" name="Warrior" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af0d-ca94-4d13-f10b" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b29-04ec-feb7-9d4c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="24.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="667a-df61-068f-d8e4" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f450-8724-b2d2-876b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33ec-23eb-2e6d-2c59" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6aac-f32c-7683-65ac" name="Banner Enchantments" hidden="false" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="71d7-e495-7800-f36c" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="3f17-677b-bec4-7480" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="55ef-3b11-32aa-a4fe" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b12d-60cc-126f-be9a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="94d1-6d38-9321-f906" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="f450-8724-b2d2-876b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2342-65ab-28c9-38a2" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0e6-b68d-4b71-97e3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5424-e8b0-72f2-ed8a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d7d6-4c9c-a03b-555e" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="f450-8724-b2d2-876b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2342-65ab-28c9-38a2" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="828c-d424-c6fa-f905" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a723-f452-73ff-be25" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9f55-8412-f136-cf91" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="7">
+                  <repeats>
+                    <repeat field="selections" scope="f450-8724-b2d2-876b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2342-65ab-28c9-38a2" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c217-3bbb-c5db-0f59" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0ce0-5193-bac2-03f3" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d72f-1531-6214-e435" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="88b2-a098-0164-890f" name="Åsklanders" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="43a9-90e1-ff4d-f831" name="Åsklanders Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6b16-b9f1-f596-ca96" name="Åsklanders Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7db1-f258-6fa4-6a22" name="Åsklanders Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0f16-0a60-c507-f256" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="edff-d9d8-5701-38da" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="78cb-6e9f-9633-7d11" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="88b2-a098-0164-890f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00a1-17ac-09d2-c088" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4d52-2abc-7b19-80bc" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bc45-7a10-bdff-18e3" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6a60-8f44-df1d-0d73" name="Åsklander" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e09-c6fa-82e4-044c" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2db0-c65a-ea7f-e1b2" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="0dbd-a889-5a45-688f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b339-fc1f-18bd-68e9" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="88b2-a098-0164-890f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce00-7842-b5f8-a6cc" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="4154-1f14-6dd1-0f8f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="cf7d-8abc-7d30-4b8a" name="Banner Enchantments" hidden="false" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8bb7-d9d5-0418-3ec9" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="80c1-b1cd-b94a-60a4" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1d5c-a7a4-f23d-284f" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="315b-82bc-f9e8-730f" type="max"/>
+            <constraint field="24fd-8af8-0c78-001c" scope="roster" value="80.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67f5-59a9-2168-f3a7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9edf-9cfe-8dc8-3b41" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="533f-cbf4-30c2-83f9" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="00a1-17ac-09d2-c088" name="Replace Shield With" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d760-148b-d436-21c6" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="d563-c086-6d8e-6169" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="c26e-0fbc-036e-abf9" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="88b2-a098-0164-890f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a60-8f44-df1d-0d73" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8965-c39b-1fc4-1cdc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="26e7-a6fb-4a23-3def" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="c9f3-797a-dc0b-88e0" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8fd5-fd63-1427-695e" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="88b2-a098-0164-890f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a60-8f44-df1d-0d73" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4323-38c4-fe85-4f60" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="86cd-9081-1908-a55a" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d3e8-6278-b028-9267" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="4.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="83d7-4e27-5415-3619" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="88b2-a098-0164-890f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a60-8f44-df1d-0d73" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d46-d351-7a0c-4be6" type="max"/>
+                <constraint field="24fd-8af8-0c78-001c" scope="roster" value="120.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6173-2ade-c37f-3ba8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="43d1-cdd2-6601-4998" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="cf57-395c-201e-771a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup">
+          <categoryLinks>
+            <categoryLink id="976e-2ced-9fba-8c3d" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ba61-979e-71cb-5c60" name="Huskarls" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf2-8954-e3b6-8637" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="382e-73f5-0f9c-db80" name="Huskarls Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="72d1-cd72-f2c0-1aa9" name="Huskarls Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="09fb-7ae1-a586-eb33" name="Huskarls Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5a5c-d849-6b2e-4739" name="As One" hidden="false">
+          <description>Defensive Trait.
+If the unit has at least 2 Full ranks and a majority of its models have Shields and As One, all models of Standard Size in the unit gains +1 Armour against Ranged Attacks and in the first Round of Combat.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="672e-6f3e-1baf-30b5" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="8e77-de73-41b6-c348" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="e979-d64e-2f93-4c0a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ba61-979e-71cb-5c60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2ce-35f1-783a-4c21" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="35ea-f3bd-1e60-9bf5" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5ec5-44e3-2e1b-e793" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Åsklander Chief)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1fef-d160-f113-74d1" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c8cf-ae10-80de-947f" name="Huskarl" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8c-3c41-e24a-9dba" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2021-8129-6823-c7de" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="11c8-67e7-506e-4c8a" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ba61-979e-71cb-5c60" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0597-6a3f-b95f-7c8a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="31ab-3526-29f5-6504" name="Banner Enchantments" hidden="false" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="783f-f2c8-c7f5-ad92" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="19f5-ae31-e684-83f3" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="ba61-979e-71cb-5c60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8cf-ae10-80de-947f" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a536-f27f-78fe-362c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7001-6f21-77a7-1b20" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7910-9e38-8c14-74be" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c694-9e15-b9b3-c33d" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="d152-0345-6b8b-d137" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="b2ce-35f1-783a-4c21" name="Replace Shield with Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="ba61-979e-71cb-5c60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8cf-ae10-80de-947f" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e950-6e5c-ff4a-f352" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b294-ef7e-e1f6-de6f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0886-9b9c-91e9-7f7d" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="ba61-979e-71cb-5c60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c8cf-ae10-80de-947f" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0944-9662-20bd-10e1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="670c-c9f1-eca7-97d7" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8974-534d-09d8-187d" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8eea-d70f-9bbc-89dd" name="Wargs" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c007-6522-33e3-fc55" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="217a-93ac-1dce-dc65" name="Wargs Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5873-2b4e-543b-bd4c" name="Wargs Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="aedb-04ca-f085-75c6" name="Wargs Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c290-0e61-abac-69f4" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6ba7-f985-7e62-c939" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="b7bc-5fcc-1fdb-8d8b" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c61c-9768-a2eb-7bad" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="37ed-a963-b57d-c036" name="Warg" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0da-3091-b54b-dd5e" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05a9-0512-81ee-8252" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7f4a-4b90-a2a9-4071" name="Åsklander Horsemen" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="decrement" field="1b2d-4498-d679-55fb" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="64e6-0778-b8d9-1bf9" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b2d-4498-d679-55fb" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="da2d-60d4-0ba6-eaa9" name="Barbarian Horseman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="476a-8eaf-ad9c-c868" name="Barbarian Horseman Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6a87-ac19-a9a3-2e5a" name="Barbarian Horseman Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9b8b-7435-2613-f8be" name="Black Steed Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e33f-241c-ed1b-4f7f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="2145-0217-80ca-fd5e" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="f9b5-0070-813d-1648" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="2c57-284d-f5fe-f772" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="2bfd-4175-35b4-e5b6" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="209f-2eda-2dcf-faaa" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c7b4-507d-baf9-6dbf" name="Åsklander Horsemen" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b25-3765-86d0-bd7b" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c0-334b-4de3-b4d9" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8c8f-1a1e-1c49-a062" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="7f4a-4b90-a2a9-4071" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f439-b088-8cd3-7ffb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="08a7-aa48-2208-83a0" name="Banner Enchantments" hidden="false" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ee6-97ea-e0e5-937f" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a594-db90-4a74-fb36" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ace-e87f-8cab-0d58" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1942-74b8-5aab-5687" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="7f4a-4b90-a2a9-4071" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c7b4-507d-baf9-6dbf" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1e5-2010-c8c1-1d83" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0137-e607-55a7-a608" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8e6d-3e50-f1a1-5122" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f98-4e65-ca0a-4a96" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e503-4df4-83c4-e85d" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="99ed-77cc-2c51-78f5" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="7f4a-4b90-a2a9-4071" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c7b4-507d-baf9-6dbf" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a7-b0c4-e489-d620" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5b9d-f713-19c8-bfaa" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4f0e-ba89-bb9c-522e" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9541-1d4a-37ce-097f" name="Flayers" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c433-7a15-f5a7-d8fa" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a13f-e0c3-500b-c1a7" name="Flayers Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">10&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">50&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="591a-8ff7-0f06-402f" name="Flayers Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">6+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fa73-f695-c014-28f7" name="Flayers Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7dd0-428a-eb6f-ddfb" name="Shadow Chaser Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e488-f597-5f31-6145" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="d292-76fa-a557-8ba7" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule"/>
+        <infoLink id="e9b3-ddcb-0486-aece" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="61dc-67ef-3517-d054" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="7be6-597d-f0b1-2e00" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9ba6-6e81-633a-a1dc" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="15a2-fae1-7afb-d2db" name="Flayer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15c6-e759-bfd0-a21c" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7965-d5f3-e7fe-2b05" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="19.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd03-6128-d929-ee0f" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="9541-1d4a-37ce-097f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15a2-fae1-7afb-d2db" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a09f-a629-41ba-5f64" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f966-9b85-f82b-1383" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="491f-b4ec-9ec3-5962" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8279-6976-2c79-e7f4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4851-6ca3-e828-65cf" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="9541-1d4a-37ce-097f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15a2-fae1-7afb-d2db" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7655-62a9-f25f-7000" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3454-4610-22e4-1383" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1dce-5d0a-2272-c1a7" name="Skinning Lash" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="9541-1d4a-37ce-097f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15a2-fae1-7afb-d2db" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="369a-f99d-db36-0431" type="max"/>
+                <constraint field="24fd-8af8-0c78-001c" scope="roster" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cdf8-761a-5446-a669" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="4ff8-7443-de68-9a8a" name="Skinning Lash" hidden="false">
+                  <description>Special Attack
+A unit with at least one model with Skinning Lash can make a Sweeping Attack against a single unengaged enemy unit when passing within 1&quot; (it does not need to and cannot move through or over that unit). The enemy unit suffers 1 hit with Strength 4 and Armour Penetration 0 for each model with Skinning Lash in the unit. A unit that loses one or more Health Points due to the Skinning Lash Sweeping Attack suffers -1 Discipline until the end of its next Player Turn.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a201-7616-1270-c5e3" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="9541-1d4a-37ce-097f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15a2-fae1-7afb-d2db" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62d7-7d44-df50-971c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1c79-5add-e851-8339" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5b01-7730-a185-67e3" name="Command Group" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="0e15-9e4e-b415-349b" name="Champion" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3371-94c3-e52f-1921" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="21a3-9e1a-2b49-e1e3" name="Musician" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f85-8218-0da2-5d8e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="be95-9a87-b729-bcad" name="Warhounds" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe6d-151e-fbc4-5dd4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="62c3-dce2-c674-3fe3" name="Warhounds Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7df6-b00f-4901-5044" name="Warhounds Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5953-40b3-e074-ddd0" name="Warhounds Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a383-f9c2-c7ec-0bce" name="Release the Hounds" hidden="false">
+          <description>Universal Rule.
+During their owner’s first Player Turn, Warhounds gain +8” March Rate and Devastating Charge (+1 Att, +1 Off, +1 Str, +1 AP).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="4785-875c-2ce3-41ff" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ded7-364a-8778-5891" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="644d-7a8d-f834-184b" name="Warhound" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f0b-5918-ab5e-7bb3" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a70f-0ad9-36f4-bfca" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="3839-79c4-cc86-777c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff02-f7f1-0ad3-eb90" name="Marauding Giant" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84ee-fc05-b72d-6f28" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2054-36fe-d651-8fcf" name="Giant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="df00-8668-7886-12ae" name="Giant Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">6+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5083-cf98-9ee3-3b92" name="Giant Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5878-5967-ec09-5dca" name="Giant See, Giant Do" hidden="false">
+          <description>The model gains Battle Fever.</description>
+        </rule>
+        <rule id="37f2-b149-5ba9-3876" name="Rage" hidden="false">
+          <description>For each Health Point the model currently has below 7, it gains +1 Attack Value.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="fdc7-b085-8024-3fb5" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="ac7b-bed7-dc46-6ccb" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6a9a-740f-d944-8562" name="New CategoryLink" hidden="false" targetId="d224-066a-e928-c28c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5b22-e7be-be2e-aa15" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d794-acd2-6ee3-73b9" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="ee2b-bc1e-f87f-92c1" name="Big Brother" hidden="false">
+              <description>The model’s Health Points are set to 8, and its base size is changed to 75×100 mm. The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="60a8-4443-88b5-8abe" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0167-1de9-ee72-9deb" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="8e79-2d43-ed7d-aa8a" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="cdc8-5052-9c32-5b9a" name="Giant Club" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c405-0798-1a01-60bd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="ceaa-e793-8acd-557b" name="Giant Club" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="08d5-9706-ceb8-4720" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7692-1fbf-6812-dc78" name="Monstrous Familiar" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c9b-e665-4f7d-3861" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="eef5-9a42-d3da-e170" name="Colossal Cleavers" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0"/>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains +1 Attack Value. Attacks with this weapon gain +1 Armour Penetration, and Battle Focus. The wielder must Pursue and Overrun whenever possible.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="4b3d-3546-19cf-896e" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d3f4-76fe-962b-0501" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fafc-95ca-e437-6260" name="Tribal Warspear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9ca-2b85-aa43-a499" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="80f9-9d37-d655-f6df" name="Tribal Warspear" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083"/>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Attacks with this weapon gain +1 Strength and Multiple Wounds (D3, against Towering Presence). Charging enemy units in base contact with the wielder suffer -1 Agility. The wielder follows the rules for War Platforms with the following exception: It can only join Infantry units that include at least one R&amp;F Åsklander or Huskarl model.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="8ba5-735b-c288-4926" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="260.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c93b-955d-d8ef-8759" name="Jötunn" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6707-7b7b-4199-638c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8e5c-4c20-8671-be22" name="Jötunn Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="71d6-5aab-a405-570d" name="Jötunn Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">7</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0d3c-2bdf-5fdd-1ee6" name="Jötunn Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5d84-612b-a8d0-4914" name="​Freezing Mist" hidden="false">
+          <description>Universal Rule.
+Attacks with Flaming Attacks must reroll successful to-wound rolls against the model.
+All enemy units in base contact with the Jötunn suffers:
+● -3 Agility to a minimum of 1.
+● -1 Armour to a minimum of 0.
+● -1 Armour Penetration to a minimum of 0.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="50e3-426f-0f7e-4579" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cc8e-fe4a-3991-f96c" name="New CategoryLink" hidden="false" targetId="d224-066a-e928-c28c" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="475.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ebf2-6b68-ea36-95f1" name="Ice Trolls" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="470c-18c9-a28a-b94a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5398-e516-37c0-aaf8" name="Troll Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a43f-7b3b-f7b9-d897" name="Troll Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8041-3080-77bf-a87c" name="Troll Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="21be-0d6f-e00e-27ea" name="Stupid" hidden="false">
+          <description>At the start of each friendly Player Turn, each unengaged non-fleeing unit with one or more models with Stupid must take a Discipline Test. If the test is failed, all models in the unit become Shaken until the end of the Player Turn, and in the Movement Phase, directly after Rallying Fleeing units, the unit must move D6&quot; directly forward, stopping 1&quot; before Impassible Terrain or other units.</description>
+        </rule>
+        <rule id="89b5-26ac-6c4e-9319" name="Troll Belch" hidden="false">
+          <description>Special Attack.
+At the model part’s Initiative Step, it may choose to not perform its Close Combat Attacks and instead choose an enemy that the attacking model would be able to attack with Close Combat Attacks. This unit suffers a hit, which is resolved with Strength 5 and Armour Penetration 10.</description>
+        </rule>
+        <rule id="3ee4-08a2-48ea-ee53" name="Ice Troll" hidden="false">
+          <description>The model’s Armour is ​ set​ to 2. Flaming Attacks must reroll successful to-wound rolls against the model.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="08b1-430b-2b57-1ff4" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="815f-5956-641a-3a62" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f339-d1b9-67d8-0766" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="aff1-3d6d-0c9c-ce19" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ccf8-1bd1-4b5e-3f17" name="Ice Troll" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8692-f54e-8654-b708" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="175e-c5ea-ffe2-85e9" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="81.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="17fa-c5e5-7139-474f" name="Berserkers" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="55dc-b142-c7b4-1fed" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="1097-077b-d083-e1d6" name="Berserkers Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e135-4c95-5105-f7a9" name="Berserkers Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">5+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2163-21c2-0571-4345" name="Berserkers Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="82fa-c15b-0acd-ec48" name="Berserker&apos;s Bear Pelt" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+          <characteristics>
+            <characteristic name="Type" typeId="017b-143b-0520-bdc1">Light Armour</characteristic>
+            <characteristic name="Save" typeId="4ca3-2498-f356-f056">+1</characteristic>
+            <characteristic name="Rules" typeId="f269-16dd-a614-0f90">Follows the rules for Light Armour (can be enchanted as Light armor). In addition, at the start of any of your Player Turns all models with Berserker’s Bear Pelt in a unit may choose to lose its Shield and gain ​Frenzy ​, Fearless ​, ​Battle Focus ​, ​Lightning Reflexes ​, and ​+1 Strength ​. Effects lasts for the remainder of the game.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="046a-ff6a-7219-f4d0" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="ed38-a79c-4f93-6e69" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="25b7-83ef-584e-e4fe" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="0281-19fd-71b7-914e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d03f-1dc3-04d1-d84f" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6c78-ce89-3bb1-6dd6" name="Berserker" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c00c-2dbc-8138-4043" type="min"/>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9ee-2108-7a3a-97ec" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b54b-fd0d-1bdb-51aa" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ca0-dbbd-9d23-e6eb" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="d1df-cdc0-afb4-6275" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="780f-6090-9f8a-80c4" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="17fa-c5e5-7139-474f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c78-ce89-3bb1-6dd6" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0770-6585-98dd-87e5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b6bd-8bbc-2d27-5b10" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b7f7-b281-194a-7e48" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="17fa-c5e5-7139-474f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c78-ce89-3bb1-6dd6" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da14-c3a8-0564-0bec" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6bf2-ca88-3751-fa3d" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6da2-f0a6-9e42-4757" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="17fa-c5e5-7139-474f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6c78-ce89-3bb1-6dd6" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d7a-7097-b872-2d62" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="305d-22bc-a4fc-8e55" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="22.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8d26-3a08-e887-8536" name="Kraken" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3daf-cc3e-2fc5-8b70" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="89aa-3f0a-897b-e8d4" name="Kraken Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b7f6-386e-4b5c-98dd" name="Kraken Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3223-fa18-5aac-7c9a" name="Kraken Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3100-0761-f6b6-ff29" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d8ba-4383-55fa-bc57" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="2013-737c-4110-e41a" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="4054-0e2a-ebef-8951" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="50f0-a149-055c-1f74" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fc4e-d03d-4d1b-dc1f" name="New CategoryLink" hidden="false" targetId="d224-066a-e928-c28c" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="375.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="64e6-0778-b8d9-1bf9" name="Åsklander Horsemen (Core)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03be-5428-e77c-fdf4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5767-994b-c10c-dd5a" name="Barbarian Horseman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b2d9-140a-26ec-f91a" name="Barbarian Horseman Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2fc2-a14c-569c-2c1b" name="Barbarian Horseman Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ab3c-d5dd-fe68-4941" name="Black Steed Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fe1e-52a5-670d-715f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="a878-9fbc-5350-35b6" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="07f3-f2c8-4d41-4239" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="03be-d682-aabe-60b5" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
+        <infoLink id="7c4e-260f-9f13-1746" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9977-ccbd-8efc-1acd" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c204-d62c-c015-94ae" name="Åsklander Horsemen" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="236d-e101-5346-0f38" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a55-8441-0982-f2ca" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7b4c-45d5-4e29-8a12" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7bf-64dd-8ea9-1df4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c35e-5543-df02-9cd7" name="Banner Enchantments" hidden="false" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="64e6-0778-b8d9-1bf9" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4b94-04de-6121-8843" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0512-ee16-d938-0e58" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6306-66f7-bb6d-e630" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="64e6-0778-b8d9-1bf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c204-d62c-c015-94ae" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8804-8612-3ba8-55f8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="76ec-b20a-35f8-e3a8" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3a09-4f2c-a237-64e1" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dfe-9212-1f23-6945" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6e14-1666-a96b-5eac" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="87d3-9c49-a25d-b9b9" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="64e6-0778-b8d9-1bf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c204-d62c-c015-94ae" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7edb-164e-4226-c050" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a11f-7e22-8e00-68ae" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6423-fab3-7a85-9557" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="c30a-4220-8c73-d69b" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0aa-d3a8-9d0c-8901" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="717c-29c9-13fd-c52b" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7eb2-d331-e18b-cadf" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="736b-aab0-bad9-c9e8" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="beec-d54f-1846-8678" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="50b0-92f9-2390-fe6b" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dde-7036-d433-a6b7" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb1-d635-a9ad-85ae" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9183-4283-c9db-83ab" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a3e3-5f23-548b-4e48" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="2eb2-5755-d708-4c4c" name="Weapon Enchantments - Åsklanders" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c88-5795-55e5-6b93" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0a30-afbb-4ce6-f5a2" name="Bjargfylli" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7526-86ec-a9b0-4ef4" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="de97-71b2-7546-36cf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6bea-afd1-e0bc-cb2c" name="Bjargfylli" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Spear enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gains Divine Attacks, Lightning Reflexes, Lethal Strike, and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cefd-3232-dc53-2e02" name="Eyratöki" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2831-a77c-f90c-ea84" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68de-d7d7-ef15-3d80" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0f93-0edc-6865-99ec" name="Eyratöki" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gains Magical Attacks, and wound automatically</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b7bc-c981-b934-04ab" name="Symbol of Slaughter" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="974e-2945-3d37-7468" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="54fb-9e9e-c2ec-9886" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cd82-88cd-f0bd-76e8" name="Symbol of Slaughter" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon and Paired Weapons enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When using this weapon the wielder gains +2 Attack Value and +2 Agility and suffers -2 Offensive Skill and -2 Defensive Skill. Attacks made with this Weapon gain Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="cb21-fc0e-6fbe-9a3b" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a2-1ac0-b18c-2272" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="f099-ea11-080f-4cad" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+        <entryLink id="259c-2107-04ee-1e50" name="Weapon Enchantments - WotDG" hidden="false" collective="false" targetId="2eb2-5755-d708-4c4c" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e473-0818-1abb-3348" name="Armour Enchantments - Åsklanders" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="86f0-a61d-6b25-4bf7" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86f0-a61d-6b25-4bf7" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="e177-2f3f-26bb-20cc" name="Gunagr&apos;s Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f905-d5c8-0e2e-2467" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34db-1d0e-2f11-9c4f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="07e0-b056-050a-6c13" name="Gunagr&apos;s Armour" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Fearless and can ​never be wounded on better than 4+.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f975-dd5b-da67-142e" name="Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="0c88-1c64-2172-a8f4" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c88-1c64-2172-a8f4" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="e0b1-6fcb-d315-6a03" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+        <entryLink id="c218-2d61-1d5c-8646" name="Armour Enchantments - WotDG" hidden="false" collective="false" targetId="e473-0818-1abb-3348" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f1be-ccdc-db5b-9013" name="Banner Enchantments - Åsklanders" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="94b4-570b-cc84-f031" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="5930-30d8-5b72-1755" name="Raven Banner" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d36-98ef-b132-60de" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="133b-19dd-6b34-05ca" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e93a-dce6-a04b-a7ea" name="Raven Banner" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Bearer’s unit gains Fear.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ec38-a844-0013-74ac" name="Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c23-f7e2-e8ad-eb43" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="83c2-a0ba-e098-79c0" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+        <entryLink id="98b9-706b-9d94-f2f8" name="Banner Enchantments - WotDG" hidden="false" collective="false" targetId="f1be-ccdc-db5b-9013" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e03c-3642-f6e6-6d33" name="Artefacts - Åsklanders" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b2e-d3ca-d3a2-edd6" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="1022-4118-68c2-07cf" name="Norn&apos;s Bones" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2f1-414b-0e8e-2d31" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f28-f8da-a88f-6430" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8e58-c21d-ae92-6ee7" name="Norn&apos;s Bones" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Wizards only.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The Wizard may swap any of its Learned Spells for any other Learned Spell in the same Path and/or the Hereditary Spell. This rule overrides the Spell Selection rules connected to being Wizard Apprentice, Adept, or Master.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b69-6051-a86b-f6c9" name="Harp of Bragi" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09a0-c173-846a-6d7a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="892b-722c-4ae7-995c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ef39-7d34-5ad7-5289" name="Harp of Bragi" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The range of the bearer’s Commanding Presence or Rally Around the Flag is always 18”.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="17df-ad66-db37-0a37" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8551-b8c7-3034-da36" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="c87b-afc6-0550-8cb1" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+        <entryLink id="e978-d40f-3797-8a07" name="Artefacts - WotDG" hidden="false" collective="false" targetId="e03c-3642-f6e6-6d33" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="ad22-35cb-7d05-aea3" name="Path of the Favoured" hidden="false">
+      <description>The model can make one more Supporting Attack than normal from the second rank, and when it fights in a Duel it gains +1 Discipline until the end of the Melee Phase. Units with one or more models with Path of the Favoured cannot add Rank Bonus to their Combat Score.</description>
+    </rule>
+    <rule id="45c4-f6e9-92e8-a409" name="Path of the Exiled" hidden="false">
+      <description>The model gains Stubborn in the first Round of Combat provided its unit does not have more ranks than files and it is Engaged in Combat in its Front Facing with an enemy unit. Units with Path of the Exiled cannot join or be joined by units without Path of the Exiled. </description>
+    </rule>
+    <rule id="381d-6b94-16aa-dcab" name="Irredeemable" hidden="false">
+      <description>The model cannot use Stomp Attacks and can use Grind Attacks as Supporting Attacks (ignoring the maximum number of Supporting Attacks). When a model with Irredeemable is killed by a Melee Attack, remove it as a casualty only at Initiative Step 0. A unit with at least one model with Irredeemable may never have more ranks than files. </description>
+    </rule>
+    <rule id="f24d-4987-95ae-9ed9" name="The Reckoning" hidden="false">
+      <description>Whenever a friendly model with Hell-Forged Armour or Irredeemable is removed as a casualty, if its unit was within 8” of a friendly model with The Reckoning, you gain one Soul Token to your Soul Token pool for each Health Point the model (that was removed as a casualty) started the game with. The number of Soul Tokens in this pool cannot exceed 4. Before a model with The Reckoning casts a non-Bound Spell you may discard up to two Soul Tokens from your Soul Token pool for the following effects (declare which effects are used before the Casting Attempt):
+1 Soul Token:
+If this Casting Attempt results in a Miscast, roll a D6 before any Dispel Attempts are made. On a roll of 3+ the Miscast result is treated as Broken Concentration (ignore other Miscast modifiers).
+X Soul Tokens:
+For each Soul Token discarded for this purpose, the Spell gains +3” Range.</description>
+    </rule>
+    <rule id="0e05-c2ea-20d5-5859" name="Battle Fever" hidden="false">
+      <description>Units consisting entirely of models with Battle Fever must reroll any natural rolls of ‘1’ when rolling for Charge Range. </description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="4b6e-450b-00c6-c6e9" name="Hell-Forged Armour" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Suit of Armour</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+3</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">The wearer gains Fearless. If more than half of a unit’s models have Hell-Forged Armour, the unit must reroll failed Break Tests.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/beastHerds.cat
+++ b/beastHerds.cat
@@ -1,0 +1,5180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="f4f2-e414-182d-9513" name="Beast Herds 2.0" revision="16" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="b739-c731-20eb-f075" name="Ambush Predators (local)" hidden="false"/>
+    <categoryEntry id="c6e5-9f4e-63f5-1cc0" name="Terrors of the Wild (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="a332-0f7d-55f5-7a50" name="Beast Herds (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="ff7a-9ee4-ffc7-7473" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="23be-7b78-e1e4-40fc" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f951-133b-1dd6-c0f8" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="7833-3f77-5698-f507" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bac4-f924-0aa3-0e0a" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="f82c-db89-dd91-f52a" name="Terrors of the Wild (local)" hidden="false" targetId="c6e5-9f4e-63f5-1cc0" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="7b81-6bc9-de27-552b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="cd1b-7175-4291-b781" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="60.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="354f-d4fd-5b19-6c37" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="2e48-09a5-4596-c5fa" name="Beast Lord" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="f62d-0aa2-ce92-9f79" name="Beast Lord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e4b4-ecc0-5d20-0c93" name="Beast Lord Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9a23-9919-57cc-3bb5" name="Beast Lord Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="157f-62c3-cd13-f121" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2e48-09a5-4596-c5fa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ede-e5f2-421d-4a72" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5bf9-28ea-67ba-8c0c" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="dbfb-310b-4710-3dbb" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="d514-4e8e-718c-7ace" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2882-dc7d-bc6f-d203" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="95b7-96da-f2d3-a028" name="Hunting Call" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8507-b552-e7fd-91cf" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4958-19a7-e4fa-0762" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a4e5-04e2-31c1-fa2e" name="Hunting Call" hidden="false">
+              <description>If a Beast Lord with this upgrade is the General, Ambush rolls of 1-2 for units with one or more models with Pack Tactics may be rerolled. Unless the owning player has the first Player Turn, Ambush rolls for such units must be made starting from the controlling player’s Player Turn 1 (but still at the end of step 2 of the Movement Phase Sequence).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b5d-c1a7-22a4-6db6" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b00-c06f-907d-596a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9bb3-d796-4754-9d01" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="87ba-62bf-1fa9-74c1" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="937e-0fa0-a9ad-c1f7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3c3a-8bf2-1ee3-60e1" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c52-35ae-3512-c601" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="20e5-66c3-7a29-06f3" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="a905-d503-e30e-ce95" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="20a0-57f4-75fb-fc16" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fce3-66fe-f7f0-dcbc" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="555c-216a-3a27-88df" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8507-b552-e7fd-91cf" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="854d-5a2a-4912-6f61" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="7232-3f61-a8d5-4824" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5070-09e2-6847-4a3a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bc4d-35d4-fe12-f343" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3ede-e5f2-421d-4a72" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a40d-80fd-0624-5d3a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1e34-d8e0-41fe-39dd" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="838e-dda2-2635-5fef" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af6d-529e-9e9a-49f1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3ab6-d8f0-a19a-0e4e" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2e5-2137-4c5a-db5a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="abf4-757a-1a38-9e62" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e50a-64b0-f1e4-5fdb" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c01-99b0-fe18-2dc2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="066c-94ca-4caa-1afd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b2bf-8080-74b8-9d1d" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1862-158b-f621-872f" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="815e-a268-92fb-5e26" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6053-b663-75c8-899a" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9824-f160-6832-3e62" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6136-4368-edfd-aa03" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="62d3-be45-3f56-8e13" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5c01-99b0-fe18-2dc2" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3603-65b6-c405-a27f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5d1b-b12f-9230-1ac5" name="Raiding Chariot (Mount)" hidden="false" collective="false" targetId="a5ff-d99a-26c3-d95a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="90"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="246f-1382-ac92-285c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="207a-1de6-b95c-3598" name="Razortusk Chariot (Mount)" hidden="false" collective="false" targetId="196f-f4cb-a2f1-df7e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="125"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c7e-7541-4d04-c78a" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="215.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="28ff-8f65-ae1a-f291" name="Beast Chieftain" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2343-c350-3945-79bf" name="Beast Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1293-2abe-400a-f2f3" name="Beast Chieftain Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="df1c-a223-d682-8dc6" name="Beast Chieftain Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="31af-c06d-6824-2e84" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="28ff-8f65-ae1a-f291" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9617-af7d-08b8-fb1a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b6fa-5011-cc0a-8fbe" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="0ac3-a690-eb20-bb28" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="091b-f0ec-5aab-3d99" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ea18-a9ad-02cb-92b2" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7196-1278-3e32-7994" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d85-9d48-f6e2-b08a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f769-cbff-5a52-d734" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9e90-53fb-648e-ec5d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0c2-d873-1533-559f" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="9ff8-907c-0b4c-8f75" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2654-fd29-2cc2-8390" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47bb-659e-adf1-332f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="796f-0244-9690-b3cb" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="8cc8-0757-44bf-2bc5" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="4538-5090-f01d-618d" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+                <entryLink id="84fe-ddf5-f931-bcfe" name="Banner Enchantments" hidden="true" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="28ff-8f65-ae1a-f291" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce82-7a43-8b8e-0fbc" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="a8e0-353a-cd15-ef5d" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="9e90-53fb-648e-ec5d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="796f-0244-9690-b3cb" type="equalTo"/>
+                            <condition field="selections" scope="9e90-53fb-648e-ec5d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cc8-0757-44bf-2bc5" type="equalTo"/>
+                            <condition field="selections" scope="9e90-53fb-648e-ec5d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4538-5090-f01d-618d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ea07-7928-333b-7ad0" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="28ff-8f65-ae1a-f291" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce82-7a43-8b8e-0fbc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c63c-c898-d769-d854" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2035-8725-2018-7d8a" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ce82-7a43-8b8e-0fbc" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="28ff-8f65-ae1a-f291" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea07-7928-333b-7ad0" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a078-94f4-cccd-072f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c7a8-1806-d86f-5296" name="Battle Standard Bearer" hidden="false" collective="false" targetId="5448-4e9d-1ea4-c32e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b1f3-23ff-a543-387d" name="Hunting Call" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2035-8725-2018-7d8a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4f9-eec4-48ec-3b1d" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a1e2-dc42-0381-1516" name="Hunting Call" hidden="false">
+              <description>If a Beast Lord with this upgrade is the General, Ambush rolls of 1-2 for units with one or more models with Pack Tactics may be rerolled. Unless the owning player has the first Player Turn, Ambush rolls for such units must be made starting from the controlling player’s Player Turn 1 (but still at the end of step 2 of the Movement Phase Sequence).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1870-50ab-ad60-8a48" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="8846-8d3e-9992-6d40" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="524b-a0c1-a170-fee3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5678-5b06-b3a2-8297" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9617-af7d-08b8-fb1a" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5558-c9eb-1f95-aaad" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8e20-58f1-5b94-19bd" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2258-9520-4399-032f" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc52-3b8c-237d-b889" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4e20-0003-7273-b0c0" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bba3-1df6-cba7-2d91" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2e61-462b-b752-1e70" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c23d-11cf-86e4-ffdd" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="28ff-8f65-ae1a-f291" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb01-d6c8-01f1-76c1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcb1-9449-ad07-6647" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="41f0-d647-6613-b1d6" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="29ff-a3d3-a2b4-882a" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5196-d2f8-4a11-a178" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c2d5-72d8-4dbb-1276" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d01b-3bfa-c866-c9d1" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="465d-308c-75c2-e6ab" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ff79-6560-c90b-3d19" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="eb01-d6c8-01f1-76c1" name="Raiding Chariot (Mount)" hidden="false" collective="false" targetId="a5ff-d99a-26c3-d95a" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="90"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="403d-bfb5-d72b-f952" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a63f-60bc-8196-91e6" name="Greater Totem Bearer" hidden="false" collective="false" targetId="2660-c88a-bf3d-3113" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="85"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3213-3f78-c9ed-69aa" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ce92-bf1a-5a18-09ef" name="Soothsayer" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="292f-3431-46c3-4a6d" name="Soothsayer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f245-cf5d-5ad8-9598" name="Soothsayer Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5d0a-92a1-0bef-6ef6" name="Soothsayer Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="67cb-23e9-3d57-692d" name="Blood Offering" hidden="false">
+          <description>A unit that includes at least one Character with this rule may reroll failed Panic Tests and Decimated Tests at the cost of inflicting one wound with no saves of any kind allowed to a Character with this rule in the unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b051-d85f-180a-becf" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="60d9-ae48-538c-ca9e" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="62a6-157d-4271-3680" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="83d0-ceb1-da04-f32c" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ce92-bf1a-5a18-09ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96e3-71c7-3074-ce09" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c577-952c-ce72-0862" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b822-b42a-da1c-d541" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bccf-d00c-f9c4-9a04" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c5ac-8613-4bb8-7c14" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="76ed-0a4a-899a-a5b0" value="200">
+                  <conditions>
+                    <condition field="selections" scope="ce92-bf1a-5a18-09ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c11-e2e5-ce23-f834" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="76ed-0a4a-899a-a5b0" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b521-726f-a8ed-73f5" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="05c1-e94f-d028-55ff" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="3555-7969-7407-9d89" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ec8a-0176-27f4-6a61" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db60-bdb7-5b67-e584" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b331-bf55-4db7-0ce1" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6cfe-e4da-ba44-d7a0" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43c-0d36-6e34-4a1f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="18ef-5634-34fc-fe65" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="66a9-fb7e-1673-3083" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="725a-a528-8db1-0bde" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6770-93aa-42a4-9ba3" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="96e3-71c7-3074-ce09" name="May become" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a7c-4bcc-8d48-808c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ee4d-5c67-578f-1b12" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="7754-e205-c45b-61c9" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5c11-e2e5-ce23-f834" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="aed2-f42c-b9f0-694e" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9cff-1b38-a037-20a6" name="Must Select Spells from" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="7403-e586-3f7a-96cf" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7403-e586-3f7a-96cf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="afcd-591d-169c-4515" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6a08-6b56-7691-f0d7" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b43f-5425-37aa-507f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9f72-df46-200f-d0dc" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6dd4-94b3-290d-23b4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2d19-492a-9477-8ee3" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="593b-f55c-fbd0-01d1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7944-d0fa-08e3-a416" name="Raiding Chariot (Mount)" hidden="false" collective="false" targetId="a5ff-d99a-26c3-d95a" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="20"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79bc-de50-d70c-1f92" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="155.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="377e-9f45-b2cc-9f0c" name="Soothsayer (Ambush)" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="4306-05cc-f238-7ed5" name="Soothsayer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ad0b-c71b-c9a4-2e1e" name="Soothsayer Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="df4a-6d60-1154-db57" name="Soothsayer Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="9f90-6eb3-0826-d456" name="Blood Offering" hidden="false">
+          <description>A unit that includes at least one Character with this rule may reroll failed Panic Tests and Decimated Tests at the cost of inflicting one wound with no saves of any kind allowed to a Character with this rule in the unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8164-3bc9-1b09-1073" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="7088-2b49-9ecb-73bd" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="23b7-5154-1f61-9372" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="12ec-ce34-346a-9116" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="377e-9f45-b2cc-9f0c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="44df-53e3-8c12-99c9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a50d-f690-7c08-1d76" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8ffa-a2d2-519f-5589" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="bd8f-f3db-1278-eeb8" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3197-dfe2-ab5e-0be2" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5aac-99e2-a79c-a37a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f2cb-eff3-aaff-4f77" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="5d14-c335-909b-0f63" value="200">
+                  <conditions>
+                    <condition field="selections" scope="377e-9f45-b2cc-9f0c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e839-ddaa-fe17-03f8" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d14-c335-909b-0f63" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="cf72-a9ee-c3a4-fcd5" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="9753-dfbe-ff00-0c50" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="f80f-684d-5c5e-f6f4" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c5ed-5783-f234-dcf3" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ed-07a2-a04d-2134" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e67f-796e-d4fe-ace8" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c065-a9b9-fde3-a84b" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a6-83b8-d64f-2125" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7b1c-9aaa-8450-8f62" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9a3b-85df-8ff3-f611" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b80-689a-40be-1e77" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e9bd-c11e-4c18-2245" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="44df-53e3-8c12-99c9" name="May become" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03d5-3e2c-3eec-ad51" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="057f-d3c7-eae7-b647" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="7dfd-c55f-b721-65c3" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e839-ddaa-fe17-03f8" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="dd52-e290-56d1-7b1d" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e908-9fd2-b2cb-a12f" name="Must Select Spells from" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="7377-27cd-a9de-5e13" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7377-27cd-a9de-5e13" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7cb7-d5cc-294e-208c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5c12-67b5-0fdb-c27a" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="227c-0b23-bc84-891a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6157-1a66-7149-d094" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be26-9aef-39f7-4e69" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8b36-77fa-d336-d2c8" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43a4-2f2a-c6b1-7576" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="165.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c76-11de-d215-71b3" name="Beast Chieftain (Ambush)" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="59ed-a9c7-662d-80dc" name="Beast Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c71c-8778-d3a5-a381" name="Beast Chieftain Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5f62-f9e4-647e-f744" name="Beast Chieftain Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c21a-5f67-4052-f9fe" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="5c76-11de-d215-71b3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b74-3957-7310-8c0c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4b84-bac2-d558-c393" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="fe8d-07d0-e0b0-dfe3" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="a9ca-3849-01ab-2343" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="75d0-c29c-27f9-dab1" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8ef2-520e-a2e4-9adb" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="aa99-3d85-1da1-1638" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4767-f5d0-d449-52f8" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c49e-0218-e4f1-646e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b0e0-06ed-c32a-c36b" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7e19-850d-d534-329f" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="451c-086c-95ff-44c8" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c313-7ed3-c6c6-6843" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9223-0423-1ab7-8ae7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6840-4f17-2070-11b0" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="630d-6331-00fe-2545" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="2d24-1763-d33d-575e" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+                <entryLink id="efa6-9566-a9f2-be06" name="Banner Enchantments" hidden="true" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="5c76-11de-d215-71b3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0735-5313-3429-4ffc" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="a8e0-353a-cd15-ef5d" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7e19-850d-d534-329f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6840-4f17-2070-11b0" type="equalTo"/>
+                            <condition field="selections" scope="7e19-850d-d534-329f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="630d-6331-00fe-2545" type="equalTo"/>
+                            <condition field="selections" scope="7e19-850d-d534-329f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d24-1763-d33d-575e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d83-a640-a596-e988" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="5c76-11de-d215-71b3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0735-5313-3429-4ffc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ff0-e17a-80ef-dfda" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c6ae-4370-6a24-4f36" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0735-5313-3429-4ffc" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="5c76-11de-d215-71b3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d83-a640-a596-e988" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d29-e934-4acc-4cc5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="470b-63e2-3323-cff9" name="Battle Standard Bearer" hidden="false" collective="false" targetId="5448-4e9d-1ea4-c32e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="38f0-06dd-d3a7-6b78" name="Hunting Call" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6ae-4370-6a24-4f36" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f05b-26be-2774-b38f" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="400c-f9ce-6e28-cafe" name="Hunting Call" hidden="false">
+              <description>If a Beast Lord with this upgrade is the General, Ambush rolls of 1-2 for units with one or more models with Pack Tactics may be rerolled. Unless the owning player has the first Player Turn, Ambush rolls for such units must be made starting from the controlling player’s Player Turn 1 (but still at the end of step 2 of the Movement Phase Sequence).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="833a-4d0c-f9ab-adf4" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="803d-a4db-79c7-6966" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7e0-1c33-c9ec-3cc7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b708-9f1d-8203-a177" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3b74-3957-7310-8c0c" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c624-697a-23ef-1395" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f5bd-6ead-3f41-ebc9" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1da5-df6e-ce94-2880" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e26-03b6-d522-84b2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a30e-3fb9-1d71-72c3" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caba-cd23-3fdd-fe41" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b87d-4305-bed8-f21f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5020-71c3-3d43-2873" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9548-316c-ec72-35db" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="006a-c39b-cd83-e107" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cec6-07bd-ea1e-85c7" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37a9-9326-6d90-c73b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="323a-e0f9-8dff-629d" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8141-9a0f-672a-1940" name="Greater Totem Bearer" hidden="false" collective="false" targetId="2660-c88a-bf3d-3113" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="85"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8b1-d72d-57e2-26b6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e74f-78ef-de7f-6201" name="Minotaur Warlord" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="023a-af9d-d95a-2933" name="Minotaur Warlord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="38a7-fb6b-a438-34c7" name="Minotaur Warlord Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9c9d-e794-4b2f-ce35" name="Minotaur Warlord Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7de2-9534-a784-750b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e74f-78ef-de7f-6201" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11db-6005-0698-5e90" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="67b7-51d2-ae70-cf33" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d47e-a045-bc8e-2310" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="51d1-9e18-85df-f32f" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="ccc5-3942-a0ef-66ab" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="fba0-bd3c-bea0-454c" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7ca3-6b65-17fd-4e0c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="efc5-8262-a436-a149" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47ed-c288-0abc-4c88" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b991-1ff8-e39d-c1f5" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="989d-fe72-e553-bcab" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5892-fd2c-0363-d606" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="19a5-9e86-b97f-2678" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="d850-a0d3-36f5-1048" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e9f7-ea11-3c28-a305" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ac-16d8-11de-a799" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0b67-4b05-5d77-1315" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2c93-00ef-439a-6f6a" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="90ee-be65-709f-ce05" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f1-cf40-1954-416d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5a72-3302-678f-207d" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="2123-93ac-b149-74cd" name="New CategoryLink" hidden="false" targetId="c9c6-f769-0ecd-623f" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="11db-6005-0698-5e90" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f3c-668c-3e33-8a8a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e2d2-5305-5286-83d1" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="0844-7d2f-2d36-fa30" name="New CategoryLink" hidden="false" targetId="c9c6-f769-0ecd-623f" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0288-8f06-da40-5c94" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d0-c096-b54e-166d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1a01-114a-fb4f-b7b4" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8984-9c77-2243-e62b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5c7c-ef45-d98a-b626" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="977b-ca55-6f38-6cc4" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54bb-aea8-b09b-34c1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bccc-6c72-f0a4-165f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bcdd-5139-cebe-9d25" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d883-b0b1-94d2-bef3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7888-bc4a-1294-204d" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="490.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="66d8-5046-7a37-f940" name="Minotaur Chieftain" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="0d44-d0c2-ba08-97e9" name="Minotaur Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ddff-0b88-3aae-f0d7" name="Minotaur Chieftain Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="481c-feab-7789-6af7" name="Minotaur Chieftain Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="09bb-9163-6530-b2ef" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="66d8-5046-7a37-f940" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0f7-0c47-0c68-e01c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e602-7800-2a54-bd8e" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="a32b-9177-9fca-a973" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="06fd-5516-9d47-de60" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="d696-6ccb-fa03-9b84" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1e9e-6a61-56cd-7850" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2226-19fb-0581-8baf" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ad7a-8822-b4c5-bcee" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2396-9ab7-1948-3d2e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ea90-aa8f-6f49-345c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a0c4-d017-8074-4b5b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d06b-b143-fd03-1be6" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="bd37-b30f-2be4-f734" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="2203-7bd2-0f65-1a61" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+                <entryLink id="b88d-75d8-0306-2140" name="Banner Enchantments" hidden="true" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="66d8-5046-7a37-f940" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="570c-27f9-fd1d-46c7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="a8e0-353a-cd15-ef5d" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ad7a-8822-b4c5-bcee" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2203-7bd2-0f65-1a61" type="equalTo"/>
+                            <condition field="selections" scope="ad7a-8822-b4c5-bcee" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d06b-b143-fd03-1be6" type="equalTo"/>
+                            <condition field="selections" scope="ad7a-8822-b4c5-bcee" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd37-b30f-2be4-f734" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cc2f-7f46-2e2d-88b2" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="66d8-5046-7a37-f940" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="570c-27f9-fd1d-46c7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="420e-9108-302c-cc32" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5bd7-ffe7-3890-d67b" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="570c-27f9-fd1d-46c7" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="66d8-5046-7a37-f940" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2f-7f46-2e2d-88b2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db03-5a1e-79e4-d6ef" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d027-5c38-d9de-db16" name="Battle Standard Bearer" hidden="false" collective="false" targetId="5448-4e9d-1ea4-c32e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5604-931c-b7f6-3b37" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="4410-b7b7-1678-ce0d" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fdc-147f-3418-8814" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e89c-59d4-0028-bfd6" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c0f7-0c47-0c68-e01c" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28f9-6520-5821-6fdf" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="75c3-d0dc-90a5-0840" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="34c9-de63-406e-57f3" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6853-65e8-3042-9d97" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b078-cca8-6386-0d58" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c34c-bd1e-0e5f-e300" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9b50-9353-3c6c-94df" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fa34-6571-dde5-4a34" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa8b-173b-fadd-afde" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="562c-d83e-6e54-558a" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d6d5-d10e-c970-d7cf" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="311e-a6a1-a93f-f3e3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="18cb-4872-3bff-6548" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6f27-e9c3-5327-fdc4" name="Greater Totem Bearer" hidden="false" collective="false" targetId="2660-c88a-bf3d-3113" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="85"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae3-2f29-763a-df38" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="220.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3bb-e96a-35d7-cd1c" name="Centaur Chieftain" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="40fd-9fe3-f12e-d382" name="Centaur Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b6ea-7ca2-da89-bc26" name="Centaur Chieftain Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ccb1-eb29-51f9-510a" name="Centaur Chieftain Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d798-7414-c645-a880" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="d3bb-e96a-35d7-cd1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d73b-1fe6-ed25-b1a5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7d0e-f756-f9ba-f229" name="Looted Booze" hidden="false" targetId="14b0-c711-dc75-dfa0" type="rule"/>
+        <infoLink id="b876-cede-5ec1-61b4" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="7238-939d-d2f2-4421" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2a01-1609-f03b-d40b" name="Drunkard" hidden="false" targetId="e42c-9308-8a5a-a28c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7ba0-8f5a-9956-b138" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="48ef-2db6-d538-6907" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1435-ce7d-3448-2d0d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="77b0-9f14-1695-e83a" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6208-edd1-8a68-6535" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="42be-40d2-25f6-b799" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e22b-ea8c-6604-32b3" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e700-7464-2564-51db" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="93b7-d09a-5675-a4cd" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="b50c-7797-fca3-1a33" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="7c75-ca1d-d850-c75a" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+                <entryLink id="4cc1-b32f-3844-00a0" name="Banner Enchantments" hidden="true" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="d3bb-e96a-35d7-cd1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8212-c3af-2d86-b9a0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="a8e0-353a-cd15-ef5d" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6208-edd1-8a68-6535" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b50c-7797-fca3-1a33" type="equalTo"/>
+                            <condition field="selections" scope="6208-edd1-8a68-6535" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="93b7-d09a-5675-a4cd" type="equalTo"/>
+                            <condition field="selections" scope="6208-edd1-8a68-6535" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c75-ca1d-d850-c75a" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fd1c-de42-a8c8-c4ac" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="d3bb-e96a-35d7-cd1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8212-c3af-2d86-b9a0" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="635a-12ef-7ebd-c811" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="be78-953e-1649-3a5b" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8212-c3af-2d86-b9a0" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="d3bb-e96a-35d7-cd1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1c-de42-a8c8-c4ac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3634-a60e-76be-f670" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c0d0-3c48-5229-3c30" name="Battle Standard Bearer" hidden="false" collective="false" targetId="5448-4e9d-1ea4-c32e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dc06-129c-cca0-785b" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="a776-0f54-1e86-10da" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f5d-7d86-8eac-504c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8ece-25ae-15ed-7cfd" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d73b-1fe6-ed25-b1a5" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e244-84d6-2a64-cd0c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ec32-a03f-1610-2de4" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a429-4377-86df-542d" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bae7-95ac-cb5b-a31f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="766b-d9f8-d837-97d2" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3d9-112c-047a-f1f2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8094-054d-be26-7e56" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8948-e869-eec8-42b5" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e21-46c3-ea13-f6f9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3689-183c-7002-d0ce" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f9e1-a3e3-b832-9abf" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe98-853e-d575-b1e3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b4ed-c91f-60af-f9cb" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f3c0-3241-5ac8-7818" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f1-db44-bde8-db43" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7c3e-6bbd-d57c-db81" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4ea4-9f28-feee-5a90" name="Greater Totem Bearer" hidden="false" collective="false" targetId="2660-c88a-bf3d-3113" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="85"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe4b-405d-f6ca-51b6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="220.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ef7-5541-f283-b1d8" name="Centaur Chieftain (Ambush)" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="6588-1184-8948-e712" name="Centaur Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e408-f70a-a2c8-bbc5" name="Centaur Chieftain Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">6+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c50b-cf8e-3610-8373" name="Centaur Chieftain Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ee1d-7cf3-45ed-136f" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3ef7-5541-f283-b1d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a605-13db-57ef-26df" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a549-6567-7fb8-78b1" name="Looted Booze" hidden="false" targetId="14b0-c711-dc75-dfa0" type="rule"/>
+        <infoLink id="1ed8-1041-333c-a806" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="83e2-77c6-fa9c-46ce" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f7be-c167-81e7-ba71" name="Drunkard" hidden="false" targetId="e42c-9308-8a5a-a28c" type="rule"/>
+        <infoLink id="875c-e591-2b2a-f34d" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="784b-1958-e200-008a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="9711-a92b-ba10-db01" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f22f-e0ab-e1fb-34f0" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99d3-3bcf-e4ca-fd6a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="901d-13d7-e157-5c55" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d7d-4196-ed91-1fcf" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2901-94f5-ff6a-5836" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="dde4-1cc3-d7d5-a804" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dee6-c544-4e24-f7a6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ab13-58ef-f415-540a" name="Armour Enchantments" hidden="false" collective="false" targetId="95f4-76ef-2215-3286" type="selectionEntryGroup"/>
+                <entryLink id="6e06-bf6c-1119-6e10" name="Artefacts" hidden="false" collective="false" targetId="284b-f16d-b477-e504" type="selectionEntryGroup"/>
+                <entryLink id="f01f-254c-2a1d-2d06" name="Weapon Enchantments" hidden="false" collective="false" targetId="626c-f21d-e2c9-1743" type="selectionEntryGroup"/>
+                <entryLink id="c4b9-1203-56bc-f8c5" name="Banner Enchantments" hidden="true" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="3ef7-5541-f283-b1d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc32-a5eb-4da6-88b0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="a8e0-353a-cd15-ef5d" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="0d7d-4196-ed91-1fcf" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e06-bf6c-1119-6e10" type="equalTo"/>
+                            <condition field="selections" scope="0d7d-4196-ed91-1fcf" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f01f-254c-2a1d-2d06" type="equalTo"/>
+                            <condition field="selections" scope="0d7d-4196-ed91-1fcf" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab13-58ef-f415-540a" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e891-6a01-8b36-e5d4" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3ef7-5541-f283-b1d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc32-a5eb-4da6-88b0" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2fc-694d-665d-01b3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fc73-41e3-6c8e-b5e6" name="Army General" hidden="false" collective="false" targetId="ece2-ca4c-4a02-ee6c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fc32-a5eb-4da6-88b0" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3ef7-5541-f283-b1d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e891-6a01-8b36-e5d4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f3e-d8b8-2e7d-8132" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9621-c80c-3f1c-a355" name="Battle Standard Bearer" hidden="false" collective="false" targetId="5448-4e9d-1ea4-c32e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8daf-4d08-7d6f-e3e3" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="988d-9dac-caea-ea2e" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b41e-ec96-ef2b-fcd8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d3a6-d5e0-dd44-19d0" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a605-13db-57ef-26df" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="261b-d505-9fc7-5974" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7e01-c71b-f6d1-bf2e" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d8cf-6c6e-1fd8-26c9" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="505f-17d2-d482-bac6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c3a9-434e-2ae9-f9a1" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d692-382c-7d22-325c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="022b-dce2-75b4-5e04" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b10b-4506-5311-8438" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae3-4b73-6a8d-4ec8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0ba8-1563-3769-3420" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="10fe-6fb8-f696-437d" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5d9-8cdc-c5f2-ad72" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="94af-1306-f25c-1e5c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a0b5-efa7-7ba9-1310" name="Beast Axe" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae68-9d73-2919-119d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="977a-ebe0-4a36-f94d" name="Beast Axe" hidden="false" targetId="ad92-996b-4a1a-b6a9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e447-0630-4fcf-2b13" name="Greater Totem Bearer" hidden="false" collective="false" targetId="2660-c88a-bf3d-3113" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="85"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c1e-78f5-2736-499d" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="230.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9729-891e-1cda-eed8" name="Wildhorn Herd" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="fd82-6943-eb6d-61f8" name="Wildhorn Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="020b-07ec-1c62-e20d" name="Wildhorn Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="515a-01eb-3817-7765" name="Wildhorn Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2566-7780-6fb0-297d" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4128-83b3-8db5-3fd2" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="3541-1eb0-08c6-0630" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="2732-96a3-d394-8569" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="07f1-0a10-d0ae-dbaf" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="aad6-8bc8-b1ac-0776" name="Wildhorn" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf85-19cd-c56b-c5a2" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af9a-6f64-4dc3-707f" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d825-4743-6a72-0fec" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="9729-891e-1cda-eed8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e287-9259-1290-dd02" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4cfa-822f-da23-6b41" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0872-a715-8e25-9802" name="Equipment" hidden="false" collective="false" defaultSelectionEntryId="7c29-1c09-185a-712d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87ed-2fd8-f830-973c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efa7-35af-81a7-1178" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1b18-89f2-8638-6e2d" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="9729-891e-1cda-eed8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aad6-8bc8-b1ac-0776" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb74-ee07-6f0e-d49d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="fae1-65da-95e7-3de0" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7c29-1c09-185a-712d" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22d8-3a40-296c-9ca7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e69f-99f8-28d4-6b48" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="53f3-504f-1a96-75a7" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="9729-891e-1cda-eed8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aad6-8bc8-b1ac-0776" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69b5-b9c7-192e-ba9d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7067-bdfb-0df2-d6de" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8cfc-a47e-ec4a-d973" name="Paired and Throwing Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="9729-891e-1cda-eed8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aad6-8bc8-b1ac-0776" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90bf-78ee-fe09-9ca0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f02d-631f-aa90-86b2" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+                <infoLink id="8e4e-8047-ca4c-fdd6" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="09ca-6e4e-8804-eb2c" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="1659-eccf-29f2-8c4f" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="9729-891e-1cda-eed8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ee5-192a-149e-ca55" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e997-3585-abdd-4579" name="Wildhorn Herd (Ambush)" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3358-091d-73fb-919f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9722-bf4c-d754-af5a" name="Wildhorn Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="57a8-9969-d47c-01d0" name="Wildhorn Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="458f-7895-670e-2005" name="Wildhorn Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1c98-a3ae-be6a-39ae" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="627e-c3bd-b776-070f" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="4b48-87a0-afe2-3c46" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="f438-a9b0-7907-7df5" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="19a2-6be1-56d6-2ff2" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="90a5-bc96-6deb-c969" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="4816-2934-a963-0898" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fed7-344d-0670-b5a5" name="Wildhorn" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee01-2b0a-4106-f4dc" type="min"/>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec1d-fc0c-f0c0-c5da" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="560d-cf72-0ae5-5fa8" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="e997-3585-abdd-4579" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fed7-344d-0670-b5a5" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e112-1c94-b118-a708" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7c05-8c80-1daa-9873" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cce2-d222-2d39-666e" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e997-3585-abdd-4579" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2503-b300-1691-9e35" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4e8f-fb79-ff5c-2f6c" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8000-fbab-530c-8668" name="Equipment" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5671-2d84-fd91-6ba1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3f65-9793-0dd6-6ee9" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="e997-3585-abdd-4579" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fed7-344d-0670-b5a5" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c12c-6e5f-eee6-0295" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1c79-20b3-7c68-3dc9" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="edb1-ee76-9515-d26e" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d355-e8e1-0e35-96c3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5857-c590-59d1-fc5c" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2785-3528-ad1f-71f0" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="ec3c-6bf6-f5f6-68b0" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e997-3585-abdd-4579" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c87-353d-66a2-aee8" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7f6c-a0fa-f008-bba9" name="Mongrel Herd" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="029a-a330-139e-3058" name="Mongrel Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6c73-049e-63cc-b876" name="Mongrel Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a571-cbbc-bf87-8a8c" name="Mongrel Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4944-5faa-d1d6-796a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="c7df-2fef-a663-3ad3" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="c965-6d0e-5615-7f14" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="c023-24be-498a-012e" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="073f-034f-7d2d-9d26" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bd2c-e470-a02f-8823" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4091-2a4f-5390-8d63" name="Spears" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f88c-a03e-dabb-9ba7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="dc52-6d33-d2f9-3b08" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0093-c439-15f6-b9bc" name="Mongrel" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a81-28f8-abf6-1068" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1746-55bd-0f14-7bf6" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4ae1-b696-c4b4-9057" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="7f6c-a0fa-f008-bba9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77af-2d3f-c47d-ece4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9a0b-0050-08fe-4cba" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="b3bf-fb21-a57b-accc" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ad6c-4f2f-c88d-84c0" name="Mongrel Herd (Ambush)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e0a-585b-1c0f-8489" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a25b-84fd-a17c-d0d8" name="Mongrel Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bb70-5501-886f-51d4" name="Mongrel Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="402d-5ec3-dde2-8a3e" name="Mongrel Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e84b-bcdf-29d8-0e20" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="14f4-8741-8775-3884" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="dbc0-fe62-1e37-386e" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="d5ca-9b32-67a9-088b" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="1c8c-2853-bbe8-5904" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bae3-8973-c143-77eb" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fe8c-7cd9-539d-8608" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="e938-67b8-d8d1-07f2" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6070-0433-a7a0-1eb5" name="Spears" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a32-6dcc-6a60-a361" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fa93-9b4b-65ab-2a2f" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da70-8f1d-58a3-63ae" name="Mongrel" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f7-29d4-c895-0d19" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1266-be03-13aa-6516" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ca18-2e69-5a37-9c7f" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ad6c-4f2f-c88d-84c0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="116d-6072-81cc-6cdc" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="862f-c712-8ca8-ca90" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+              <categoryLinks>
+                <categoryLink id="3bac-3338-646e-4abe" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                <categoryLink id="5191-00cf-48ff-f116" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="331c-0561-6793-da50" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7100-3483-7a08-f839" name="Mongrel Raiders" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbd2-e058-a3ee-0157" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4e8b-a19e-d67e-86ac" name="Mongrel Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a241-01d0-77de-c3b9" name="Mongrel Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a716-7674-2ec3-1053" name="Mongrel Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7657-eb4e-6e08-6192" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="1ef3-bfc2-b488-e82d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="67ed-1232-e35f-3e8f" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="5016-6d18-a37c-f137" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="48cf-8158-6aeb-5b27" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f229-ba70-55ae-2688" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7ca1-97ff-a8fe-6da1" name="Mongrel Raider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d316-ed85-7829-8837" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b6-4aae-7d35-51ee" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="7.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="05fd-b43b-c0ab-76e4" name="Command Group" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="92d8-236e-46a6-c631" name="Champion" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c7b-c7d3-5ca2-0a64" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="c03f-d2ee-9ed2-3719" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="77e1-a95a-99d0-2e12" name="Musician" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7ce-b923-4322-add0" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0d04-e394-f6bb-dbe9" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5edf-c725-eb0d-5e85" name="Mongrel Raiders (Scout &amp; Ambush)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="847c-34b4-04af-65f8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="1cfc-9984-4b63-6200" name="Mongrel Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="276d-93c1-1a2e-418f" name="Mongrel Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cf12-7e59-c305-c49a" name="Mongrel Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c84f-bf66-7891-1312" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="9b22-f99f-3f50-0321" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="c631-a2d9-7d17-7208" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="beb5-b126-8298-2e0d" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5300-adf4-16a7-c564" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ab4d-8526-76cc-321c" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+        <infoLink id="3c4d-4fc7-08e2-5da5" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="31d1-4817-c33e-ed3e" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="678b-2fd6-6ed2-1968" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="207c-dd67-d602-83cc" name="Mongrel Raider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb00-fc1a-0a16-8374" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5dc-f009-430f-9bcd" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4fad-412d-ae93-dfa1" name="Command Group" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="83c2-a5ab-2989-75a6" name="Champion" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e973-6f12-9f5a-56de" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="7c69-13b8-4165-519f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                <categoryLink id="735a-455d-b8b1-670b" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="065c-4fbe-dd56-8ce5" name="Musician" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d60-05af-c2ff-2c47" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="be78-e3cd-f42b-ee5c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                <categoryLink id="06af-d864-7e3a-c15d" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7649-97ad-61a1-b00b" name="Feral Hounds" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5ece-79a7-61ee-0b0b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4583-18cf-e900-8564" name="Feral Hounds Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f554-c172-51c2-8ac8" name="Feral Hounds Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="067d-0255-41b1-bc7b" name="Feral Hounds Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="daf0-8566-728e-edac" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1564-2600-6e5e-a0af" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+        <infoLink id="30f8-0c33-bdfd-bb42" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="894d-3f93-97a1-6a3d" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="aaf3-642e-9607-3f8e" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="7c20-96a9-6324-5a1c" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b00f-1b53-88f2-b373" name="Feral Hound" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bf5-8abd-2fc1-a7c4" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3e5-2692-5333-943c" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="ca55-6d00-0a86-02ce" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="581f-0818-b9af-84a0" name="Feral Hounds (Core)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b3c-b5c8-85cf-9f38" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="442f-94be-1b8f-f6b0" name="Feral Hounds Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f416-2072-b159-af08" name="Feral Hounds Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c7f6-c7a2-8d4b-872d" name="Feral Hounds Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="78e6-89fd-0a73-9a6d" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ac60-6dc3-88bd-00da" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+        <infoLink id="a3aa-9cd5-6fb7-e269" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="1149-6171-73df-1384" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bfde-269b-e397-a7a5" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="e2eb-b690-ee2c-e33b" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9a5a-5677-4326-95eb" name="Feral Hound" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db12-0715-60da-86ec" type="max"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ce5-3349-f7b0-6a11" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="69c5-7f5b-79ca-6bd6" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3998-d17d-fb31-a86a" name="Longhorn​ Herd" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="b31c-bdb6-7460-2a11" name="Longhorn​ Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="304a-585c-d6b2-8225" name="Longhorn​ Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b032-6026-6eec-08e4" name="Longhorn​ Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="93b1-6e22-fa58-e92d" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3998-d17d-fb31-a86a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e25-66c9-76b6-651b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="45ed-abdf-0de0-53fa" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="42c5-e099-c079-1576" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="802f-d3a7-2215-3601" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="9d5f-73fa-e3b9-32e5" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="78bf-3aa6-2bda-e81a" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="6a18-95d8-7456-00f2" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Beast Lord, Beast Chieftain)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b584-d875-a03b-55ae" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2e25-66c9-76b6-651b" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46a2-a8df-026b-4c71" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="abe2-4e5e-089a-c8cd" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8ec7-9aca-e35b-77bf" name="Longhorn​" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e82-f911-f9d3-2166" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af70-f3c9-2dd9-39f2" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="23.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ed87-1e11-5a06-8d7e" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3998-d17d-fb31-a86a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a795-485b-92e6-0045" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="1544-a23b-2c4d-80d7" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="b29a-b4c5-7edc-0f31" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="2602-d999-5517-405b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="1e8e-62dd-6ff5-4a70" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3998-d17d-fb31-a86a" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a73b-520f-fdc8-0e0e" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2270-bb3a-ad96-ebda" name="Longhorn​ Herd (Ambush)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f043-a51e-6425-5ff5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0f0c-a27a-963f-1c8e" name="Longhorn​ Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5a6b-98dc-4be6-f9f0" name="Longhorn​ Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7fee-052a-b37c-f354" name="Longhorn​ Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4130-b924-8f5b-7ead" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2270-bb3a-ad96-ebda" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c2cb-888d-652b-2a65" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c3e2-3b96-3425-fac7" name="Pack Tactics" hidden="false" targetId="85dc-2537-fba7-3b8e" type="rule"/>
+        <infoLink id="0410-37f7-4735-e953" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="a884-e3aa-df9e-532c" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="a4fd-d136-72af-6546" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5bb5-145b-3a79-8d34" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="ea4d-17f4-58a9-6442" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Beast Lord, Beast Chieftain)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="de48-9d33-b8ea-fb60" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="70f3-3db0-35ba-5740" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="4b26-b5df-c6b4-eaae" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c2cb-888d-652b-2a65" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4354-9ea5-a8d3-3ba7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8753-bb85-4e79-ab71" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8787-7bba-6915-6ea8" name="Longhorn​" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0991-616a-867d-15b7" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b92-b5da-2759-7028" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="24.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fd79-09c3-93c1-545d" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2270-bb3a-ad96-ebda" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d403-b75a-3560-6078" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="21b2-7f2c-f10d-39d4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="c8e6-3503-0d0d-a5b9" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+              <categoryLinks>
+                <categoryLink id="d4e7-45f2-3c1b-382e" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="66c4-6734-fc5f-ea9b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="0d80-7ea3-6272-40b5" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2270-bb3a-ad96-ebda" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4258-73f5-cf0b-e48f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4cc7-7d31-f318-a2f2" name="Minotaurs" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a60-5dee-6f1b-1668" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="61fa-4da5-2d05-008e" name="Minotaurs Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="14f8-ac76-0cdc-6fee" name="Minotaurs Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d0df-3ab4-f640-3273" name="Minotaurs Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c3f8-b277-0360-5b19" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="b444-22ca-129f-09fa" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="4102-2ba1-f997-1d49" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="d525-9fa9-f8ea-db86" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a3ad-58e7-88b0-c5b7" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3f54-43a2-e4b5-5c1a" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="64c8-e5f2-5bc5-e22f" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="125b-5071-e5a4-b65d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="14ae-e4e1-d6c6-7b1d" name="Minotaur" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a29-5584-9307-5a29" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="96b4-f4c2-954b-5350" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="78.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b3b3-4e09-b3bf-59c0" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4cc7-7d31-f318-a2f2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f3dd-e3e5-9f77-e3ff" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="87d9-00bd-3eb3-cc5f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="cfee-c0e8-8fa1-bb60" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+              <categoryLinks>
+                <categoryLink id="7f2a-91c6-4c84-0fbd" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e563-e60b-9e43-2bb3" name="Equipment" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc81-d9ff-feb5-e30e" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="7597-51b1-cb3d-0427" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="38d6-1c70-3e83-d6d6" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="4cc7-7d31-f318-a2f2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="14ae-e4e1-d6c6-7b1d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fca-e1ad-ee35-518c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9ce4-7138-11da-5693" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="5f74-b8be-aa9c-53d0" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a92b-bfda-858b-1706" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="6">
+                  <repeats>
+                    <repeat field="selections" scope="4cc7-7d31-f318-a2f2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="14ae-e4e1-d6c6-7b1d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dae2-abe5-1267-3589" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e9a1-de09-26d8-8b43" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="74a5-d45f-6458-1b42" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d07a-2bdc-6ebd-0cd9" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+                  <repeats>
+                    <repeat field="selections" scope="4cc7-7d31-f318-a2f2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="14ae-e4e1-d6c6-7b1d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="511e-91df-e9f6-871d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="49e1-8938-0864-0bde" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="cc00-e948-745a-a18d" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="80e0-31b2-06b0-4d7f" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="7cc8-bab0-40cc-2f74" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4cc7-7d31-f318-a2f2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5723-6f09-98fc-b3d6" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="f34b-adc1-41d3-75cf" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d6a-fc22-8070-15cc" name="Centaurs" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e185-06ab-3d99-b96b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bc12-af61-2a9c-7ec8" name="Centaurs Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6ef2-de2b-7988-1760" name="Centaurs Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7d79-9b01-25dc-553a" name="Centaurs Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d77b-bcb7-1af3-fdc3" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9787-2796-3893-da63" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2a34-efd3-63f7-2f8a" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="5946-26ef-33a9-f5cb" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="1b6c-835a-ed1e-2801" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="7104-eac2-cdfb-af36" name="Drunkard" hidden="false" targetId="e42c-9308-8a5a-a28c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b3b8-54a1-d421-ab8d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0b54-bfeb-2292-63fe" name="Centaur" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7617-10b6-9bd3-286a" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a428-a035-02ef-f4ec" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="34e9-96b1-d95d-e69d" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="4d6a-fc22-8070-15cc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b54-bfeb-2292-63fe" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b5a-21bb-b84e-dc03" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2f66-34a2-8cac-1c16" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="5d5c-1e6b-662f-f0b7" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1821-ec88-49dd-260c" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4d6a-fc22-8070-15cc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="029c-4dc2-0163-2b03" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="709d-262f-ff6e-75d2" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="0264-2fd7-bacd-1c15" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+              <categoryLinks>
+                <categoryLink id="541c-e8ed-f3e3-18b1" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="290f-9135-429f-ca2c" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bcd-7e65-afe5-78ed" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="b395-a643-5a58-b2a1" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="e838-0152-5dcd-168c" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="4d6a-fc22-8070-15cc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b54-bfeb-2292-63fe" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed4e-1493-db03-4b6f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d905-e3e2-6e87-7003" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="c7ff-ce09-0228-5331" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0081-07e9-25f0-8413" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="4d6a-fc22-8070-15cc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b54-bfeb-2292-63fe" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f00a-8388-8770-af18" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1398-1f95-7e54-ffcb" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="cab4-e560-a80f-cef7" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0ef2-8c77-3051-2d30" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+                  <repeats>
+                    <repeat field="selections" scope="4d6a-fc22-8070-15cc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b54-bfeb-2292-63fe" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f10-d671-44db-cc43" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b89c-1e16-0a44-3288" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="6ac7-17ab-64c5-ee02" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="130e-0fd0-626d-4fd4" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="561c-447e-b95c-7e14" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4d6a-fc22-8070-15cc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84e7-2929-7737-7ff1" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="bc2e-ab92-e03f-b280" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2775-57a1-d8ac-d735" name="Centaurs (Ambush)" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="808e-62ce-a068-d9ae" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bf38-686e-a580-518f" name="Centaurs Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2bf7-b632-e145-afb1" name="Centaurs Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="69d0-e87f-513f-9786" name="Centaurs Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0ea8-f750-028c-3db5" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4da2-b51d-24c0-87be" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3fda-8dbe-24a6-bed0" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="c2ae-a27a-c6a7-504a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="a923-1070-60ce-028b" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="bec1-2d38-d0f6-745f" name="Drunkard" hidden="false" targetId="e42c-9308-8a5a-a28c" type="rule"/>
+        <infoLink id="99a8-3011-efda-0a2a" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b33f-a950-b39a-0cd4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="891b-1bf8-a233-3e22" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="75e7-57c6-6eaf-0812" name="Centaur" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd72-a698-e69f-3178" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e88b-1b62-571e-0c4f" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="28.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fbe3-9814-f755-891e" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="2775-57a1-d8ac-d735" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75e7-57c6-6eaf-0812" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="697b-5ccb-53fe-118c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7e5e-abe9-7f1a-6fd0" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="26c0-10bd-c578-5918" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fdbc-8eff-2940-981e" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2775-57a1-d8ac-d735" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dcdf-24b8-bcea-41ab" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="831a-84ae-2881-6c13" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="359a-dddc-7078-396e" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
+              <categoryLinks>
+                <categoryLink id="84c3-14f5-8e0c-b953" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3580-c1ef-d9d5-6bb1" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eaf-ca6f-96e8-c937" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="ed91-776e-1180-5bd5" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="cd71-2cc6-d262-44cd" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="2775-57a1-d8ac-d735" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75e7-57c6-6eaf-0812" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db6a-f0b3-8d1c-a811" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7544-394d-b63e-b8a9" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="750d-2162-9c64-b760" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="36fb-516d-41a5-8cb6" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="2775-57a1-d8ac-d735" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75e7-57c6-6eaf-0812" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="759c-752a-fa2b-f7a8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a086-2e50-4bff-5e3b" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="5244-0dcd-aca6-ea31" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6179-b734-520d-fbff" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+                  <repeats>
+                    <repeat field="selections" scope="2775-57a1-d8ac-d735" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75e7-57c6-6eaf-0812" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e4d-a651-bf3d-9f9c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c1d2-21a3-efcc-1fa5" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="667f-87f4-7f33-d146" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4251-2fbf-7010-954a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="f011-a89f-1544-6394" name="Totem Bearer" hidden="false" collective="false" targetId="b529-ac08-b823-4d33" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2775-57a1-d8ac-d735" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a5b-7c2d-2e80-4f6d" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="9c97-6aea-4d5d-b6a0" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d393-968c-f4c6-78ed" name="Raiding Chariot" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae8d-b9f6-dc01-b065" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fe18-241a-ab4d-5366" name="Raiding Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5588-c490-7e22-ac51" name="Raiding Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b68f-d1fa-29c2-494c" name="Wildhorn" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f20d-0d1a-3b89-789c" name="Longhorn" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0e26-1382-512d-c6ba" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="54aa-bacb-1c1f-6849" name="War Hog (2)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="85d5-e114-aff5-fa8c" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="42d7-13a4-49af-09bd" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="f4a6-486c-28c7-c69a" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="685b-5a79-2143-6527" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b857-7112-6db1-b55a" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="d554-f8af-c3df-47f8" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="6b0e-97f5-f818-5306" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="0b2a-7cfc-320b-cb98" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="1410-0917-48a0-1b18" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c2d8-5dd3-c919-92ef" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="26a4-6c6a-3078-c8a8" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a83c-9b05-54f5-02b8" name="Raiding Chariot" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4033-11ee-77e0-1629" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa8a-ccc5-97b8-9494" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a3d-8c72-9b93-7462" name="Raiding Chariot (Core)" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c890-87da-6be1-708b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="90f5-2c8a-b427-eab4" name="Raiding Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="67e3-d42d-0b08-9230" name="Raiding Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7a66-ecbb-9480-67a5" name="Wildhorn" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f999-e636-ea20-a656" name="Longhorn" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1214-526c-8ac4-4db9" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1f0f-22ca-4b43-b319" name="War Hog (2)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e1a2-7169-121a-da21" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="6033-14dd-09bc-61ab" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="787f-7fd5-df86-634d" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="3f25-af15-74f9-6b16" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="894b-d2b1-2dfe-953b" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="19a7-f05f-15c3-4813" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="f05c-84ef-c4dc-fd2f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="ded3-9054-e239-23a7" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="185a-60da-596c-fb86" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7064-d51d-7d02-93cf" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1b90-3c02-9aac-b1a2" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a8f9-90e2-ca58-08c7" name="Raiding Chariot" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a63-b8c0-a3f7-368a" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6732-9c06-3096-8bfe" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f344-a48e-762b-2fbe" name="Razortusk Herd" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f80-24bd-2b1b-2fe2" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a5e8-050c-7f21-08f9" name="Razortusk Herd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="14c4-2db7-fbab-9ae0" name="Razortusk Herd Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="074c-4ee1-32db-bc05" name="Razortusk Herd Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="345f-5f14-7ea2-6b81" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ef17-d8b7-60b6-48c6" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="242b-ddba-56d9-4f89" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e4e4-2d76-2098-1360" name="Razortusk" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d49-1d03-5081-f314" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db77-0824-1821-d5fe" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="62.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="38.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab5b-5716-8b72-8982" name="Razortusk Chariot" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="854c-a3f8-1a56-5e6e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="54ac-3f52-7f59-f3a2" name="Razortusk Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7dac-4129-b473-b961" name="Razortusk Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="15f4-c544-e258-f4c6" name="Wildhorn" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="895c-a1fc-178b-800a" name="Longhorn" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="39af-ed7a-b01a-09ce" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ef70-7d62-5e2c-afd7" name="Razortusk" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="7219-2038-3e75-9887" name="Hunting Horn" hidden="false">
+          <description>All friendly units within 6&quot; of one or more models with Hunting Horn gain +1&quot; to their Charge Range rolls</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="555c-4ccc-f7a0-ebaf" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="9528-1a19-4a67-b608" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="f440-253f-4004-2c2c" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="13b4-a6ca-d7f8-117d" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="90d7-4c65-7ce9-0d1d" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="f2de-431f-797e-04b9" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="774b-6ed0-a42b-e815" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b14a-ca29-0d26-512a" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="2b03-4ccd-7c5c-dcc3" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0fd7-d7a2-0f31-e4d1" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="1e44-8493-007b-0737" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3b29-3fd9-cd73-c788" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="230.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f605-9c88-9e05-b238" name="Briar Beast" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8551-aa73-674f-7cad" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bd1e-0329-26e7-9dea" name="Briar Beast Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3D6</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9850-2338-e947-0990" name="Briar Beast Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6ded-da03-b7de-9a1d" name="Briar Beast Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">D6+1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a561-f4fd-d226-d10a" name="Sleeper" hidden="false">
+          <description>The model follows the rules for Ambush with the following exceptions:
+- At the end of step 2 of the owner’s Movement Phase Sequence (including the owner’s Player Turn 1), the owner may decide for each of their Briar Beasts if they will enter the Battlefield or not (no dice rolls are required).
+- When the model enters the Battlefield, it must be placed completely within any Forest Terrain Feature instead of having its Rear Facing touch the Board Edge. If the model cannot be placed, it cannot enter the Battlefield this turn.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="4873-b1cd-d073-8ce1" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="415e-7c29-a1b8-e67e" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="beba-b803-7125-aa28" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="061f-604e-d0eb-0ed4" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="58c4-4235-4396-d562" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f6-2e26-9418-da5d" name="Gargoyles" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4150-3e17-a02e-31ee" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5e00-457e-ca76-5234" name="Gargoyles Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 5&quot;, Fly 9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 10&quot;, Fly 18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e8b4-ee81-a35c-a1c5" name="Gargoyles Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3002-2065-b8f6-3245" name="Gargoyles Denfensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b42b-24f2-fb4e-7c1b" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6785-fbab-bbee-2a37" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e52b-d0e7-a2d2-967e" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="1a3e-294c-6347-c434" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="eb46-f0a5-745f-7757" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2ba1-6690-58c1-14b0" name="Gargoyle" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ec7-94bc-101d-3f92" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b638-59bd-25d2-e110" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a0c4-7664-0b29-e9f2" name="Scout" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a05-363c-deaa-9c42" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6753-2759-fd0a-13da" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="54a6-0e42-ba32-7f87" name="Cyclops" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f148-429f-ab89-d823" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bddc-b7dc-90d4-254e" name="Cyclops Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="61be-3347-0465-9745" name="Cyclops Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="349e-32a4-a7f8-5b1c" name="Cyclops Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5273-c5aa-a447-d3ee" name="Hurl Attack (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">6-36&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3[7]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">0[4]</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3, Clipped Wings)], Magical Attacks, Divine Attacks. A Cyclops that only Pivots (and moves no further) during its owner’s Movement Phase ignores the to-hit modifier from Moving and Shooting in the next Shooting Phase.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c036-003e-7233-2b32" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2792-095a-91cc-d409" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="ca11-639e-91af-91d4" name="Divine Attacks" hidden="false" targetId="030a-8283-3ebb-93f1" type="rule"/>
+        <infoLink id="2eb7-b191-2afe-9cb8" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="077a-a46b-14a1-b167" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="98d3-a70c-481f-8c80" name="Terrors of the Wild (local)" hidden="false" targetId="c6e5-9f4e-63f5-1cc0" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="355.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d66e-0ed1-134e-8683" name="Gortach​" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a446-15eb-0977-5908" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a398-0654-ce94-bce2" name="Gortach​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f650-97a4-0377-b1dc" name="Gortach​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">6</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="132d-f635-0238-9f3d" name="Gortach​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="3975-1069-1a33-b25c" name="Strength​ ​from​ ​Flesh" hidden="false">
+          <description>Whenever a Gortach inflicts an unsaved Lethal Strike (rolling a natural ‘6’ to wound with a Close Combat Attack with Lethal Strike), the attack gains Multiple Wounds (D3), and the Gortach Recovers 1 Health Point at the end of the Initiative Step. No more than 1 Health Point may be Recovered by each Gortach per phase in this manner.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="377d-ee76-925e-1302" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="35fe-e827-f224-15f9" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="6046-bada-72f5-7068" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="9bf5-fbc2-2d1b-af63" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="38c1-703e-b376-0382" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="53da-1fc2-68cd-2acc" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="87b9-2e00-708a-c0a7" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="832d-b4e2-7c34-ef25" name="Terrors of the Wild (local)" hidden="false" targetId="c6e5-9f4e-63f5-1cc0" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="475.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1cc0-a800-cfb2-22f1" name="Jabberwock​" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc43-c139-a45d-ff27" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f887-3a28-df67-7a90" name="Jabberwock​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 8&quot;, Fly 8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 16&quot;, Fly 16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="147f-3207-72e0-0622" name="Jabberwock​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3457-62fa-e982-e394" name="Jabberwock​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="4b1b-3a08-33e2-d2ab" name="Aura​ ​of​ ​Madness" hidden="false">
+          <description>Enemy units within 6&quot; of one or more models with Aura of Madness suffer -1 Discipline.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="fa7a-3d18-2108-7728" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a32b-507a-9b3e-c4ac" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="21f3-c8f4-056f-3891" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 3, AP 2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="29d4-5528-e1ff-6b39" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="ae7e-d630-ee3b-329d" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f007-1f0b-762e-b0c2" name="Terrors of the Wild (local)" hidden="false" targetId="c6e5-9f4e-63f5-1cc0" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="340.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd42-a48f-d14d-6b8c" name="Beast​ ​Giant​" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c13b-bef5-21ce-2c6d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d834-e148-e60a-7d18" name="Beast​ ​Giant​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e23f-1679-9262-29df" name="Beast​ ​Giant​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8cf1-294d-a9b8-8e0b" name="Beast​ ​Giant​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <conditions>
+                <condition field="selections" scope="fd42-a48f-d14d-6b8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31a3-06fa-ba34-1ebd" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e571-8d15-7dbb-ca86" name="Giant See, Giant Do" hidden="false">
+          <description>The model gains Drunkard and Strider (Forest).
+At the end of a friendly Movement Phase, if the model is in contact with a Forest Terrain Feature it may lose its current Weapon (if applicable) and gain Uprooted Tree.</description>
+        </rule>
+        <rule id="d1aa-a1c2-2454-6553" name="Rage:" hidden="false">
+          <description>For each Health Point the model currently has below 7, it gains +1 Attack Value.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e3fd-75d5-f1b4-f57f" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="88cb-84de-58fc-3d2d" name="Drunkard" hidden="false" targetId="e42c-9308-8a5a-a28c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7b4b-94a8-577f-5511" name="Terrors of the Wild (local)" hidden="false" targetId="c6e5-9f4e-63f5-1cc0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="31a3-06fa-ba34-1ebd" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7735-5bde-092f-2396" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="30b4-81b1-846b-f266" name="Big Brother" hidden="false">
+              <description>The model’s Health Points are set to 8, and its base size is changed to 75×100 mm. The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b553-d2b1-a510-721e" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c089-0138-dcdb-7516" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="84ea-c8c2-dc6e-a510" name="Giant Club" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f10-dcac-ab6a-fb1f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a2f1-2319-f3f7-df75" name="Giant Club" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="221d-8cb7-02f5-8ee9" name="Uprooted​ ​Tree" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17aa-3e39-2aed-417c" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="76f6-d6d2-86df-5b5c" name="Uprooted​ ​Tree" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">5</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">0</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Attacks made with this weapon hit automatically and have their Strength set ​to 5 and their Armour Penetration set​ to 0.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c2e6-66ae-ec55-4345" name="Beer​ ​Barrel​" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02a0-e20e-8c76-0501" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f346-3ba9-f21e-663a" name="Beer​ ​Barrel​" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">8&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1, One Use Only</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Area Attack (3), Reload!, hits automatically.After being used as a Shooting Weapon, the bearer loses Looted Booze.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="e44c-e126-0856-1ffd" name="Looted Booze" hidden="false" targetId="14b0-c711-dc75-dfa0" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="2660-c88a-bf3d-3113" name="Greater Totem Bearer" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="c39c-878c-3f5c-0254" name="Totems" hidden="false" targetId="e76c-2473-67db-bd24" type="rule"/>
+        <infoLink id="7746-dc42-acd4-ab24" name="Greater Totem Bearers" hidden="false" targetId="a133-a959-f4bc-501e" type="rule"/>
+        <infoLink id="4821-bef6-b119-cc84" name="Gnarled Hide Totem" hidden="false" targetId="b260-fd37-11b0-13db" type="rule"/>
+        <infoLink id="4c91-60e2-abcc-3856" name="Black Wing Totem" hidden="false" targetId="fc8f-5639-178a-2773" type="rule"/>
+        <infoLink id="2332-a4e6-3533-e048" name="Blooded Horn Totem" hidden="false" targetId="f717-2aa1-3576-9a7a" type="rule"/>
+        <infoLink id="fe4b-6b6f-0caf-7475" name="Clouded Eye Totem" hidden="false" targetId="d873-6f7c-1cec-16fa" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a5ff-d99a-26c3-d95a" name="Raiding Chariot (Mount)" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="40be-7841-4a19-0547" name="Raiding Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3285-e63b-29b5-aad2" name="Raiding Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7d4b-4f82-3d87-e123" name="Crew Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6465-2853-2f5a-277e" name="War Hog (2)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1bcc-5ab9-7629-72e4" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"/>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"/>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5742-32e1-a44b-7bd8" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="574f-0fb3-0ebc-b550" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="678b-8558-2223-1d2b" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="0bbc-aa64-e52f-3d53" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="e49b-8ff4-ab27-e2d2" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="04b9-685b-2399-e819" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="05b0-6991-c3a0-910f" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="47cf-667f-53b1-e40a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4c58-5935-8043-93cd" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="196f-f4cb-a2f1-df7e" name="Razortusk Chariot (Mount)" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c882-2a9e-75d4-bd58" name="Razortusk Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1bcd-83de-7325-5372" name="Razortusk Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5076-dcfd-8b28-3809" name="Crew Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="96a9-4271-3a30-bfee" name="Razortusk" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d587-9793-e055-99f9" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"/>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"/>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="114f-6395-ddd0-8337" name="Hunting Horn" hidden="false">
+          <description>All friendly units within 6&quot; of one or more models with Hunting Horn gain +1&quot; to their Charge Range rolls.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0ae3-97da-1726-6145" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="e4f4-3d4e-6280-2d9e" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1239-bd52-e8d6-6cd8" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="2027-62d0-1c2d-db10" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="3344-70bf-c1d5-f387" name="Primal Instinct" hidden="false" targetId="6fbe-6b4d-623a-237c" type="rule"/>
+        <infoLink id="ddb6-2dfd-d504-3ab8" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="48ce-5967-de45-e327" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4846-1a1e-c117-330f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="7de1-e5b0-02ae-6082" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str; +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ef0f-67c6-d2eb-44ed" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ece2-ca4c-4a02-ee6c" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f3a6-e55c-9d9a-798d" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1470-31e7-6a6d-5849" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5a2-ea3a-4820-9ba0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b07-4af5-9017-93e8" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e398-08ab-f23b-93b1" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5448-4e9d-1ea4-c32e" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f07-7198-d9e6-e0cb" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ca2-aea0-cfd4-fc12" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4697-b76d-34ce-b62f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d16a-1657-597f-0dec" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b529-ac08-b823-4d33" name="Totem Bearer" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="ea8d-d21a-4260-bf75" name="Totems" hidden="false" targetId="e76c-2473-67db-bd24" type="rule"/>
+        <infoLink id="8c36-8113-bb57-fd4c" name="Totem Bearers" hidden="false" targetId="55e2-504d-caba-d4d8" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="932a-1b43-4d8e-9888" name="Totem" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32c6-054f-dabc-0ab2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d854-7c7f-d921-0f5c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b07a-e191-c7f6-82b5" name="Black Wing Totem" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="818b-b148-6cab-73fb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b0c1-7de6-32ac-c1e9" name="Black Wing Totem" hidden="false" targetId="fc8f-5639-178a-2773" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b1a1-c3e8-184c-07b0" name="Blooded Horn Totem" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c24c-b383-e46c-857f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6e89-c9eb-bc0c-02b6" name="Blooded Horn Totem" hidden="false" targetId="f717-2aa1-3576-9a7a" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1bbc-a377-c79d-e1bd" name="Clouded Eye Totem" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a6ac-f161-864d-e7b0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b466-e09a-3a79-5003" name="Clouded Eye Totem" hidden="false" targetId="d873-6f7c-1cec-16fa" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7709-6289-ce1c-537f" name="Gnarled Hide Totem" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c62-c1a3-d01e-3346" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="fe8a-3d24-8a04-c9b9" name="Gnarled Hide Totem" hidden="false" targetId="b260-fd37-11b0-13db" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="132c-23d5-89a7-9455" name="Totem Bearer" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0110-7e54-9fb2-46b7" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="229e-ff81-f423-3bfe" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6424-5aed-f48d-4c7b" name="Gnarled Hide Totem" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="a441-652d-110e-bcc4" name="Totem Bearers" hidden="false" targetId="55e2-504d-caba-d4d8" type="rule"/>
+            <infoLink id="5bcc-5fe0-cf6a-14c0" name="Totems" hidden="false" targetId="e76c-2473-67db-bd24" type="rule"/>
+            <infoLink id="a892-ff8a-a023-0c4c" name="Gnarled Hide Totem" hidden="false" targetId="b260-fd37-11b0-13db" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d35e-fd69-c816-dff6" name="Blooded Horn Totem" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="b222-e252-18a2-696a" name="Totem Bearers" hidden="false" targetId="55e2-504d-caba-d4d8" type="rule"/>
+            <infoLink id="421e-23d1-f773-a6e1" name="Totems" hidden="false" targetId="e76c-2473-67db-bd24" type="rule"/>
+            <infoLink id="096a-162a-d01e-d8ca" name="Blooded Horn Totem" hidden="false" targetId="f717-2aa1-3576-9a7a" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="01ab-bc76-0790-edf1" name="Clouded Eye Totem" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="10e3-743c-c24c-db21" name="Totem Bearers" hidden="false" targetId="55e2-504d-caba-d4d8" type="rule"/>
+            <infoLink id="4f21-654b-32d6-7f98" name="Totems" hidden="false" targetId="e76c-2473-67db-bd24" type="rule"/>
+            <infoLink id="9315-5e4a-6a22-19ed" name="Clouded Eye Totem" hidden="false" targetId="d873-6f7c-1cec-16fa" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b834-16f3-3618-4fd2" name="Black Wing Totem" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="7acf-4a32-398b-6727" name="Totem Bearers" hidden="false" targetId="55e2-504d-caba-d4d8" type="rule"/>
+            <infoLink id="5782-abfe-284e-02e3" name="Totems" hidden="false" targetId="e76c-2473-67db-bd24" type="rule"/>
+            <infoLink id="1c46-3cff-8e99-3fea" name="Black Wing Totem" hidden="false" targetId="fc8f-5639-178a-2773" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="64c2-b1ab-159f-e6f7" name="Armour Enchantments - BH" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="db54-d156-923f-ea31" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db54-d156-923f-ea31" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c39a-b16f-60bd-41e8" name="Obscuring Fog" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5752-8e1a-8e6d-f912" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7cb5-9422-aea7-b7a8" name="Obscuring Fog" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, enemy units in base contact with the bearer suffer -1 Agility. The bearer’s unit does not benefit from +1 Agility for Charging.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="fa29-ac4b-443a-03d6" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d626-9903-45b1-7083" name="Aaghor’s Affliction" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbb1-4f57-3bd2-984f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a70f-47e6-67c9-3ea6" name="Aaghor’s Affliction" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains Regeneration (4+) and +1 Resilience, but automatically fails all of its Armour Saves.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c7d-882e-9da6-77d4" name="Wildform" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f0d-3d40-40a2-9200" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2519-f391-814d-8793" name="Wildform" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suits of Armour enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of the Melee Phase the bearer may choose to gain one of the following: +1 Strength, +1 Armour Penetration, -1 Resilience or  -1 Strength, -1 Armour Penetration, +1 Resilience. Effects last until the end of the Melee Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dad8-75b8-5e28-e040" name="Trickster’s Cunning" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4fc1-f146-e52e-160e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="91b5-e986-bb45-216c" name="Trickster’s Cunning" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Successful to-wound rolls against the wearer must be rerolled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3682-d608-266e-39ca" name="Weapon Enchantments - BH" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb41-deea-2150-e647" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="31c9-def6-321c-21b8" name="Hawthorn Curse" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d828-70d9-ab17-27ac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b28f-202a-a262-5a78" name="Hawthorn Curse" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models without Ambush only. Hand Weapon enchantment. Attacks made with this weapon gain Magical Attacks and Devastating Charge (+2 Str, +2 AP). The weapon can be used as a Shooting Weapon (3+) and the following profile: Range 18”, Shots 1, Str 3[6], AP 10, Penetrating, Reload!, [Multiple Wounds (D3)]. This Shooting Attack never suffers negative to-hit modifiers.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b37f-36bf-c404-4bbd" name="Ancestral Carvings" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fe4-ffe0-f0ea-b3fb" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88f9-6f41-2d64-aa4a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="514c-36de-1fcf-5472" name="Ancestral Carvings" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain +2 Strength, +2 Armour Penetration, and Magical Attacks. The wielder gains +2 Attack Value and Distracting while using this weapon.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="41aa-cdb3-c1bd-dd6e" name="Twin Hungers" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a7fd-4495-63d8-6df2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8a26-3d8b-465c-d5a3" name="Twin Hungers" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Paired Weapons enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Lethal Strike and Magical Attacks. Whenever the wielder rolls a natural ‘6’ to wound with a Close Combat Attack, and this attack successfully causes an unsaved wound, the bearer Recovers 1 Health Point at the end of the Initiative Step. No more than 1 Health Point may be recovered per Phase in this manner.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="98ba-c207-b059-9765" name="Fatal Folly" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aca1-8ef4-0e72-83e7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5824-9f36-4849-ea75" name="Fatal Folly" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Beast Axe enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Magical Attacks. For each Close Combat Attack against the wielder that rolls a natural to-hit roll of ‘1’, the wielder must perform a Close Combat Attack at the same Initiative Step (this overrides the normal restriction that Beast Axe attacks always strike at Initiative Step 0). This must be allocated towards the model (or Health Pool) that rolled the ‘1’ to hit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="be49-ceb2-de22-7187" name="Artefacts - BH" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="294b-1c5d-4b0b-d60b" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="59ea-e441-c0f0-1d62" name="Eye of Dominance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="138f-b3d8-7eb3-ada3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dd90-29fd-ec14-608b" name="Obscuring Fog" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Close Combat Attacks from Beast, Cavalry and Construct models will always hit the bearer only on a roll of 6+. If the attacking model is a multipart model, only model parts with Harnessed are affected.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d275-45b0-c716-80a2" name="Crown of Horns" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce91-72e3-0b9f-4201" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ef22-5fc2-5604-d7bc" name="Crown of Horns" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer, all models in its unit, and all units within range of its Commanding Presence (if applicable) automatically pass Discipline Tests taken due to Primal Instinct.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f740-f864-9de2-2e42" name="Seed of the Dark Forest" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d8e-24bf-a68b-cee8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e2d7-6e34-9169-498f" name="Seed of the Dark Forest" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. Right before the battle (during step 7 of the Deployment Phase Sequence), the bearer must place a single Forest Terrain Feature (that must be no larger than 10&quot; in length and 6&quot; in width) on the Battlefield, not in contact with any other Terrain Feature, more than 1&quot; away from all enemy units, and with its centre within 12&quot; of the bearer. All friendly models inside the Dark Forest gain a +1 modifier to their casting rolls for Augment spells and Hex spells, and add (+1/+1) to the Power Level of  Totem Bound Spells they cast.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a618-6d67-6aff-6013" name="Pillager Icon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="50b4-e8c6-a52f-7323" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c7d5-bab8-3710-e96c" name="Pillager Icon" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">All friendly units within 12&quot; of the bearer comprised entirely of Razortusks or single model Chariots, excluding Characters, gain Vanguard.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0e54-40cf-17e3-d0d6" name="Dark Rain" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99e8-1057-2ec5-678c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b113-095a-34aa-4834" name="Dark Rain" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. This item is automatically activated at the start of the first Game Turn (if the bearer is not on the Battlefield at this time, the item cannot be used). Its effects last until the end of this Game Turn. If the owning player has the second Player Turn, all Shooting Attacks suffer -2 to hit during the opponent&apos;s Shooting Phase. If the owning player has the first Player Turn, instead all Shooting Attacks suffer -1 to hit during the opponent&apos;s Shooting Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bf93-a886-2b55-f101" name="Inscribing Burin" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eef2-06ea-2f28-0bab" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="22e1-f454-0cd3-7e03" name="Inscribing Burin" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While the bearer has more than half of its base inside a Forest Terrain Feature, all friendly units with more than half of their Footprint inside any Forest Terrain Feature on the Battlefield gain Magic Resistance (2).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8bb6-ae84-7397-2b1c" name="Banner Enchantments - BH" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="3481-81a1-d4a3-fc41" name="Banner of the Wild Herd" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="54f3-c14b-425a-3c6b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2994-9637-ef33-9893" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="31fb-3a77-7120-9c07" name="Banner of the Wild Herd" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. A single Banner of the Wild Herd per unit may be activated at the start of each Round of Combat. For the duration of this Round of Combat, all Wildhorns and Mongrels in the bearer’s unit gain +1 Strength and +1 Armour Penetration.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="95f4-76ef-2215-3286" name="Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="3f3a-4e1f-5dea-cbb9" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f3a-4e1f-5dea-cbb9" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="0891-0022-3b03-f098" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+        <entryLink id="295f-4a3b-fc8c-8845" name="Armour Enchantments - BH" hidden="false" collective="false" targetId="64c2-b1ab-159f-e6f7" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="284b-f16d-b477-e504" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e0e1-a7b1-61b6-71f8" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="5675-dc12-229d-a83b" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+        <entryLink id="c664-7e87-2d6f-a6ef" name="Artefacts - BH" hidden="false" collective="false" targetId="be49-ceb2-de22-7187" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="77fe-fe82-fc43-7c81" name="Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8e0-353a-cd15-ef5d" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="5814-7b84-65d7-c26f" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+        <entryLink id="b9e8-f0bd-2f0d-6a29" name="Banner Enchantments - BH" hidden="false" collective="false" targetId="8bb6-ae84-7397-2b1c" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="626c-f21d-e2c9-1743" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2105-e186-cc57-b8b3" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="8312-a9ed-56de-6a1b" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+        <entryLink id="8821-4a5d-a309-6de5" name="Weapon Enchantments - BH" hidden="false" collective="false" targetId="3682-d608-266e-39ca" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="85dc-2537-fba7-3b8e" name="Pack Tactics" hidden="false">
+      <description>Units fully composed of models with Pack Tactics gain Swiftstride for the Charge Range roll when charging the Flank or Rear Facing of an enemy unit. This does not apply to Pursuit (and Overrun) Moves.</description>
+    </rule>
+    <rule id="e42c-9308-8a5a-a28c" name="Drunkard" hidden="false">
+      <description>The unit may gain one of two different sets of effects depending on whether it shows up Sober or Drunk on the Battlefield. At step 8 of the Pre-Game Sequence (after Spell Selection) the player must choose whether a Drunkard unit is Sober or Drunk. Drunk Characters cannot join units containing any Sober models and vice versa (models without Drunkard are considered neither Drunk or Sober).
+Sober - The model gains Vanguard and Light Troops. A unit that has been Sober once loses Scoring for the rest of the game. If playing Capture the Flags, Scoring is not lost.
+Drunk - The model gains Fearless and Devastating Charge (+1 Str, +1 AP). Drunk units cannot Ambush.
+</description>
+    </rule>
+    <rule id="14b0-c711-dc75-dfa0" name="Looted Booze" hidden="false">
+      <description>One use only. May be activated at the start of any Player Turn. All models with Drunkard change from Sober to Drunk.</description>
+    </rule>
+    <rule id="6fbe-6b4d-623a-237c" name="Primal Instinct" hidden="false">
+      <description>At the start of each Round of Combat, each unit with one or more model parts with this Attack Attribute must take a Discipline Test. If the test is passed, all model parts with Primal Instinct in the unit must reroll failed to-hit rolls during this Round of Combat.</description>
+    </rule>
+    <rule id="b260-fd37-11b0-13db" name="Gnarled Hide Totem" hidden="false">
+      <description>The target gains +1 Armour and Distracting.</description>
+    </rule>
+    <rule id="f717-2aa1-3576-9a7a" name="Blooded Horn Totem" hidden="false">
+      <description>The target gains +1 Attack Value, and their Close Combat Attacks gain +2 Armour Penetration.</description>
+    </rule>
+    <rule id="d873-6f7c-1cec-16fa" name="Clouded Eye Totem" hidden="false">
+      <description>A unit with all models affected by the spell gains Hard Target and Magic Resistance (3).</description>
+    </rule>
+    <rule id="fc8f-5639-178a-2773" name="Black Wing Totem" hidden="false">
+      <description>A unit with all models affected by the spell gains +3 Agility and adds D3+1&quot; to its Charge Range.</description>
+    </rule>
+    <rule id="e76c-2473-67db-bd24" name="Totems" hidden="false">
+      <description>Totems are upgrades that certain Beast Herds Characters and Champions may take. Each Totem contains one or more Totem Bound Spells with Power Level (4/8) with Duration: Lasts One Turn.
+
+An Army cannot attempt to cast Totem Bound Spells of the same kind more than twice during the same Magic Phase, regardless of which model attempts to cast it. Only one Totem Bound Spell can affect a unit at a time (the one most recently successfully cast).</description>
+    </rule>
+    <rule id="55e2-504d-caba-d4d8" name="Totem Bearers" hidden="false">
+      <description>Totems borne by Champions contain a single Bound Spell chosen from the list above,which must be noted on the Army List, and have the Type: Caster’s Unit.</description>
+    </rule>
+    <rule id="a133-a959-f4bc-501e" name="Greater Totem Bearers" hidden="false">
+      <description>Greater Totems born by Characters contain all four Bound Spells from the list above and have the Types: Augment and Range 18&quot;.</description>
+    </rule>
+    <rule id="f454-5fcd-8ce3-b17d" name="Hunting Call" hidden="false">
+      <description>If the Army includes a model with Hunting Call, the owner may:
+
+- Choose to roll for Ambush for units with one or more models with Pack Tactics starting from the owner’s Player Turn 1 (but still at the end of step 2 of the Movement Phase Sequence), unless the owner has the first Player Turn.
+
+- Reroll Ambush rolls of 1-2 for units with one or more models with Pack Tactics.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="ad92-996b-4a1a-b6a9" name="Beast Axe" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Always strike at Initiative Step 0 (regardless of the wielder’s Agility). The wielder gains +2 Defensive Skill unless weilding another weapon. This weapon cannot be enchanted with Weapon Enchantments from the the Common Special Equipment section. </characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/beastHerds.cat
+++ b/beastHerds.cat
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f4f2-e414-182d-9513" name="Beast Herds 2.0" revision="16" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f4f2-e414-182d-9513" name="Beast Herds 2.0" revision="17" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="b739-c731-20eb-f075" name="Ambush Predators (local)" hidden="false"/>
-    <categoryEntry id="c6e5-9f4e-63f5-1cc0" name="Terrors of the Wild (local)" hidden="false"/>
+    <categoryEntry id="b739-c731-20eb-f075" name="Ambush Predators" hidden="false"/>
+    <categoryEntry id="c6e5-9f4e-63f5-1cc0" name="Terrors of the Wild" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="a332-0f7d-55f5-7a50" name="Beast Herds (local)" hidden="false">
+    <forceEntry id="a332-0f7d-55f5-7a50" name="Beast Herds" hidden="false">
       <categoryLinks>
         <categoryLink id="ff7a-9ee4-ffc7-7473" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -1253,9 +1253,6 @@
               <infoLinks>
                 <infoLink id="5a72-3302-678f-207d" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="2123-93ac-b149-74cd" name="New CategoryLink" hidden="false" targetId="c9c6-f769-0ecd-623f" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
@@ -1267,9 +1264,6 @@
               <infoLinks>
                 <infoLink id="e2d2-5305-5286-83d1" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="0844-7d2f-2d36-fa30" name="New CategoryLink" hidden="false" targetId="c9c6-f769-0ecd-623f" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
@@ -2498,7 +2492,6 @@
             <entryLink id="862f-c712-8ca8-ca90" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
               <categoryLinks>
                 <categoryLink id="3bac-3338-646e-4abe" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-                <categoryLink id="5191-00cf-48ff-f116" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
@@ -2680,7 +2673,6 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="7c69-13b8-4165-519f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-                <categoryLink id="735a-455d-b8b1-670b" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
               </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
@@ -2692,7 +2684,6 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="be78-e3cd-f42b-ee5c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-                <categoryLink id="06af-d864-7e3a-c15d" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
               </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
@@ -3051,11 +3042,7 @@
             <categoryLink id="21b2-7f2c-f10d-39d4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
           </categoryLinks>
           <entryLinks>
-            <entryLink id="c8e6-3503-0d0d-a5b9" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
-              <categoryLinks>
-                <categoryLink id="d4e7-45f2-3c1b-382e" name="New CategoryLink" hidden="false" targetId="e2e8-19e9-be0d-1742" primary="false"/>
-              </categoryLinks>
-            </entryLink>
+            <entryLink id="c8e6-3503-0d0d-a5b9" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>

--- a/daemonLegions.cat
+++ b/daemonLegions.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a422-c29f-5027-f336" name="Daemon Legions 2.2" revision="22" battleScribeVersion="2.02" authorName="Artur &apos;WarX&apos; Fijalkowski, DarkSky" authorContact="wiki.warx@gmail.com" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a422-c29f-5027-f336" name="Daemon Legions 2.2" revision="23" battleScribeVersion="2.02" authorName="Artur &apos;WarX&apos; Fijalkowski, DarkSky" authorContact="wiki.warx@gmail.com" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="e6e2-5027-c8f6-da13" name="2 Defensive">
       <characteristicTypes>
@@ -51,7 +51,30 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05ff-5a6d-e662-81c0" type="max"/>
       </constraints>
     </categoryEntry>
+    <categoryEntry id="e6bc-b5cf-f6f6-2ac0" name="Aves (local)" hidden="false"/>
   </categoryEntries>
+  <forceEntries>
+    <forceEntry id="6375-f8e7-dd81-4625" name="Daemon Legions (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="3d0e-8c55-cead-30d9" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="a35e-4c01-f278-0f9c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8702-9559-cbe8-00d9" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="89a6-907d-d7fb-1904" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3481-69ea-0de4-4e2b" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="a80b-bd55-f78e-121f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="58c2-2a6b-cc3f-1ad7" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
   <selectionEntries>
     <selectionEntry id="97b3-ca59-67ea-42ab" name="Omen of Savar" hidden="false" collective="false" type="unit">
       <constraints>
@@ -275,7 +298,7 @@
                 <infoLink id="d203-e231-001d-ed88" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
               </infoLinks>
               <categoryLinks>
-                <categoryLink id="c767-addf-0104-b530" name="Aves" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="false"/>
+                <categoryLink id="36a4-7912-103a-f04d" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false"/>
               </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="185.0"/>
@@ -1347,8 +1370,8 @@
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="465b-456c-c806-8c0f" name="Aves" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="false"/>
         <categoryLink id="1ae1-6e6d-6b0a-77b0" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="50b7-06d4-da13-696c" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="41e7-ed5f-20e5-bc83" name="Command Group" hidden="false" collective="false">
@@ -1870,7 +1893,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a5fe-d3b0-7ed8-e30c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
-        <categoryLink id="2586-1bb1-99db-33fe" name="Aves" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="false"/>
+        <categoryLink id="498f-4f38-864c-a19d" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="e0af-d0da-fc4e-3d6a" name="Path of Magic" hidden="false" collective="false">
@@ -2409,7 +2432,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <entryLink id="9f1c-a0cf-fa70-cd97" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-21.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-11.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e0cb-1ac1-75f9-5a19" name="Mageblight Gremlins" hidden="false" collective="false" type="unit">
@@ -2936,7 +2959,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ff38-8b87-7ce9-76e5" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
-        <categoryLink id="7611-5574-2209-673a" name="Aves" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="false"/>
+        <categoryLink id="755e-c8f5-5042-50fa" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="becc-9975-8ce1-b2fa" name="Manifestations of Blazing Glory" hidden="false" collective="false" targetId="01d1-9391-d85a-1f6f" type="selectionEntryGroup"/>
@@ -3025,7 +3048,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </rule>
           </rules>
           <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3260,7 +3283,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e8b5-d8cf-1d9c-30b2" name="New CategoryLink" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="true"/>
+        <categoryLink id="1618-552c-cdb5-b89b" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="fec9-abd8-770a-6892" name="Furies" hidden="false" collective="false" type="model">
@@ -3382,7 +3405,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7e59-e9c1-0097-24d2" name="New CategoryLink" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="true"/>
+        <categoryLink id="c5bf-2a0a-baf0-4cb1" name="New CategoryLink" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7d2a-a811-df76-91a6" name="Veil Serpents" hidden="false" collective="false" type="model">
@@ -3521,7 +3544,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <infoLink id="fc6a-65ef-7153-f765" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="0eb6-811e-d43e-b4a3" name="New CategoryLink" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="true"/>
+        <categoryLink id="6bc4-be49-3ec3-b247" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7a32-7e13-ff6a-b01b" name="Bloat Flies" hidden="false" collective="false" type="model">
@@ -3662,7 +3685,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5007-dbb0-d3e2-831b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
-        <categoryLink id="cc56-e30f-cce9-e3b4" name="Aves" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="false"/>
+        <categoryLink id="c087-3485-ebc8-b3ac" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="13af-d873-0aaf-a85c" name="Wizard Level" hidden="false" collective="false">
@@ -3729,7 +3752,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
     <selectionEntry id="a566-a60d-5074-ec12" name="Harbinger of Father Chaos - Fly" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="7c8c-c1f6-e538-983a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
-        <categoryLink id="f458-5a36-570a-660b" name="Aves" hidden="false" targetId="e5ba-9a6f-e156-4126" primary="false"/>
+        <categoryLink id="f196-d682-6d15-af9c" name="Aves (local)" hidden="false" targetId="e6bc-b5cf-f6f6-2ac0" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="aeeb-3016-d8ec-9067" name="Harbinger of Father Chaos" hidden="false" collective="false" targetId="5c3b-7d58-1689-4939" type="selectionEntry"/>

--- a/dreadElves.cat
+++ b/dreadElves.cat
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e864-7507-1f0d-3ea2" name="Dread Elves 2.0" revision="15" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e864-7507-1f0d-3ea2" name="Dread Elves 2.0" revision="16" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="3a14-99d4-8059-140f" name="The Menagerie (local)" hidden="false"/>
-    <categoryEntry id="2611-7f11-a4ea-5807" name="Destroyers (local)" hidden="false"/>
-    <categoryEntry id="d761-542f-a7ba-bb88" name="Raiders (local)" hidden="false"/>
+    <categoryEntry id="3a14-99d4-8059-140f" name="The Menagerie" hidden="false"/>
+    <categoryEntry id="2611-7f11-a4ea-5807" name="Destroyers" hidden="false"/>
+    <categoryEntry id="d761-542f-a7ba-bb88" name="Raiders" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="69e5-00da-77bb-e5b0" name="Dread Elves (local)" hidden="false">
+    <forceEntry id="69e5-00da-77bb-e5b0" name="Dread Elves" hidden="false">
       <categoryLinks>
         <categoryLink id="86e2-9732-2dbc-71ff" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -1477,9 +1477,6 @@ Models with Towering Presence other than the Divine Altar cannot benefit from Di
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbd6-11ae-7cfd-48a0" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="3716-2360-b0d7-fc6a" name="New CategoryLink" hidden="false" targetId="acc1-73a3-25ca-7ac2" primary="false"/>
-              </categoryLinks>
               <entryLinks>
                 <entryLink id="eb4f-f96d-c19b-017d" name="Manticore" hidden="false" collective="false" targetId="b9e4-b91d-d874-f3c5" type="selectionEntry"/>
               </entryLinks>
@@ -1498,9 +1495,6 @@ Models with Towering Presence other than the Divine Altar cannot benefit from Di
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89d2-b49e-ae72-c39a" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="0e5b-c8f9-fb6d-667a" name="New CategoryLink" hidden="false" targetId="acc1-73a3-25ca-7ac2" primary="false"/>
-              </categoryLinks>
               <entryLinks>
                 <entryLink id="54be-cd79-5b7a-6449" name="Dragon" hidden="false" collective="false" targetId="409d-6c5e-5489-d2cd" type="selectionEntry"/>
               </entryLinks>

--- a/dreadElves.cat
+++ b/dreadElves.cat
@@ -1,0 +1,4702 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="e864-7507-1f0d-3ea2" name="Dread Elves 2.0" revision="15" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="3a14-99d4-8059-140f" name="The Menagerie (local)" hidden="false"/>
+    <categoryEntry id="2611-7f11-a4ea-5807" name="Destroyers (local)" hidden="false"/>
+    <categoryEntry id="d761-542f-a7ba-bb88" name="Raiders (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="69e5-00da-77bb-e5b0" name="Dread Elves (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="86e2-9732-2dbc-71ff" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="4b62-fcd5-9073-f300" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3a6a-660c-bc51-3d1a" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="0564-92dc-a0dc-fd91" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0b72-3e9b-9167-2b36" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="369d-3b12-cc0a-725c" name="Raiders (local)" hidden="false" targetId="d761-542f-a7ba-bb88" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="1ac7-96ae-d0b4-3bfa" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e9be-6bd4-388f-fd26" name="Destroyers (local)" hidden="false" targetId="2611-7f11-a4ea-5807" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="15.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="6069-6c48-94f0-c04c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6689-6926-a9b2-40f7" name="The Menagerie (local)" hidden="false" targetId="3a14-99d4-8059-140f" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="cbf6-6488-22dc-ee0b" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="41a8-2f33-d82e-8d8c" name="Dread Prince" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="0125-0bf7-fd7a-a500" name="Dread Prince Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="930b-b62d-a9cd-3a08" name="Dread Prince Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d983-c8c6-7228-7b1e" name="Dread Prince Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">8</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6b5e-7960-e9d4-9a51" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="1bdd-3edf-e0d3-1d47" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="38d4-7be4-0387-2e2e" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2bf3-b0ae-a653-ea8b" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3822-1f39-6883-336a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b502-92ee-b41f-6076" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ffe0-30a8-55b7-4646" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="0a54-589e-3059-ca75" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ccb-0ddf-9891-523c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e0a2-c3fd-aac4-1544" name="DE Weapon Enchantments" hidden="false" collective="false" targetId="7cbc-441d-4afe-9539" type="selectionEntryGroup"/>
+                    <entryLink id="ef68-503a-78b8-fcc1" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="2398-f2b1-eeea-9fac" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="09f6-fd8c-1061-5592" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09f6-fd8c-1061-5592" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="d006-e1f6-7905-c55d" name="DE Armour Enchantments" hidden="false" collective="false" targetId="b805-a822-8da5-929e" type="selectionEntryGroup"/>
+                    <entryLink id="3fb6-7846-ab1d-e3c4" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="7133-5118-e5bd-ee97" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdba-81c1-550c-c2dc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7fbc-565c-a33a-a3ec" name="DE Aretefacts" hidden="false" collective="false" targetId="94d1-de93-b133-3e3d" type="selectionEntryGroup"/>
+                    <entryLink id="599d-6886-e799-9dbb" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="92d8-9fcb-41d0-3b84" name="Alliance" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff3e-c2b9-24e0-fc4d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cc85-b1dc-f233-c8da" name="Cult of Cadaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="501f-e90f-5893-4870" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0d14-cabb-b69b-95cd" name="Cadaron" hidden="false" collective="false" targetId="957d-879f-c8bb-d5e5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ea9b-27db-8ddf-b4a1" name="Cult of Nabh" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5fca-d848-8b46-89db" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5cbe-c85b-fee7-f6fb" name="Nabh" hidden="false" collective="false" targetId="1925-f536-3a8f-2333" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="586f-b764-8d6c-eeb6" name="Cult of Olaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="175c-ae58-7817-b73c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e371-d0e2-b1d5-cbd3" name="Olaron" hidden="false" collective="false" targetId="6c06-8f39-e8d1-b8e8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0bab-8ce0-9967-35b6" name="Cult of Yema" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="100c-6a12-66b7-c2ee" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0350-159b-9fb9-29df" name="Yema" hidden="false" collective="false" targetId="15ad-bd81-b47b-b029" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="53e9-589f-54cb-d46a" name="Beast Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="61cd-5322-4a46-ddc6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ff7d-b007-464c-20a7" name="Beast Master" hidden="false" targetId="7806-170b-a2b2-c7da" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2a4f-c9c9-045d-f970" name="Fleet Commander" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="66d4-c5e3-f871-8667" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0df2-bb7d-b529-d447" name="Fleet Commander" hidden="false" targetId="f6c5-ccad-f5bd-c65f" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="4ae9-f6ca-b98d-4be3" name="Fleet Commander" hidden="false" collective="false" targetId="5298-cbec-35c4-6f30" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="565a-f075-08da-8cfc" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="41f3-2166-d68b-fe64" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faa5-9ceb-4036-22d3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1772-2745-57e2-7a88" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="136b-df53-0dcd-de41" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d253-9207-2287-19c3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0892-166d-c04f-f60a" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4895-13e8-ebb8-d787" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6753-591a-0416-021b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8c58-2833-0522-0f50" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="07ee-8d12-476c-bd0e" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9986-2a26-59f0-c3a3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6453-a40a-21c6-bace" name="Repeater Handbow (1+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4681-eda7-284c-3387" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="272a-31e5-64b8-3433" name="Repeater Handbow (1+)" hidden="false" targetId="3ace-a562-4861-7210" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f14d-831d-35c5-9612" name="Repeater Crossbow (1+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3baf-b14e-ae2f-5c4e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4515-ffd0-9031-c602" name="Repeater Crossbow (1+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="772d-4d9e-ddfc-846a" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d254-bc44-5410-a7d5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="811a-3a8f-a2dd-10fc" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cdc2-3f58-ad19-99f6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a12f-3112-119f-3f68" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="53ce-bbff-b1ec-68bd" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd5a-b1ba-d86f-d20f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f48b-24ed-a53a-9890" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ab9c-0d94-83e9-806a" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e917-219d-5fae-2a22" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0c0c-71c7-9c25-e8b1" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1da8-bf21-39d5-be68" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="76fb-72b0-cb6b-6cd3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6dbe-151c-e3b3-9cf1" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bf2a-f8ef-05f9-0b4d" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7744-66cf-73c3-b47d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0a9e-2181-df7a-465e" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d65-fb7c-df0e-b841" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f636-582b-4d3e-aba8" name="Elven Horse" hidden="false" collective="false" targetId="c0d0-20bc-f556-468f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e488-921e-ec2a-3d1b" name="Raptor" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67a4-5534-de21-7b40" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="da76-fa62-1111-5974" name="Raptor" hidden="false" collective="false" targetId="e1d2-1439-a2b8-d8ec" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9fd3-4f62-8ab6-0c30" name="Raptor Chariot" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="41a8-2f33-d82e-8d8c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a4f-c9c9-045d-f970" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e83d-25b5-9a0a-3e73" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e715-d399-389a-aeb8" name="Raptor Chariot" hidden="false" collective="false" targetId="5465-f1c8-ada2-b24c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e708-261d-28f0-fea1" name="Pegasus" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="697f-f65d-7c4c-b0b2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="37af-54a3-99a7-2e05" name="Pegasus" hidden="false" collective="false" targetId="1182-69a3-0773-e51e" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7929-8c5d-cd7e-c220" name="Manticore" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="41a8-2f33-d82e-8d8c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a4f-c9c9-045d-f970" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="72b3-a62f-653c-78dc" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="5b20-5ba4-a080-37b0" name="The Menagerie (local)" hidden="false" targetId="3a14-99d4-8059-140f" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="cceb-38d1-c6d3-305a" name="Manticore" hidden="false" collective="false" targetId="b9e4-b91d-d874-f3c5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9aea-a139-0748-560b" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="15f3-22af-11c2-c98e" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="9ed6-32d6-d129-03c6" name="The Menagerie (local)" hidden="false" targetId="3a14-99d4-8059-140f" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="cbe7-d700-e30b-074b" name="Dragon" hidden="false" collective="false" targetId="409d-6c5e-5489-d2cd" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="747f-2bc2-8d05-a018" name="Army General" hidden="false" collective="false" targetId="6f48-ba88-921e-d57e" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="240.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cb62-2ea5-8a04-b654" name="Captain" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="5021-9130-8b55-d4d2" name="Captain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6892-d1d0-f81c-96d6" name="Captain Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5841-3a04-33d8-99bb" name="Captain Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5e96-b383-3b09-d9f1" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="4a25-d777-8456-dfee" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5c8a-d52f-0200-5eb7" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5582-d855-1c23-ad72" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0fb-53ed-caa9-dfa2" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b055-2498-059a-2c16" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b2c7-af4e-4ba5-3195" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="6bd3-645b-192e-f073" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe42-06f4-b464-f2a5" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="39e9-5c43-9a0f-f990" name="DE Weapon Enchantments" hidden="false" collective="false" targetId="7cbc-441d-4afe-9539" type="selectionEntryGroup"/>
+                    <entryLink id="df78-e3a8-6981-d26e" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="193b-5c7e-14aa-0c8a" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="a17f-401f-ca73-2be1" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a17f-401f-ca73-2be1" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7367-dc6e-34d2-ab70" name="DE Armour Enchantments" hidden="false" collective="false" targetId="b805-a822-8da5-929e" type="selectionEntryGroup"/>
+                    <entryLink id="3b6f-da7e-e826-db29" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1cf1-62af-ec9c-db2e" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="985e-97a4-6d23-c93b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="a291-d2a5-fb82-b5ac" name="DE Aretefacts" hidden="false" collective="false" targetId="94d1-de93-b133-3e3d" type="selectionEntryGroup"/>
+                    <entryLink id="bb40-102e-fb71-f801" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="04c8-f21b-0790-94a9" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="cb62-2ea5-8a04-b654" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e9a-ee0c-eee7-864c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4b0-180e-a7f9-b87f" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="eb25-39de-e2e1-03e1" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="fdd2-1d8f-e3dd-2ae7" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="ada9-06db-9a16-b246" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3e9a-ee0c-eee7-864c" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ae5-aaa7-fee7-fe91" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d018-07c5-b430-c9b8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ad0c-3f21-9705-8734" name="Battle Standard Bearer" hidden="false" collective="false" targetId="e4b9-e402-ef35-fe5e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e6cd-e10c-b86a-d719" name="Alliance" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7197-2daf-50a2-4c21" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d7bd-3c7c-f475-9044" name="Cult of Cadaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf62-f336-4985-894a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d1ee-0e9f-d43e-e244" name="Cadaron" hidden="false" collective="false" targetId="957d-879f-c8bb-d5e5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6cb2-15b6-51da-2653" name="Cult of Nabh" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d277-5a30-3cbb-b225" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e4c7-087b-04bd-706e" name="Nabh" hidden="false" collective="false" targetId="1925-f536-3a8f-2333" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a73e-f7da-2a21-1269" name="Cult of Olaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d933-ce9c-a5f0-b5f6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5cad-0341-31d3-34d8" name="Olaron" hidden="false" collective="false" targetId="6c06-8f39-e8d1-b8e8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7709-06ea-60c0-e6ad" name="Cult of Yema" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cc6-5307-c05d-d9da" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e8d5-5d2a-03a6-e9fe" name="Yema" hidden="false" collective="false" targetId="15ad-bd81-b47b-b029" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8393-bc40-7c3e-f9bf" name="Beast Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c6e-22d5-dc5b-fc98" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="04af-4596-2408-d324" name="Beast Master" hidden="false" targetId="7806-170b-a2b2-c7da" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ff6e-608d-66a2-715b" name="Fleet Commander" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7b1-c810-530b-9b7a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1509-3ffd-73c6-0bd9" name="Fleet Commander" hidden="false" targetId="f6c5-ccad-f5bd-c65f" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="8845-dae7-d9fe-d9e5" name="Fleet Commander" hidden="false" collective="false" targetId="5298-cbec-35c4-6f30" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f5a3-4600-5526-83c6" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="464a-15cd-d3d9-463b" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e8a-a2e6-6fef-2d37" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="95d9-f8e8-e60c-bba4" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0658-1387-544b-28ff" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ced2-642d-8a50-a8a3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8b79-5232-7613-6846" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c79d-b245-353c-b4ae" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a7c-8132-9732-6544" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8bd0-d60d-c89b-7847" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3f71-ae19-d981-11d9" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4db-777a-1442-1361" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0731-cc4c-2437-9187" name="Repeater Handbow (2+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c00-1a59-1a0b-9965" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="77e2-b96c-0eaf-b32c" name="Repeater Handbow (2+)" hidden="false" targetId="3ace-a562-4861-7210" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d0f9-6801-98a2-ffdc" name="Repeater Crossbow (2+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f13-4ba4-c697-bc4f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9f26-0f65-034d-ab31" name="Repeater Crossbow (2+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4e6e-93c9-89df-52aa" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="28f0-ad99-b677-b9fd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="31ab-f7e3-7a5b-fab1" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="985d-a980-45be-3b0d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a75b-e8ec-baf1-b7cd" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="14df-8d68-4311-e086" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b114-9278-a584-31df" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7021-7677-2a23-465f" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="04e0-d22e-574f-013a" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7064-e52f-06d0-c40a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="038c-1c51-5c46-4953" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c33d-1c47-5937-2af1" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b960-1ca8-8755-cb11" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c0ad-9157-0559-3f95" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d51-b464-e27a-4aa2" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c54-5914-0080-494b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cec3-9a6a-e065-2aeb" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfb7-7dc9-9185-e87e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f5dc-ab5c-d7cc-7398" name="Elven Horse" hidden="false" collective="false" targetId="c0d0-20bc-f556-468f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cace-1265-3ef2-b283" name="Raptor" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db14-6424-7f51-ee17" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="02f5-c075-0c9e-a43b" name="Raptor" hidden="false" collective="false" targetId="e1d2-1439-a2b8-d8ec" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="792b-ecd5-3900-ef92" name="Raptor Chariot" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="cb62-2ea5-8a04-b654" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff6e-608d-66a2-715b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f12-f07a-9b87-c8e3" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4ed6-456d-bcc6-aaf3" name="Raptor Chariot" hidden="false" collective="false" targetId="5465-f1c8-ada2-b24c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="918f-9cdc-2c2a-b8c6" name="Pegasus" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e989-b493-821f-cc24" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8885-844f-335a-8476" name="Pegasus" hidden="false" collective="false" targetId="1182-69a3-0773-e51e" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8c36-8235-2c1f-cd8a" name="Manticore" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ff6e-608d-66a2-715b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75ec-cce0-bc5b-46b8" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="3f21-c395-4670-c0b3" name="The Menagerie (local)" hidden="false" targetId="3a14-99d4-8059-140f" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="7c53-ea13-95e3-5fc1" name="Manticore" hidden="false" collective="false" targetId="b9e4-b91d-d874-f3c5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8ae5-aaa7-fee7-fe91" name="Army General" hidden="false" collective="false" targetId="6f48-ba88-921e-d57e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e9a-ee0c-eee7-864c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="155.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="73e5-464d-9665-0b4b" name="Cult Priest" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="af71-bf60-41b7-4cbf" name="Cult Priest Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8d91-9736-c46b-839d" name="Cult Priest Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f706-43be-d138-3e3c" name="Cult Priest Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1760-6d88-b35d-7649" name="Cult Legate" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94f6-97e3-0dfd-5677" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Model parts with a Cult gain Killer Instinct as long as a Cult Priest on foot is joined to their unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="4ddd-d143-3803-553f" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="937d-d7df-a2d0-1f1f" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="aa84-de81-8af1-a2b1" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="126c-d726-cf7e-a078" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c801-dac5-3be1-0d7a" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7066-9cd4-023f-08e8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cbf-2fe4-7411-f85d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="060b-2134-3e2d-6ef2" name="Battle Standard Bearer" hidden="false" collective="false" targetId="e4b9-e402-ef35-fe5e" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d34-d99e-f74b-bf95" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a56-525b-1244-4b58" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ceca-9c44-1834-71af" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4963-a697-6fc8-04ab" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b070-34e9-ab5b-c6b9" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e67-1184-87b7-bfd9" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="d7f9-0a89-5b18-fada" name="DE Weapon Enchantments" hidden="false" collective="false" targetId="7cbc-441d-4afe-9539" type="selectionEntryGroup"/>
+                    <entryLink id="26f0-b621-47e6-9945" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1bcb-1c64-6e04-5c31" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="e535-cdfd-4095-74eb" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e535-cdfd-4095-74eb" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0169-2bdc-cac8-aa3a" name="DE Armour Enchantments" hidden="false" collective="false" targetId="b805-a822-8da5-929e" type="selectionEntryGroup"/>
+                    <entryLink id="80b0-01d5-39bf-a02c" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1804-e95e-fb07-9d1b" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7df-7412-8a87-b94d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="dc9f-ad78-f9f0-1736" name="DE Aretefacts" hidden="false" collective="false" targetId="94d1-de93-b133-3e3d" type="selectionEntryGroup"/>
+                    <entryLink id="ef1d-8b20-73be-ed4d" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="141d-b785-b5de-afd8" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="73e5-464d-9665-0b4b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c801-dac5-3be1-0d7a" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8e6-f1c0-be9e-7bcf" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="bc4c-ff29-362e-9b0e" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="d9af-5be9-135e-4ecf" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="0c31-4c1e-9f95-a2fc" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="faa9-ac73-ed30-7e22" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4643-6310-6ccc-26d2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6d61-64ae-f90c-1734" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="94f6-97e3-0dfd-5677" name="Divine Altar" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d4d-e912-9e62-6852" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f2a-f20b-b431-b7a1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6d79-a61f-054f-2917" name="Divine Altar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="76b9-54b7-c3fa-11b9" name="Divine Altar Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0f87-bfd2-e13c-7f8e" name="Disciple (3) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9d62-0d6d-9a15-8270" name="Avatar Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b465-48ff-5817-acfd" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ebb3-deef-d8ad-5e73" name="Divine Blessings" hidden="false">
+              <description>All friendly units within 12&quot; of a Divine Altar gain Aegis (6+). At the beginning of each friendly Player Turn, you may choose to replace the Aegis with one of the following effects until the start of your next Player Turn:
+
+- All friendly units within 12&quot; of the Divine Altar may add one additional D6 for Charge Range rolls and discard the lowest D6 rolled.
+- All friendly units within 12&quot; of the Divine Altar gain Death Trance.
+
+Models with Towering Presence other than the Divine Altar cannot benefit from Divine Blessings. A single unit can only be affected by a single Divine Blessing from a single Divine Altar at any time. If under the influence of more than one Blessing, only apply the most recently used one.
+</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="7b33-f5b4-599e-c19f" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+            <infoLink id="b922-be2c-d396-9d53" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+            <infoLink id="d689-34b7-9a6a-55ea" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+            <infoLink id="3625-07a5-df96-b7b8" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="5321-6f4e-a483-9708" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+            <infoLink id="9871-b797-7c06-3858" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+            <infoLink id="915c-3dc9-0823-8c99" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+            <infoLink id="458a-54b4-ce74-7fea" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+            <infoLink id="6a05-6501-de07-bed7" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+            <infoLink id="68c5-44a2-97ee-74d2" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (D6+1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2668-9005-3e09-29c5" name="Melee Weapon" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4416-b2bb-4649-46c0" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="2dcb-b07a-f0d7-27d5" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="d495-64cc-09cc-f023" name="Light Lance" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ec0-c469-76f8-3af1" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3ca4-9c9d-b0db-d437" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="cdb0-cdf6-be49-bb89" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="001c-0503-3dc8-b266" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb6d-0ad7-3e03-47f5" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="5027-8eef-9837-970a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="a933-3b53-ed11-6d3f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dde2-f767-1bf0-b072" name="Alliance" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84a1-cd7f-f13e-bb98" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f79b-d841-aca0-81a8" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1641-74d2-2804-d138" name="Cult of Cadaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d93-b35e-f925-b6f8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a402-a0cf-b948-ed6f" name="Cadaron" hidden="false" collective="false" targetId="957d-879f-c8bb-d5e5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6dc1-2ea1-5d76-0219" name="Cult of Nabh" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35f2-2a2d-88e2-380f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5917-29f0-cdf5-97fe" name="Nabh" hidden="false" collective="false" targetId="1925-f536-3a8f-2333" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0271-4a00-f8a4-b7be" name="Cult of Olaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d3f4-c86b-e50f-6b28" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4a1a-fbf3-a09b-9d67" name="Olaron" hidden="false" collective="false" targetId="6c06-8f39-e8d1-b8e8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4a06-8fd9-5f5b-fcc5" name="Cult of Yema" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8584-8333-50f4-2b21" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="53d6-757c-2dbc-dcc4" name="Yema" hidden="false" collective="false" targetId="15ad-bd81-b47b-b029" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7b28-3d18-cc1e-79ea" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="749a-a5cb-188b-c42f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="59f9-4edb-612a-0654" name="Repeater Handbow (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6334-0917-3052-6bb8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="08ef-36bd-2981-78f7" name="Repeater Handbow (4+)" hidden="false" targetId="3ace-a562-4861-7210" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="02fd-0f39-08e9-0c99" name="Repeater Crossbow (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2956-6d94-a995-c899" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4b95-b1c8-a675-42fb" name="Repeater Crossbow (4+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f04a-c0f9-df2c-341a" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e05-544c-d9e1-0264" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bd14-eb48-6e12-76ab" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c5f-02d8-db4c-f5f7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="63cf-7a8b-25b9-9ec8" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4ff-44ec-d7bf-3728" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fe9-f57b-2565-eceb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9f30-978c-0127-4973" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5f34-4103-4b57-fc86" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c161-6745-5300-60c5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="024c-7073-fb40-dac0" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3955-b001-15e8-358d" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b69b-ed1f-58ca-e36b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f5f6-a00f-6f51-2d9a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7066-9cd4-023f-08e8" name="Army General" hidden="false" collective="false" targetId="6f48-ba88-921e-d57e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c801-dac5-3be1-0d7a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="865a-365e-868f-d06e" name="Oracle" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="ad43-1ddc-a34f-83f9" name="Oracle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a453-f206-0c34-4627" name="Oracle Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cb43-7cab-02c0-59a1" name="Oracle Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6df1-3ce6-b9ce-071c" name="Irresistible Will" hidden="false">
+          <description>Dispel rolls against non-Bound Spells cast by the model suffer a -1 modifier.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ada6-15d3-3e71-280c" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="22fc-d1d8-3763-9002" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1977-e9b3-e84b-c87d" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5fb8-e4c1-dff2-5ace" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53a6-cad7-1969-03fd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d122-9e66-3b67-f5b0" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f1ac-e159-8cc1-a69d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8da4-2532-7fc0-7d9f" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f8ea-4566-64ff-43d6" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="0f58-f868-f077-9a78" value="100">
+                  <conditions>
+                    <condition field="selections" scope="865a-365e-868f-d06e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1abe-7ee1-7f55-0e4d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f58-f868-f077-9a78" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7749-32ef-a4ae-798b" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c2f4-9415-6e07-ad9f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="cce6-2097-94d6-22b2" name="DE Weapon Enchantments" hidden="false" collective="false" targetId="7cbc-441d-4afe-9539" type="selectionEntryGroup"/>
+                    <entryLink id="d884-dbed-5b22-a60a" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="9ae9-6f83-e4b6-cd75" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="3e83-68f6-ceb3-983a" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e83-68f6-ceb3-983a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="cfbe-9a3d-e562-af87" name="DE Armour Enchantments" hidden="false" collective="false" targetId="b805-a822-8da5-929e" type="selectionEntryGroup"/>
+                    <entryLink id="8bba-9973-9306-d963" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="62b2-1314-ba86-55e8" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9152-e9a3-c70e-c4e1" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5e7e-876b-df96-b239" name="DE Aretefacts" hidden="false" collective="false" targetId="94d1-de93-b133-3e3d" type="selectionEntryGroup"/>
+                    <entryLink id="60f4-8438-4815-1e8d" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b8ec-e80c-02c4-e61d" name="Cult of Yema" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cea0-c1bb-ccd2-7eb6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ad3f-e27b-ff98-25f6" name="Yema" hidden="false" collective="false" targetId="15ad-bd81-b47b-b029" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dda1-28d9-2819-0a07" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="460c-aa2a-94a6-5b61">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7d2-e816-b88e-c6da" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff13-5d55-b4db-a41b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="460c-aa2a-94a6-5b61" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c94-d70e-efc4-5cf8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6b49-acae-463a-070c" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c645-ae17-b2da-a6a0" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e244-f529-995f-e7de" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dcdc-6039-2b81-2b50" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1abe-7ee1-7f55-0e4d" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83cb-ce3d-4663-5922" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2b33-a351-290c-08b0" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7163-d788-361e-428a" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b05-9fad-c68f-5774" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3656-deae-fa7c-ec6f" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="301b-3564-a649-bc06" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0637-597a-375c-6d01" name="Elven Horse" hidden="false" collective="false" targetId="c0d0-20bc-f556-468f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="30b8-91af-220f-7364" name="Raptor" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="971e-50b6-fbfa-1e79" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="57af-3669-5b17-2742" name="Raptor" hidden="false" collective="false" targetId="e1d2-1439-a2b8-d8ec" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="51f9-504c-17fb-e632" name="Pegasus" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="97eb-0dd9-b78e-944f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9118-7642-6f6a-1ad3" name="Pegasus" hidden="false" collective="false" targetId="1182-69a3-0773-e51e" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16d1-a511-9e77-a180" name="Manticore" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="865a-365e-868f-d06e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1abe-7ee1-7f55-0e4d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbd6-11ae-7cfd-48a0" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="3716-2360-b0d7-fc6a" name="New CategoryLink" hidden="false" targetId="acc1-73a3-25ca-7ac2" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="eb4f-f96d-c19b-017d" name="Manticore" hidden="false" collective="false" targetId="b9e4-b91d-d874-f3c5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4e51-0b1f-a35f-9585" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1abe-7ee1-7f55-0e4d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89d2-b49e-ae72-c39a" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0e5b-c8f9-fb6d-667a" name="New CategoryLink" hidden="false" targetId="acc1-73a3-25ca-7ac2" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="54be-cd79-5b7a-6449" name="Dragon" hidden="false" collective="false" targetId="409d-6c5e-5489-d2cd" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2220-6840-dca2-4702" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="5ac1-2d27-9a85-2928" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98cc-e1bd-6f79-32c7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac1-2d27-9a85-2928" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a419-147c-6afc-1e5a" name="Alchemy" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="865a-365e-868f-d06e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8ec-e80c-02c4-e61d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e990-3f56-dee7-c12b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1f9a-72fa-4e76-9d87" name="Witchcraft" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19ea-d329-816f-8c61" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ab69-e38a-0031-4620" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e580-47cb-36f0-3c14" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b54c-8b44-c2fa-c460" name="Cosmology" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d15-36be-05bb-d1c9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b30b-f5bf-7dd0-5b1c" name="Occultism" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="865a-365e-868f-d06e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8ec-e80c-02c4-e61d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d9-b312-9c5f-b3ac" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="12f4-4ee7-8c51-f6d7" name="Army General" hidden="false" collective="false" targetId="6f48-ba88-921e-d57e" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa61-381b-d9c8-24f2" name="Assassin" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="57bc-f0f0-9da4-1879" name="Assassin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="beae-4e37-8068-e979" name="Assassin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fbea-86a5-92ae-3276" name="Assassin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">9</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="59ed-de05-1bdf-1d69" name="Professional Courtesy" hidden="false">
+          <description>Assassins cannot join units that contain another Assassin. ​Assassins may perform Make Way moves even when they are in base contact with an enemy model.</description>
+        </rule>
+        <rule id="c8a9-fbbe-6f8b-8e65" name="Agent of the Obsidian Throne" hidden="false">
+          <description>Assassins ignore Cult Rivalry for the purpose of joining units, and are ignored regarding Cult Rivalry by Characters joining their unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="51f2-6797-48a6-9073" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="c3c5-16cf-9648-6df7" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="9cba-dbbd-a89a-7d74" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="d649-f0ba-50fd-35b5" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="cf98-6c9d-ae9a-c990" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4629-b23a-c9b3-57e5" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2169-d881-915e-ed6e" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e0e-e982-0dc6-18fc" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6f49-44bb-f8c5-dff0" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c766-26f7-b4c6-32e9" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="302d-27c7-8631-cb4f" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6119-9aa7-1772-2b98" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="21d5-bac0-b1bc-c9a4" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a64e-f628-cc28-8e1f" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f979-fd4a-65e9-27c6" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="b4ca-02a9-4141-1e06" name="DE Weapon Enchantments" hidden="false" collective="false" targetId="7cbc-441d-4afe-9539" type="selectionEntryGroup"/>
+                    <entryLink id="8cd1-a9dc-5f44-2022" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="7d60-c8e3-6010-e57b" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fff8-2ef8-884d-6156" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f5f9-61eb-de94-eb59" name="DE Aretefacts" hidden="false" collective="false" targetId="94d1-de93-b133-3e3d" type="selectionEntryGroup"/>
+                    <entryLink id="f428-4ac3-2986-bfd3" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2ca5-44d4-4879-7fe1" name="Path of Bloody Murder" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd41-16e3-08e5-8d96" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="2dd9-3f61-6aaa-0237" name="Path of Bloody Murder" hidden="false">
+              <description>The model gains Cult of Nabh, Distracting, and Aegis (4+, against Melee Attacks)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="87fb-291d-36c2-9b41" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+            <infoLink id="e121-edcd-ac1d-6aa6" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="a99b-106e-4098-dfa6" name="Nabh" hidden="false" collective="false" targetId="1925-f536-3a8f-2333" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7386-6d50-3d01-b3af" name="Master Poisoner" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c347-f04f-a0c4-bfe3" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4047-cec5-94ef-5817" name="Poison" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7947-2632-907c-71d2" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="d4e9-53ed-ac02-38fe" name="Nightshade" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a83-e33d-05b8-af48" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="14c0-bdb6-5640-ca4a" name="Nightshade" hidden="false">
+                      <description>The attack always​ w​ ounds on at least 3+</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="3eb9-899f-ec81-3179" name="Wolfsbane" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d46c-6593-568c-5a3c" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="fbd5-93c3-31f5-90ad" name="Wolfsbane" hidden="false">
+                      <description>The attack has its Armour Penetration set​ ​to 10.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2e1b-23ec-e694-7ce5" name="Bloodroot" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="885b-f53e-fe3f-e8de" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="3d0d-beb9-7e88-461f" name="Bloodroot" hidden="false">
+                      <description>The attack gains +1 Strength, +1 Armour Penetration, and Multiple Wounds (2,
+against Character).</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="155.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3e1e-e56a-4cbd-6928" name="Assassin - Path of Silent Death" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="fb03-1135-97db-f5f9" name="Assassin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8ba2-88e3-219e-4174" name="Assassin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c320-b505-03ae-b55b" name="Assassin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">9</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="311a-1a7f-ab74-e1d7" name="Assassin Throwing Weapons (1+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">As User</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">As User</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="583a-0592-1129-e678" name="Professional Courtesy" hidden="false">
+          <description>Assassins cannot join units that contain another Assassin. ​Assassins may perform Make Way moves even when they are in base contact with an enemy model.</description>
+        </rule>
+        <rule id="9918-a688-f1aa-3d50" name="Agent of the Obsidian Throne" hidden="false">
+          <description>Assassins ignore Cult Rivalry for the purpose of joining units, and are ignored regarding Cult Rivalry by Characters joining their unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="cc53-5373-ff96-9c8f" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="3a60-9779-2497-f370" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="3d4e-2263-f253-1e7d" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="2cb0-d377-e602-6b12" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="d7cd-221b-12e8-1a7c" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d5bd-14d1-14f4-2647" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="a6cb-af51-0d84-e914" name="Raiders (local)" hidden="false" targetId="d761-542f-a7ba-bb88" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1403-c34a-d2f6-91f2" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3057-2185-917e-90e3" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d7ea-b45f-b5d2-6f75" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c273-db70-d337-a990" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9d1-3f45-4101-ac1d" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2e00-b817-06c9-9377" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6efe-9641-61c1-0989" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="c40c-763b-4d5f-81c3" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7951-60c5-5295-2947" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7f2b-b68a-95c8-62b9" name="DE Weapon Enchantments" hidden="false" collective="false" targetId="7cbc-441d-4afe-9539" type="selectionEntryGroup"/>
+                    <entryLink id="6332-e4e9-d75d-3965" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="443b-5eb0-14c7-3529" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdc3-e6bf-ce00-d549" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2e3d-cec5-7ee1-c015" name="DE Aretefacts" hidden="false" collective="false" targetId="94d1-de93-b133-3e3d" type="selectionEntryGroup"/>
+                    <entryLink id="7a52-16ca-f115-dafa" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="000f-417e-cf27-89c0" name="Master Poisoner" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dda-eca6-69fb-9b46" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e315-545e-e94c-8ff0" name="Poison" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f91f-bba1-50c4-8204" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="06d9-2702-e863-cad8" name="Nightshade" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="589c-3fb0-5b49-f2f6" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="84e5-fc5d-218b-2a71" name="Nightshade" hidden="false">
+                      <description>The attack always​ w​ ounds on at least 3+</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a64c-62d2-5a05-73a3" name="Wolfsbane" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8279-f967-a78e-16c0" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="da3d-4d4f-87b3-fb81" name="Wolfsbane" hidden="false">
+                      <description>The attack has its Armour Penetration set​ ​to 10.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1447-3b44-54c5-269b" name="Bloodroot" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eba0-f0b0-befa-da4b" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="8d72-36d2-943c-056b" name="Bloodroot" hidden="false">
+                      <description>The attack gains +1 Strength, +1 Armour Penetration, and Multiple Wounds (2,
+against Character).</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="344f-727d-e393-dbfb" name="Cadaron" hidden="false" collective="false" targetId="957d-879f-c8bb-d5e5" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2e23-a9ea-2f6a-dc58" name="Dread Legionnaires" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="b248-839f-beaf-0ca0" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="afcc-11c5-271a-3570" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="65a5-1339-9a50-99c3" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="477c-1b52-ced8-aeca" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="7bed-659f-3880-455d" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="53cd-caee-4f76-08c5" name="Cadaron" hidden="false" targetId="b1da-1f0c-f7fc-7b0a" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="085e-e665-bf32-6e2b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="72aa-5f7d-ccd1-44b3" name="Nabh" hidden="false" targetId="e6b5-3659-76c8-7239" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a473-4c6c-a815-9494" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8989-6366-5a7b-4e8e" name="Olaron" hidden="false" targetId="6cb3-a814-2fc8-25dc" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb78-a955-08a6-15a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="560f-2b07-085b-057e" name="Yema" hidden="false" targetId="2c7b-8229-318f-a763" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52b9-785d-868c-7ccf" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="51fb-ed8a-7ed0-3b30" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="dae9-d585-642e-0751" name="Dread Legionnaire" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09c6-f715-0a1a-c833" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="014e-ee2f-b4e2-4d60" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="194f-97c2-92ed-826e" name="Dread Legionnaire Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1a90-9052-1ac6-911b" name="Dread Legionnaire Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="81c0-e647-b114-3d9a" name="Dread Legionnaire Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="13.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="04ba-c6c8-2e3e-9810" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2e23-a9ea-2f6a-dc58" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b41-9854-c01b-2ac7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3696-d5c9-5c55-d13a" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4f4-7917-4713-4e23" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2162-99e4-33f3-dd08" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="77b8-65a7-4d43-c8cb" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="134c-4c41-96c0-52c9" name="Spears" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="2e23-a9ea-2f6a-dc58" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dae9-d585-642e-0751" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b62-304b-142c-2e81" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7980-05ba-746d-ce26" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7505-fef1-096e-881d" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b6f-5b02-13ad-c245" name="Corsairs" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="bbdd-705e-c7ce-e592" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2142-47a3-3cb9-d9c9" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="8493-8c23-262e-52ca" name="Kraken&apos;s Hide" hidden="false" targetId="f691-8c07-03fd-0ae6" type="profile"/>
+        <infoLink id="bf4f-60f5-7db9-297f" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="7c35-ce5f-4794-e97e" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="fc75-72fd-980e-adf6" name="Cadaron" hidden="false" targetId="b1da-1f0c-f7fc-7b0a" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="085e-e665-bf32-6e2b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b39c-dfc5-9e57-4310" name="Nabh" hidden="false" targetId="e6b5-3659-76c8-7239" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a473-4c6c-a815-9494" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8fc0-fe54-1bf3-fd52" name="Olaron" hidden="false" targetId="6cb3-a814-2fc8-25dc" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb78-a955-08a6-15a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0891-11eb-8158-4607" name="Yema" hidden="false" targetId="2c7b-8229-318f-a763" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52b9-785d-868c-7ccf" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f879-24b6-38c1-1028" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="35a2-39f4-c550-b6dd" name="Corsair" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adc3-b186-7ae7-625a" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d0e-1b11-d429-ddfc" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="9383-6c7b-ce64-9780" name="Corsair Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c70e-db80-c955-1216" name="Corsair Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4f3b-49eb-862f-c986" name="Corsair Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e407-ad55-26af-d6ca" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1b6f-5b02-13ad-c245" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8120-c9d5-9eef-4d92" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0976-3ec1-4295-ddf3" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46a8-e615-666f-f646" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="abe5-630f-6a6a-a035" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="e572-cdf0-543c-e312" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4f39-cb10-aca7-5c58" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="1b6f-5b02-13ad-c245" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35a2-39f4-c550-b6dd" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6162-e63b-0059-f9aa" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4ed1-2fbc-b709-33aa" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d5b6-6811-3347-ca92" name="Repeater Handbow (4+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="1b6f-5b02-13ad-c245" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35a2-39f4-c550-b6dd" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="1b6f-5b02-13ad-c245" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35a2-39f4-c550-b6dd" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="085e-e665-bf32-6e2b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="1d05-dd9a-1120-446b" value="175">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="085e-e665-bf32-6e2b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc24-871d-385a-76fd" type="max"/>
+            <constraint field="24fd-8af8-0c78-001c" scope="roster" value="140.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d05-dd9a-1120-446b" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ae16-365f-61b8-d2bc" name="Repeater Handbow" hidden="false" targetId="3ace-a562-4861-7210" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1f3f-dc74-2d4f-cc8d" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5298-cbec-35c4-6f30" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="1b6f-5b02-13ad-c245" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35a2-39f4-c550-b6dd" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="cf75-7cb5-4167-487e" value="1">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5298-cbec-35c4-6f30" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5771-4bff-ea34-0bb5" type="max"/>
+            <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf75-7cb5-4167-487e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cf07-6c7b-0795-a709" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="3e83-fc7d-20d5-1586" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f2d3-e777-8143-53ec" name="Blades of Nabh" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="5c88-9f99-3c1b-5f0a" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="de53-6e9d-7296-00b2" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="9a61-5cd3-44f9-1120" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="7cae-7da7-bc78-e980" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+        <infoLink id="f665-e2ac-8331-875e" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="ffa4-2e7c-9467-a486" name="Nabh" hidden="false" targetId="e6b5-3659-76c8-7239" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5b6a-ff75-35fa-4dfd" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bc73-6ac1-4909-6b72" name="Blade of Nabh" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="abef-4891-2b82-437a" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2812-e039-2d02-d3a8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3d86-008a-7425-f802" name="Blade of Nabh Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3d50-1b37-fa6e-906e" name="Blade of Nabh Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b79c-5b5a-5c18-c424" name="Blade of Nabh Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d00-3be1-fc48-aa51" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f2d3-e777-8143-53ec" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea6a-1989-31ec-998c" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3657-a500-8cc5-4e02" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f15-18e1-65df-4f7b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6332-5e4c-7467-e8ad" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="8db9-515a-2e1d-00aa" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="c203-f775-cdec-38da" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="68c2-b161-9a0c-d91d" name="Repeater Auxilliaries" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="f838-a944-7ba2-03d5" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="a26a-44a7-4dda-ffb6" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="968c-bff8-d4fc-fc32" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="ef23-5af4-218f-9eec" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="b0e5-8945-acbf-b617" name="Repeater Crossbow (4+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+        <infoLink id="6a57-87f6-ea56-496c" name="Yema" hidden="false" targetId="2c7b-8229-318f-a763" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52b9-785d-868c-7ccf" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8f44-1ce5-21f2-901a" name="Olaron" hidden="false" targetId="6cb3-a814-2fc8-25dc" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb78-a955-08a6-15a8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0d37-3a7e-a515-4772" name="Nabh" hidden="false" targetId="e6b5-3659-76c8-7239" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a473-4c6c-a815-9494" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3ef1-d67a-ca51-58b5" name="Cadaron" hidden="false" targetId="b1da-1f0c-f7fc-7b0a" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="085e-e665-bf32-6e2b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3681-074e-2bff-aed7" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="c7e6-d3dc-479e-d034" name="Raiders (local)" hidden="false" targetId="d761-542f-a7ba-bb88" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="df42-8c83-b308-c4cc" name="Repeater Auxilliary" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="22">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="085e-e665-bf32-6e2b" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c8c-ddd4-b00f-79a7" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f800-cebf-375e-1239" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="015e-d0a7-6dab-ed96" name="Repeater Auxilliary Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b2d1-a399-83e5-b3aa" name="Repeater Auxilliary Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="fa22-7e0b-5379-e64c" name="Repeater Auxilliary Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="64b8-04b1-1749-9e6d" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="68c2-b161-9a0c-d91d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1d8-dcda-ee00-1a50" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0243-a559-4af0-6ab1" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1dbe-eccc-4f75-4801" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0ccf-2a3d-5777-2fbe" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="87c6-a81b-d3f7-8968" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="87e7-99f8-45bb-ac31" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="68c2-b161-9a0c-d91d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="df42-8c83-b308-c4cc" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="584f-06ee-a74f-b7d7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3902-d202-ad78-e189" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="d25c-52b5-5ea1-7fdd" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5717-ed5e-648d-d59e" name="Dark Raiders" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c500-3c1e-dc3b-35ad" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7f95-5684-c44f-b790" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="cc72-4151-9747-95e8" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="197e-f21d-26b5-c874" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="8d5a-9788-386c-a83e" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="e0a5-c814-695c-7b84" name="Cadaron" hidden="false" targetId="b1da-1f0c-f7fc-7b0a" type="rule"/>
+        <infoLink id="c7ef-0620-639a-ad8a" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="b8a2-0667-0377-b25b" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="8eee-a485-206e-8e63" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8e14-efee-b8bc-17dd" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="1517-22d8-d1a2-dc11" name="Raiders (local)" hidden="false" targetId="d761-542f-a7ba-bb88" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7879-ebbe-0cf5-03a9" name="Dark Raider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c69c-a8d4-4278-7be5" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adbb-0ae8-4721-4cb8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8f17-f361-1325-0314" name="Dark Raider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5f88-7f75-d7a4-0299" name="Dark Raider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9421-fb6c-7df6-8df7" name="Dark Raider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1e93-b16e-4b63-d510" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="474a-6ecf-4bac-de3e" name="Repeater Crossbows (4+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+              <repeats>
+                <repeat field="selections" scope="5717-ed5e-648d-d59e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7879-ebbe-0cf5-03a9" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="49be-d27f-9861-08e7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f54e-4b00-d2a2-a41e" name="Repeater Crossbow (4+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ec84-d731-54f0-43f7" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="5717-ed5e-648d-d59e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7879-ebbe-0cf5-03a9" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11f8-8060-5354-03c6" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8473-520e-df3a-1d7c" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="a15a-10c8-1d53-3085" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24c3-4461-446f-26e1" name="Raven Cloaks" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3cb-00e6-2951-062e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2c37-0790-f9ad-3055" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="1c39-da68-077f-ba67" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="3fe2-9bb6-d991-1a39" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="7acb-378a-cf0b-fa4d" name="Cadaron" hidden="false" targetId="b1da-1f0c-f7fc-7b0a" type="rule"/>
+        <infoLink id="c73d-85e9-6067-eafc" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="51c1-ef9f-2bf8-4e2f" name="Repeater Crossbow (3+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8cc8-5589-9d7b-0cf7" name="New CategoryLink" hidden="false" targetId="d761-542f-a7ba-bb88" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5230-31d2-908c-b727" name="Raven Cloak" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bce-b920-a348-bf2c" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8443-5590-8f07-aba0" type="min"/>
+            <constraint field="selections" scope="roster" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b0-803e-a767-4c4e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="31fa-36ee-4fbe-a480" name="Raven Cloak Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ea67-a017-9735-6f24" name="Raven Cloak Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="22ad-e9de-21c4-dfa7" name="Raven Cloak Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="33.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="74a3-692f-428f-ff47" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d01a-cc68-63a5-6b6c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7771-c461-4e1a-fac2" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11a7-43f2-4446-042d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e794-e947-f2b5-c477" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="24c3-4461-446f-26e1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5230-31d2-908c-b727" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c39-b5ed-f50d-0fc5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="93b4-b6cb-be61-3697" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b048-4c28-5d56-58d9" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="24c3-4461-446f-26e1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5230-31d2-908c-b727" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d6c-dfbc-5bd7-f5ba" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cea6-3a92-f8bb-7bfc" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dbb9-afca-dd57-a827" name="Tower Guard" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="b647-fe27-65d5-39ce" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule"/>
+        <infoLink id="04ec-fc35-b9eb-186d" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="b183-0e63-d846-b13d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="8899-b34b-5bf1-5cf0" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="49a2-c222-d3d2-b171" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="37e1-9234-9d34-568b" name="Olaron" hidden="false" targetId="6cb3-a814-2fc8-25dc" type="rule"/>
+        <infoLink id="a518-b547-aaa0-3d61" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="e27c-1d1d-ed48-e25e" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bac0-ea38-768f-b861" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3def-c3a8-d6ee-60b4" name="Tower Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d11c-7862-7f59-54a9" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b719-a672-df78-dca0" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="d147-cfee-411a-70ba" name="Tower Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="eb6a-58f2-d008-9738" name="Tower Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1b90-5b68-019c-eb1f" name="Tower Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="796a-dcf5-b7da-6a0b" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="dbb9-afca-dd57-a827" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1656-69d2-8a34-58a0" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5d39-fedd-735f-cc9b" name="Banner Enchantment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="8376-4004-5b5f-fb30" value="2">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb78-a955-08a6-15a8" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8376-4004-5b5f-fb30" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="b600-de0b-7f51-d5d8" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="c33c-b66d-422a-3baf" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="0fb8-361b-f433-cc9e" value="2">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb78-a955-08a6-15a8" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <categoryLinks>
+                    <categoryLink id="9213-9ecf-d1ba-b587" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="1e3b-4280-3dfc-6d2c" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="c4ad-a5f3-a2ec-4d36" value="2">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fb78-a955-08a6-15a8" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <categoryLinks>
+                    <categoryLink id="e431-832a-1d07-844d" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="b7aa-75a1-f122-663b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ebd-a926-7921-5fa5" name="Dread Knights" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="056a-6984-f2f8-87dc" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ba30-daa3-bf40-04a3" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="bf7d-d284-0391-4ac4" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="2118-1309-2035-9e55" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="6114-ff58-6f72-fcf9" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="1532-b74c-01d2-ef72" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="5a9d-0a77-76fb-ddd4" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="de7a-5ed0-8fe2-d12d" name="Scent of Blood" hidden="false" targetId="061b-d5e1-3d70-4c82" type="rule"/>
+        <infoLink id="4547-96b9-73af-dd7b" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b3e2-de94-07bb-1a0b" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6d90-f249-1c57-5e2b" name="Dread Knight" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4e0-a511-5352-9dfd" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="76e3-dbbc-ec18-ef0c" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="6e6b-cc76-e9bf-3f30" name="Dread Knight Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3bf2-3587-59f3-a81a" name="Dread Knight Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2779-44c7-ef51-3462" name="Dread Knight Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="66f8-cc35-909f-cbc5" name="Raptor Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="48.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="805d-a035-aa53-eb12" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6ebd-a926-7921-5fa5" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cb3-9410-f7fe-f910" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="bd70-08c1-7667-d5fc" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88f2-2084-10d8-2f88" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="cc88-db5d-992c-409b" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="bcf5-4a30-0f77-a6f4" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="2ff1-6a98-ebbf-a89c" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3bdd-ccb2-8a07-1054" name="Raptor Chariot" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39e9-5d4e-aecd-273b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2eb5-ad0e-4e27-b11d" name="Raptor Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8c57-4685-e528-3748" name="Raptor Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e343-14b8-2cab-77de" name="Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1086-0b7a-842b-96ac" name="Raptor (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a4b4-a420-05fa-e4f2" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f3e8-bbca-9fed-7dd4" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="9f5a-c5e0-f4fa-c77c" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="ad99-ecdd-8d18-bb78" name="Repeater Crossbow (4+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+        <infoLink id="dc30-c14e-7a33-8366" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="6428-2e26-8c4e-bb47" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="887b-98e2-12c3-7e55" name="Scent of Blood" hidden="false" targetId="061b-d5e1-3d70-4c82" type="rule"/>
+        <infoLink id="36ee-00a9-8a20-97a8" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="975b-f290-b304-e218" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="be3e-b449-978e-0509" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b945-ca46-6750-da89" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="195.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2959-b157-0c5f-d8b4" name="Harpies" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="402b-f3b8-7d95-ae0d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ef11-1848-f57a-847e" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="0789-c16c-81ee-c719" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="437b-60ea-e8ad-8520" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="da16-1841-dd37-ab09" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="62f2-50f0-8024-1e4d" name="Harpy" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f048-ff78-95ff-4389" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e00b-9934-8dce-abd1" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="fa40-21b1-f39b-c997" name="Harpy Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot; (10&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot; (20&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="bf5a-2461-1ae4-1485" name="Harpy Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="64bb-a870-a50f-9b1a" name="Harpy Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="14.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f735-378c-1ce0-4d30" name="Dread Judges" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="8a3d-d9b4-a04e-23a0" name="Executioner&apos;s Blade" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+          <characteristics>
+            <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+            <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+            <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Attacks made with this weapon gain Lethal Strike and Multiple Wounds (2, against Standard).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="92aa-fca4-8d18-0d80" name="Nabh" hidden="false" targetId="e6b5-3659-76c8-7239" type="rule"/>
+        <infoLink id="4523-0107-fd2f-61d9" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="aa5f-ce95-3540-824d" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="9ee2-2cbd-b806-8fd9" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c75a-f1b5-94e5-65fb" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="67f2-bf43-0c86-51b5" name="Dread Judge" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="edec-c00e-4930-967f" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b39d-b854-3fcc-e53f" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="f83f-4f7f-46c9-55bb" name="Dread Judge Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a40a-1588-6ba7-8bac" name="Dread Judge Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0325-60af-4383-3459" name="Dread Judge Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="24.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="547f-f2c7-7845-6e49" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f735-378c-1ce0-4d30" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3067-26b7-00fb-4604" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="58b5-8e1f-5f66-797f" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ee7-1fab-08b9-d576" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ae28-4d0b-67bb-0678" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="3907-9270-cfec-1975" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8780-132f-4d39-fa10" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1f43-69a8-c175-3fad" name="Dancers of Yema" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="106d-e1cc-6f61-f14c" name="Gladiator Weapons" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+          <characteristics>
+            <characteristic name="Str" typeId="7d4e-b182-dd11-52a0"/>
+            <characteristic name="AP" typeId="646b-1e72-1589-5083"/>
+            <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains Weapon Master and Aegis (4+) against Melee Attacks. These weapons may be used as either Hand Weapon and Shield, Paired Weapons, Spear and Shield, Great Weapon, or Halberd.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fe78-cfc2-6a2e-55fa" name="Yema" hidden="false" targetId="2c7b-8229-318f-a763" type="rule"/>
+        <infoLink id="108c-080e-c695-fec7" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="46bd-630a-3a15-1728" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="0a85-7338-53ac-f4f9" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="0811-7dad-36db-2678" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f0a1-7a63-9fe5-9993" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="391d-e796-d822-3848" name="Dancer of Yema" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fdfb-bf43-eaa8-3ecf" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b9c-7774-fd1d-acbd" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="f0d2-38c9-396f-2134" name="Dancer of Yema Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3290-3a01-f6dc-9662" name="Dancer of Yema Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="29d0-7335-e9ab-629f" name="Dancer of Yema Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="22.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eb5a-c637-6eb2-0a5d" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1f43-69a8-c175-3fad" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e009-fd34-6e2b-3303" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d451-18de-c86f-bce4" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be5f-c884-628f-32f0" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9af9-999c-415e-57a2" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="1ff8-8be7-4cad-344c" name="DE Banner Enchantments" hidden="false" collective="false" targetId="1395-1a1a-49a0-9c1b" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b54b-876c-e7ae-ba30" name="Skirmisher" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1f43-69a8-c175-3fad" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="391d-e796-d822-3848" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="1f43-69a8-c175-3fad" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="391d-e796-d822-3848" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfcc-e97e-56cd-7216" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e0f-6527-33a9-f4d8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="10e5-865a-0430-ce61" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="e6ba-d362-1e30-a1de" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bcd3-b95a-f5c0-5244" name="Medusa" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bad7-2416-6442-3a0b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a394-44fd-f0ec-2d27" name="Medusa Offence" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0c38-a2ea-b3ed-e04b" name="Medusa Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6128-9fc5-8079-b7bb" name="Medusa Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a95d-a976-6d52-7f16" name="Petrifying Stare" hidden="false">
+          <description>The model can cast Deceptive Glamour from Witchcraft as a Bound Spell with Power Level (4/8).
+In addition, friendly Standard Size units with at least one Full Rank that are Engaged in the same Combat as one or more Medusas count as having an additional Full Rank for the purpose of Steadfast and Disrupted.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9498-6854-7d56-2fa2" name="Yema" hidden="false" targetId="2c7b-8229-318f-a763" type="rule"/>
+        <infoLink id="bdc3-6842-082a-c181" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="91bf-32f9-6f88-1081" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="9546-e3f0-0fd5-af75" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fbc9-7320-2acc-241a" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e352-f4be-0be8-76e8" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7b5b-542d-bcc2-456e" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e508-ef89-0014-5dbd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0a54-1d05-7848-515e" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f412-b645-6bb3-907b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5101-aabd-92a8-bb1c" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d117-9020-d39d-3141" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="82f2-e99e-c9fa-a5c8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f2b0-a4f3-bcc7-40f4" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="068d-721b-2af4-f099" name="Dark Acolytes" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e3b-fb07-28a5-e1bf" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ec2f-e334-685c-8933" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="97cc-152d-1082-9fdd" name="Wizard Conclave" hidden="false" targetId="7455-f914-028b-3359" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Altered Sight, Ice and Fire - Cosmology, Crippling Fatigue - Hereditary Spell)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="068d-721b-2af4-f099" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca13-2a8a-3cb9-cef5" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="name" value="Wizard Conclave (Pentagram of Pain, Breath of Corruption, The Grave Calls - Occultism)">
+              <conditions>
+                <condition field="selections" scope="068d-721b-2af4-f099" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf8e-712b-8642-7c54" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="15b9-032d-25f9-f517" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8ba7-3bbe-9fb3-fc5b" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="77bd-e222-179a-7db7" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="e1c9-ead1-2a7f-c8c2" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="5ff0-ce18-f238-dace" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ec87-77fe-288d-e587" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="efd0-9602-e8f9-7887" name="Dark Acolyte" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f3c-d69a-9bc3-bdb2" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4188-1ba5-73f4-1478" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2fb3-050e-3501-a1d8" name="Dark Acolyte Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="818c-a583-2094-25be" name="Dark Acolyte Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="abfa-1617-5487-762e" name="Dark Acolyte Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="dd4e-9a20-5a5f-dff2" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ca13-2a8a-3cb9-cef5" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b0e-bac3-0068-689f" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cf8e-712b-8642-7c54" name="Cult of Yema" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="068d-721b-2af4-f099" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="efd0-9602-e8f9-7887" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="48f2-fd78-4c91-11bb" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="25c6-47a8-8657-3c09" name="Yema" hidden="false" targetId="2c7b-8229-318f-a763" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab5c-9542-314b-8887" name="Divine Altar" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5fd-b9b1-1fe1-a87b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="04b7-863a-7767-3d08" name="Divine Altar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f51b-f0d6-b746-6ec4" name="Divine Altar Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8ff4-d626-7889-bd09" name="Disciple (3) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0f0d-4c9c-6d2e-7725" name="Avatar Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cb0b-d302-ae9e-719d" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="cb9e-252f-bb4b-5913" name="Divine Blessings" hidden="false">
+          <description>All friendly units within 12&quot; of a Divine Altar gain Aegis (6+). At the beginning of each friendly Player Turn, you may choose to replace the Aegis with one of the following effects until the start of your next Player Turn:
+
+- All friendly units within 12&quot; of the Divine Altar are subject to Maximised Roll when rolling for charge range.
+- All friendly units within 12&quot; of the Divine Altar at the beginning of their initiative step gain Death Trance.
+
+Models with Towering Presence other than the Divine Altar cannot benefit from Divine Blessings. A single unit can only be affected by a single Divine Blessing from a single Divine Altar at any time. If under the influence of more than one Blessing, only apply the most recently used one.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9474-6bf1-808d-f8a1" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="2ca8-a4e8-71d6-8317" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="bf97-f39b-6320-51ad" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="2db0-a3e7-e268-424a" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="099a-581e-00c2-4c14" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="3498-38af-b7bc-2f02" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="8334-2b87-d160-824a" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="b9cb-ab02-c4b7-63a0" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="2970-0c34-1f9c-0115" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="271c-049c-bcb9-fd2c" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5e74-4427-ab8d-8b12" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1d53-f53a-eb86-3061" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8724-83e8-99a8-4682" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1d3a-1948-2861-22a5" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c00b-627e-4640-10c5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="829f-4b43-3948-4c9d" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d261-18c8-84aa-3967" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ac0-088a-6f97-3b3d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5648-4066-1d37-be03" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="385.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="41f1-3cf4-27ca-d38a" name="Hunting Chariot" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="4ca9-779a-1c09-60bd" name="Hunting Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5e00-37ee-e599-5451" name="Hunting Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6cbb-1e3b-07be-f4e8" name="Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e425-9819-a935-cdd7" name="Elven Horse (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="91a8-63f0-e296-8526" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e027-2c55-c618-dff1" name="Harpoon Launcher (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">7</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Lethal Strike, Quick to Fire, Accurate, Reload!, Multiple Wounds (D3, Clipped Wings), Harpooned​.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="379c-d81a-3266-cea1" name="Harpooned" hidden="false">
+          <description>A model with Towering Presence that has lost one or more Health Points due to an attack with this Attack Attribute suffers -2 Advance Rate, -4 March Rate, and lose Fly until the end of the next Player Turn.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8899-1e9b-2962-9886" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="3e87-880d-73d2-05ab" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="1811-9aeb-ea5a-6187" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="ff47-a483-4d05-ca15" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="9372-2f83-e112-601d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="435c-dd12-d739-5cb4" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="7337-58fe-0212-cc23" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="42d0-387a-5573-5b61" name="New CategoryLink" hidden="false" targetId="2611-7f11-a4ea-5807" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c53-b497-1c21-c8bf" name="Dread Reaper" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dac6-3a6d-7cf7-cabf" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f901-eb4d-a28c-a310" name="Dread Reaper Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">5&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9337-e9b9-a361-84e9" name="Dread Reaper Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0b2e-e69d-2c5e-a133" name="Dread Reaper Crew" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0b12-c170-8644-b4da" name="Elven Bolt Thrower" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [6]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Bolt Thrower Artillery Weapon, [Multiple Wounds (D3)]</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f753-a817-34b3-6046" name="Elven Bolt Thrower" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">6</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e6d1-f880-98b8-d68f" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="a924-5815-45e4-617b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="9fbb-eb03-cf95-d0be" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="ada2-2344-40db-9616" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fd5a-3c8e-f32b-be2a" name="Destroyers (local)" hidden="false" targetId="2611-7f11-a4ea-5807" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc07-1764-3400-fdd4" name="Kraken" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f166-10ba-4671-0c4a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="50c7-18dc-1300-aa02" name="Kraken Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="58fe-e494-2efa-8af4" name="Kraken Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0502-eb73-1342-ec86" name="Kraken Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="26ae-a60d-396b-2c99" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="814b-08ee-8bc6-5a3f" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="9e11-fb15-a733-aa7f" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="13e1-1154-dce8-209d" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ac4a-e6db-688e-e49c" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3fa1-4aaa-1a82-2a78" name="New CategoryLink" hidden="false" targetId="3a14-99d4-8059-140f" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="390.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4b0e-bb5c-37f4-c693" name="Hydra" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="358a-860f-43a1-1ec0" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c4cb-8a97-ab65-b6e1" name="Hydra Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d623-3309-8dba-167c" name="Hydra Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="af6a-39c2-ec15-39f5" name="Hydra Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">7</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ea46-a008-453e-3547" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e2c0-eaf2-e064-fc8b" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP 1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="588c-d7e2-49bb-6f92" name="New CategoryLink" hidden="false" targetId="3a14-99d4-8059-140f" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="6f48-ba88-921e-d57e" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d7a-d54a-b25e-8270" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="032d-bc87-cbbe-562f" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b31-0623-a0e7-8e37" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d69c-8d95-85f1-50c1" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="4192-f0c7-073d-6e5e" name="Cult General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16e5-1caa-d7be-f98e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="8e2a-490a-cf8a-8802" name="Cult General" hidden="false">
+              <description>If the General belongs to a Cult and the Army List does not include any models from any other Cult, then all Dread Legionnaires, Repeater Auxiliaries, and Corsairs gain the same Cult rules as the Army’s General.
+</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5609-d54a-df64-b200" name="Army Cult" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4192-f0c7-073d-6e5e" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="1071-4441-33cb-0164" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4192-f0c7-073d-6e5e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="60db-79f7-2e60-9244" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1071-4441-33cb-0164" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a473-4c6c-a815-9494" name="Nabh" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c676-27c9-9a51-35b3" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fc46-ad3c-1744-e467" name="Nabh" hidden="false" collective="false" targetId="1925-f536-3a8f-2333" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="52b9-785d-868c-7ccf" name="Yema" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3266-6244-2c38-ee34" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="837e-8633-c42f-73c9" name="Yema" hidden="false" collective="false" targetId="15ad-bd81-b47b-b029" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="085e-e665-bf32-6e2b" name="Cadaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f7b-2006-39df-b0ef" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8532-e094-32b8-f7d2" name="Cadaron" hidden="false" collective="false" targetId="957d-879f-c8bb-d5e5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fb78-a955-08a6-15a8" name="Olaron" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c4b-6074-07e1-a778" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6479-adb4-dec6-307f" name="Olaron" hidden="false" collective="false" targetId="6c06-8f39-e8d1-b8e8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e4b9-e402-ef35-fe5e" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7522-1ae4-29fd-b273" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e841-6180-dc57-297a" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7e68-7274-d521-0ed7" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1925-f536-3a8f-2333" name="Nabh" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e485-fdb7-aad3-1444" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0074-5f92-52d9-db47" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="50c2-1b0f-967b-bd66" name="Nabh" hidden="false">
+          <description>The model gains Cult Rivalry.
+The model part gains Hatred and loses Killer Instinct if it had it.
+</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c06-8f39-e8d1-b8e8" name="Olaron" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f09-63c4-abda-642f" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1972-2c95-d0cd-9dc8" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="ca7e-1ff4-76a2-91b6" name="Olaron" hidden="false">
+          <description>The model gains Cult Rivalry.
+The model gains +1 Discipline. If the model&apos;s Discipline would be more than 10 after all modifiers are applied and it was not borrowing discipline from a model with Commanding Presence, all Discipline tests taken by the model&apos;s unit are subject to Minimised Roll instead of gaining +1 Discipline.
+</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="957d-879f-c8bb-d5e5" name="Cadaron" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ae6-515f-b5b8-5cd0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ad7-3232-d112-dcec" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="3eea-4279-bf89-fe2d" name="Cadaron" hidden="false">
+          <description>The model gains Cult Rivalry.
+Shooting Attacks made by the model part gain +1 to hit when shooting from Short Range. A model part with Cult of Cadaron and a Shooting Weapon loses Killer Instinct if it had it.
+
+</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15ad-bd81-b47b-b029" name="Yema" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b14d-434d-e9b0-e060" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="de96-b09a-b350-4633" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="3a47-fc52-c1ce-12fc" name="Yema" hidden="false">
+          <description>The model gains Cult Rivalry, Strider, +1 Advance Rate, and +2 March Rate (this also affects mounts). The model part loses Killer Instinct if it had it.
+
+</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c0d0-20bc-f556-468f" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7cb9-e3af-ba90-3506" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="523a-2737-d26d-6046" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8b82-ecb0-2042-1838" name="Elven Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="35ba-883b-dad6-cb81" name="Elven Horse Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="597b-8735-3dd1-0e70" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e165-7186-1872-5e61" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7c7c-6893-493b-53b1" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fcc3-3f42-b352-d4d7" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="e165-7186-1872-5e61" name="Light Troops and -1 Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3e4-5b7b-bd6e-968a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0bfb-30e0-6fda-3aa7" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="446e-db97-cb10-4d83" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1d2-1439-a2b8-d8ec" name="Raptor" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f8f-c2e1-ba4d-d251" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcbb-9a06-01e8-1c6c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2fff-528c-5074-9236" name="Raptor Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0650-d924-32a7-e122" name="Raptor Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ae82-7dd7-3892-0b73" name="Raptor Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="16cc-26b9-76a7-707a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="8a68-fd6a-6d90-b5fc" name="Scent of Blood" hidden="false" targetId="061b-d5e1-3d70-4c82" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1182-69a3-0773-e51e" name="Pegasus" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef45-480d-7de2-9ff0" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5b7-560b-024c-8a27" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fadc-4865-c5cf-63f1" name="Pegasus Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b05c-8ae7-ad5e-1ef7" name="Pegasus Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3265-6e38-36b7-a2a4" name="Pegasus Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3f1f-a4fc-1f52-df87" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="e35b-f354-3cbd-4639" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="6b31-9d75-e1e3-198d" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5465-f1c8-ada2-b24c" name="Raptor Chariot" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d1a-6472-f5e4-3619" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da66-5d9b-f40a-5746" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="1258-71aa-8835-ea20" name="Raptor Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="15e7-161d-ecf2-befc" name="Raptor Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cb00-e97e-534b-5b0a" name="Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="538e-9566-320d-ec2e" name="Raptor (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d284-b631-4c3c-3b2d" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3e9e-6f99-680e-37de" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="3395-adb4-c9c5-54db" name="Scent of Blood" hidden="false" targetId="061b-d5e1-3d70-4c82" type="rule"/>
+        <infoLink id="ca65-bb3c-d2d4-a204" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="6c5f-a7ca-6b21-998b" name="Repeater Crossbow (4+)" hidden="false" targetId="3018-73dd-db99-f8e4" type="profile"/>
+        <infoLink id="ef16-63a7-6c57-b42f" name="Killer Instinct" hidden="false" targetId="e599-edc2-acea-74ec" type="rule"/>
+        <infoLink id="d995-58f5-490c-3e9e" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="a16c-19ec-1f83-18d5" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="2207-b10c-d70d-1912" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="b5f3-7f29-3add-1688" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b9e4-b91d-d874-f3c5" name="Manticore" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="843d-d7fb-81a8-975b" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8a4-f94a-bed9-1494" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3cf6-b730-1688-5572" name="Manticore Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4ec0-0553-0184-278c" name="Manticore Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5dd1-1c16-6f81-66c6" name="Manticore Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a48e-13a6-7c33-2f70" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="b0a9-08db-0aa5-156c" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="9a27-29a4-6833-ac08" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="e250-e3d6-6c04-89f0" name="Scent of Blood" hidden="false" targetId="061b-d5e1-3d70-4c82" type="rule"/>
+        <infoLink id="04e2-cca0-a6c8-2da0" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="f6e3-8c66-2b16-5b8e" name="Death Trance" hidden="false" targetId="aa0d-8237-bae5-fee5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="409d-6c5e-5489-d2cd" name="Dragon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="285c-477d-a423-8c49" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d8c-ae9d-673c-a158" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9562-017f-aa75-68f9" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="8f95-3ea0-b34f-7e25" name="Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5a98-8caa-a2ff-c1b1" name="Dragon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="95a1-9b0a-68d4-2437" name="Dragon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2602-500a-7bf4-a302" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="bcb4-1ee2-5a86-f62a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="e957-efd2-e505-6239" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP 1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5298-cbec-35c4-6f30" name="Fleet Commander" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e527-864a-132c-885d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78d0-76c7-f7d9-b820" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="7cbc-441d-4afe-9539" name="DE Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f500-f76e-b2e1-8d33" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2051-8a95-214b-1c7c" name="Death&apos;s Kiss - Models on Foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e7f-b7b7-7a5b-13da" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ebce-d9d6-4a57-b509" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="62aa-88a7-cbd5-5633" name="Death&apos;s Kiss" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Great Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain +1 Strength, +1 Armour Penetration, Magical Attacks, and Multiple Wounds (2). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="358d-7724-2dcc-7317" name="Transcendence" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e9e-ac2b-2116-87c6" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dde5-209f-fe1f-a63d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cc02-355a-e7b0-de94" name="Transcendence" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon, Paired Weapons, Halberd and Lance Enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Lethal Strike and Magical Attacks. For every unsaved wound inflicted by attacks made with it, the wielder gains +1 Strength and +1 Armour Penetration for the remainder of the game, to a maximum of +2 each.  </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fea0-b307-730c-d8f9" name="Moraec&apos;s Reaping" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c53-db0d-62ab-fdab" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f71-1f6b-20c1-b793" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d4e8-308a-eb0a-a7e6" name="Moraec&apos;s Reaping" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon and Paired Weapons enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder always has at least Attack Value 4. Attacks with this weapon gain Magical Attacks, Death Trance, and always ​have at least Strength 4 and at least Armour Penetration 3. For each unsaved wound inflicted with this weapon, the owner gains one Veil Token.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b805-a822-8da5-929e" name="DE Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="cb5e-37fb-b7de-d58a" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb5e-37fb-b7de-d58a" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="4935-a9cd-150a-129c" name="Seal of the Republic - Models on Foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e4f-4656-0649-ad87" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ae8-ff91-75d2-2fdf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5870-1b7f-e724-399e" name="Seal of the Republic" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Heavy Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">For each unsaved wound inflicted by the wearer’s Close Combat Attacks, the wearer gains +1 to its Armour for the remainder of the game.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1281-b571-98fb-f594" name="Terrifying Visage" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2997-69ea-e35a-4551" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d7c-4e37-3b5c-4ba7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7757-1235-56a3-34ad" name="Terrifying Visage - Standard size only" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Distracting while using this Shield.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="ce96-6ddd-2e3f-9ebd" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="94d1-de93-b133-3e3d" name="DE Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68f3-da1e-0a1e-f784" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="67f2-6caf-f4b2-1378" name="Midnight Cloak" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2df4-27fc-b77f-5e8c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1a5-c113-d0ab-3ad9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a9dd-60f6-d1ac-65fc" name="Midnight Cloak" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains Devastating Charge (Multiple Wounds (D3)) and Aegis (3+) against Ranged Attacks. Cannot be taken by models with Towering Presence.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1001-5ebe-07e2-4877" name="Amulet of Spite - Wizards only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="acb4-0670-5aef-2567" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8462-1c40-8bee-4442" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1717-f36e-cd4e-f573" name="Amulet of Spite" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">In each friendly Magic Phase, after drawing a Flux Card, the owner gains an additional Magic Dice. In each of the opponent’s Magic Phases, after drawing a Flux Card, the owner must discard a single Magic Dice. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="60ab-0ff7-41f3-3de7" name="Pendant of Disdain" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fcf0-587c-1e8d-645d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16ee-95b1-97ed-421f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="28c3-4bf6-ac7e-ba3a" name="Pendant of Disdain" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (4+, against Strength 5 or more).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4ad1-ae59-b647-221b" name="Beastmaster&apos;s Lash" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="481f-2ba4-2397-bb68" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdcc-3983-23ca-a9bf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4077-c6d8-6fca-5c07" name="Beastmaster&apos;s Lash" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The roll for determining the number of hits from stomp attacks of friendly Gigantic models within 12&quot; of the bearer is subject to Maximised Roll. The roll for determining the number of hits from Stomp attacks of enemy Gigantic models within 12&quot; of the bearer is subject to Minimised Roll.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b9f0-fa4f-a782-0640" name="Ring of Shadows" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f57-6ff9-4c63-13ae" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64e4-73bc-5842-b0ce" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b97a-f1b6-ea11-8ebc" name="Ring of Shadows" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If the bearer&apos;s unit consists of entirely Standard Size models, - All models in the unit gain Hard Target. - Close Combat attacks allocated towards models in the bearer&apos;s unit suffer -1 Offensive Skill.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="90be-51cc-1f8c-f803" name="Wandering Familiar - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03be-fb12-04be-924b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39da-6fc6-6908-3b07" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5397-8815-44d0-f6d5" name="Wandering Familiar" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of each friendly Magic Phase, you may place a familiar counter with a 20x20mm base within 6&quot; of the bearer. This familiar acts (and is subject to the same restrictions) as a model of Standard Size for the purpose of drawing Line of Sight. It must be placed more than 1&quot; away from other models and from Impassable Terrain. Once it is placed, the player must declare which Facing of the familiar is its Front Facing. Whenever the bearer casts a non-Bound Spell, they may choose to use the position of their familiar when drawing Line of Sight, measuring Range and determining Front Arc (they must use all of these or none at all). At the end of the Magic Phase, the familiar is removed. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3eb5-135e-cba9-0fbc" name="Elixir of Shadows - Assassins only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a26e-7b6b-3cf7-0c18" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d1c-8a88-edef-d523" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5239-e205-75c7-46a2" name="Elixir of Shadows" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any Round of Combat. Until the end of the phase, the bearer gains Divine Attacks and must reroll failed to-wound rolls with its Close Combat Attacks. At the end of the phase, the bearer loses 1 Health Point (with no saves of any kind allowed). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1395-1a1a-49a0-9c1b" name="DE Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c4ad-a5f3-a2ec-4d36" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d8d7-3d24-646c-4383" name="Banner of Gar Daecos - Cannot be taken by Core units" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5db-5370-52fc-d457" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac9c-ce9e-b1b8-f023" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="aea0-c82e-20ef-9619" name="Banner of Gar Daecos" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">All friendly units Engaged in the same Combat as the bearer gain Death Trance.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3686-e125-70b4-795b" name="Banner of Blood" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6125-afe1-735b-b9e9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7ba-562d-7ec8-48fc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cb5a-7e8b-ddf9-ff95" name="Banner of Blood" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Model parts without Harnessed in the bearer&apos;s unit gains Devastating Charge (+1 Att).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7171-67ac-3e5a-19a8" name="Academy Banner - Dread Legionnaires, Repeater Auxilliaries and Corsairs only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d197-ef9b-36d7-12bf" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81a8-176c-7acb-5f94" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9062-a526-819c-36bc" name="Academy Banner" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">R&amp;F models in the bearer&apos;s unit gain +1 AP in the first round of combat. Dread Legionnaires, Repeater Auxiliaries, and Corsairs in units within 6&quot; of one or more other unit with Academy Banner gain +1 AP in the first round of combat.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="e599-edc2-acea-74ec" name="Killer Instinct" hidden="false">
+      <description>The Attack must reroll natural to-wound rolls of ‘1’.</description>
+    </rule>
+    <rule id="aa0d-8237-bae5-fee5" name="Death Trance" hidden="false">
+      <description>The attack gains +1 to wound during the first Round of Combat. Close Combat Attacks from models with more than one instance of Death Trance gain +1 to wound during all Rounds of Combat instead.
+</description>
+    </rule>
+    <rule id="061b-d5e1-3d70-4c82" name="Scent of Blood" hidden="false">
+      <description>The model gains Frenzy while Engaged in Combat.</description>
+    </rule>
+    <rule id="f6c5-ccad-f5bd-c65f" name="Fleet Commander" hidden="false">
+      <description>The model gains Kraken’s Hide. For each Character with Fleet Commander in the Army,
+a single unit of Corsairs may be upgraded with Vanguard.</description>
+    </rule>
+    <rule id="7806-170b-a2b2-c7da" name="Beast Master" hidden="false">
+      <description>Discipline Tests of all friendly Hydras and Krakens within 12&quot; of one or more Characters with Beast Master are subject to minimised roll.
+At the start of each Melee Phase, choose one friendly Hydra, Kraken, or Manticore (rider is unaffected) within 12&quot; of the Beast Master. This model part must reroll failed to-hit rolls with its Close Combat Attacks during this phase.</description>
+    </rule>
+    <rule id="bc9a-dc9a-996b-c13a" name="Cult Rivalry" hidden="false">
+      <description>A model can never belong to more than one Cult. Characters belonging to a Cult
+cannot join units which contain any model from another Cult.</description>
+    </rule>
+    <rule id="b1da-1f0c-f7fc-7b0a" name="Cadaron" hidden="false">
+      <description>The model gains Cult Rivalry.
+Shooting Attacks made by the model part gain +1 to hit when shooting from Short Range. The model part loses Killer Instinct if it had it.
+
+</description>
+    </rule>
+    <rule id="e6b5-3659-76c8-7239" name="Nabh" hidden="false">
+      <description>The model gains Cult Rivalry.
+The model part gains Hatred and loses Killer Instinct if it had it.
+</description>
+    </rule>
+    <rule id="6cb3-a814-2fc8-25dc" name="Olaron" hidden="false">
+      <description>The model gains Cult Rivalry.
+The range of Commanding Presence from a model with Cult of Olaron to units with at least half their models with Cult of Olaron is always​ ​18&quot;.
+</description>
+    </rule>
+    <rule id="2c7b-8229-318f-a763" name="Yema" hidden="false">
+      <description>The model gains Cult Rivalry, Strider, +1 Advance Rate, and +2 March Rate (this also affects mounts). The model part loses Killer Instinct if it had it.
+
+</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="f691-8c07-03fd-0ae6" name="Kraken&apos;s Hide" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">None</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+1 / +2</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">If mounted, the wearer gains +1 Armour. If on foot, the wearer gains +2 Armour.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3018-73dd-db99-f8e4" name="Repeater Crossbow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582"/>
+      </characteristics>
+    </profile>
+    <profile id="3ace-a562-4861-7210" name="Repeater Handbow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire. This weapon can be used even if the model performed a March Move earlier this Player Turn.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/dwarvenHolds.cat
+++ b/dwarvenHolds.cat
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="041b-e72b-1f30-5a89" name="Dwarven Holds 2.0" revision="18" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="041b-e72b-1f30-5a89" name="Dwarven Holds 2.0" revision="19" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="1101-0d1e-0830-2bbb" name="Clan&apos;s Thunder (local)" hidden="false"/>
-    <categoryEntry id="d027-973a-954e-3377" name="Engines of War (local)" hidden="false"/>
+    <categoryEntry id="1101-0d1e-0830-2bbb" name="Clan&apos;s Thunder" hidden="false"/>
+    <categoryEntry id="d027-973a-954e-3377" name="Engines of War" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="1332-e68c-203e-bad0" name="Dwarven Holds (local)" hidden="false">
+    <forceEntry id="1332-e68c-203e-bad0" name="Dwarven Holds" hidden="false">
       <categoryLinks>
         <categoryLink id="45bc-7422-fc6d-fa57" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>

--- a/dwarvenHolds.cat
+++ b/dwarvenHolds.cat
@@ -1,0 +1,3954 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="041b-e72b-1f30-5a89" name="Dwarven Holds 2.0" revision="18" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="1101-0d1e-0830-2bbb" name="Clan&apos;s Thunder (local)" hidden="false"/>
+    <categoryEntry id="d027-973a-954e-3377" name="Engines of War (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="1332-e68c-203e-bad0" name="Dwarven Holds (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="45bc-7422-fc6d-fa57" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="e9b2-b24c-ee42-564e" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d6e6-4b56-be4e-a741" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="4313-53d0-e980-e47c" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="ceba-2f9c-91d2-0d49" name="Clan&apos;s Thunder (local)" hidden="false" targetId="1101-0d1e-0830-2bbb" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="031d-7395-a22c-d8fb" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="db84-a783-d6e4-57a9" name="Engines of War (local)" hidden="false" targetId="d027-973a-954e-3377" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="37d5-6490-2b9a-f23b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="033c-09c2-064f-1717" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="e197-83e0-bb7b-35be" name="King" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="5e15-a593-679a-1051" name="King Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e954-d86e-718a-fdcd" name="King Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="452b-8522-d555-118c" name="King Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7998-6097-75af-c9f1" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="bd21-b967-9b8b-9100" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="2a49-aee5-2632-33fe" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fb98-664f-729a-3483" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4979-45c3-0009-3afd" name="Runic Items" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39b5-7bcf-ad39-a648" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a975-ca4d-7857-8ab4" name="Runic Items" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e16f-dd62-b197-bb21" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e18c-6d96-4b15-26e2" name="Armour Runes" hidden="false" collective="false" targetId="cafc-e06c-3df7-5651" type="selectionEntryGroup"/>
+                <entryLink id="6d24-483f-69f9-9a50" name="Talismanic Runes" hidden="false" collective="false" targetId="2163-4457-52a1-d323" type="selectionEntryGroup"/>
+                <entryLink id="0b5c-03e2-e0c6-98fa" name="Weapon Runes" hidden="false" collective="false" targetId="b35f-5d0c-dc14-7725" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f328-2080-4661-6a74" name="Holdstone" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ce-6c6e-9f55-9f83" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="22eb-0aaf-0117-714e" name="Holdstone" hidden="false" targetId="0bef-02bf-bec5-e90f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="80ca-c905-c5df-da2f" name="Ancestral Memory" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b2a-88ab-99be-3be9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28aa-89ca-f8aa-27bb" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cfd5-ee52-43cd-12e5" name="Ancestral Memory" hidden="false" targetId="ee37-8a5e-19e2-d60c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c3cf-ef27-1bfc-6a99" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb56-4346-c23e-98a2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c107-c18d-0008-b79a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="70bc-3a12-1756-0172" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cbf-47ee-1a56-31a9" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="dd0f-2214-4f13-d417" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6316-a7b1-b07b-423e" name="Rune of Resonance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c13a-db58-99bd-df8d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="80b6-6a53-c84f-87ed" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ff9-c69e-dd0f-4b63" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bbab-13ec-a466-76b7" name="Pistol (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d81e-2dcc-3198-457b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3f33-7284-16e7-4911" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="93ad-25d3-6f62-a9aa" name="Guild Crafted Handgun (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27d7-5de8-8bb5-2ddc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="eed8-030f-7792-01a2" name="Guild Crafted Handgun" hidden="false" targetId="54b3-c31f-62e9-c8b8" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d312-5063-1552-ea65" name="Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5029-47ed-637e-7fa2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8fa3-4935-220e-83e2" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fe48-a4a6-a4d1-9d7a" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d953-f992-cb07-6703" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="768c-f0a1-942a-835b" name="Shield Bearers" hidden="false" collective="false" targetId="6dc5-a7b2-9231-8851" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="20"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="456b-1d10-8f75-7d94" name="War Throne" hidden="false" collective="false" targetId="06e9-e094-a2d1-b804" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8b2a-88ab-99be-3be9" name="Army General" hidden="false" collective="false" targetId="b8ed-4f27-6198-28bb" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9625-ede6-a9d4-bacb" name="Thane" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="53f1-fc70-fd03-6db6" name="Thane Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6e3a-0eca-7dd0-58be" name="Thane Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="312f-ad12-3462-809d" name="Thane Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9b37-4a61-f64b-7c7e" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="89a9-ca7d-53a3-4199" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="3176-a48e-20ba-d002" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="15ed-afe4-5990-9a17" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0f63-71fc-250f-d976" name="Runic Items" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af19-bb78-52f3-c81e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="55e9-68ee-83d9-3ff2" name="Runic Items" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0d5-8ae1-d1e7-43ce" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="da37-c0b7-de55-f8f5" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="9625-ede6-a9d4-bacb" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd73-483a-7e65-8399" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f57c-3347-6658-bee9" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="aac4-3dae-2c29-2c55" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="f8cb-1864-586a-d543" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="1b8d-7c10-81e2-47d7" name="Armour Runes" hidden="false" collective="false" targetId="cafc-e06c-3df7-5651" type="selectionEntryGroup"/>
+                <entryLink id="58ca-6db3-9b75-e4d8" name="Talismanic Runes" hidden="false" collective="false" targetId="2163-4457-52a1-d323" type="selectionEntryGroup"/>
+                <entryLink id="6c74-b22f-99bd-c31e" name="Weapon Runes" hidden="false" collective="false" targetId="b35f-5d0c-dc14-7725" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0f0b-9649-82ff-be2f" name="Holdstone" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0d4-c86e-4d36-94d1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="11a0-df0b-d8f7-b821" name="Holdstone" hidden="false" targetId="0bef-02bf-bec5-e90f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd25-0ffc-11ce-da17" name="Ancestral Memory" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9a34-1eaa-a265-24ba" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e81-d1bd-b663-c600" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d7e9-ef20-e4f8-6e6f" name="Ancestral Memory" hidden="false" targetId="ee37-8a5e-19e2-d60c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5bec-3981-2620-b5c5" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b68f-3593-6bb5-0915" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9e61-463d-ac64-fc86" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="449a-881a-436c-464c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c407-4dcd-0272-6c93" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4526-ad2d-7420-75c3" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2fab-c8be-d168-4af4" name="Rune of Resonance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d837-b5d5-40bd-3bd5" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5904-f9ec-6bd7-9508" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="726c-ed83-b76f-a377" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bd35-2f82-eee0-4650" name="Pistol (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e1c-1043-d597-2830" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5cf3-bff2-ba14-c949" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fa39-9194-1dca-171c" name=" Guild Crafted Handgun (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25d2-289f-11d8-f1ca" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3558-59cf-31b4-6ce4" name="Guild Crafted Handgun" hidden="false" targetId="54b3-c31f-62e9-c8b8" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2168-a672-39fc-dd44" name="Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f53f-6d84-ea0a-2602" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d331-7286-35b3-a0cf" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9a34-1eaa-a265-24ba" name="Army General" hidden="false" collective="false" targetId="b8ed-4f27-6198-28bb" type="selectionEntry"/>
+        <entryLink id="aa32-3e53-15ed-d86d" name="Battle Standard Bearer" hidden="false" collective="false" targetId="bd73-483a-7e65-8399" type="selectionEntry">
+          <categoryLinks>
+            <categoryLink id="e30d-8d15-1e0c-4eb1" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+        <entryLink id="5af0-e074-dd6c-2f67" name="Shield Bearers" hidden="false" collective="false" targetId="6dc5-a7b2-9231-8851" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fe50-8d84-dc2a-a9d5" name="Dragon Seeker" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="a1c3-223d-738d-0bf8" name="Dragon Seeker Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1959-1cb5-e100-55cc" name="Dragon Seeker Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a8e2-8c5f-6cc5-4ddf" name="Dragon Seeker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b9d5-f537-3cef-23b6" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="626b-c699-f634-6da8" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="2bbd-5d3d-9f59-27af" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="d213-cf4c-0d5c-cd78" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a291-b0f2-d291-b211" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3cf8-9f8b-a7a5-3733" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="13cc-2206-fc58-cdbb" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+        <infoLink id="f0b0-ed68-2c54-6c98" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="d22c-5455-cc52-7c7d" name="Yer comin&apos; with me!" hidden="false" targetId="d49d-b447-96aa-51d3" type="rule"/>
+        <infoLink id="2e2e-7c07-cb11-f8b1" name="The bigger they are..." hidden="false" targetId="43a8-01e9-7da5-0c42" type="rule"/>
+        <infoLink id="df88-9452-f6fb-26ec" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="34b7-7bb0-d0b8-db2c" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="aedd-98d5-121a-741f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="412a-99ac-df4b-f742" name="Weapon Runes" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f17b-3f4a-0ac5-f129" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="99e7-5e20-b2c6-7591" name="Weapon Runes" hidden="false" collective="false" targetId="b35f-5d0c-dc14-7725" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8efc-a451-e3f6-cd3f" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ad13-4cf5-c3ac-4476" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3407-47ce-8fa0-6d58" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7dcc-75f5-461d-b7f0" name="Monster Seeker" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9997-219d-239e-0a96" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="592a-f290-e7e7-68ec" name="Monster Seeker" hidden="false">
+                  <description>The model gains Multiple Wounds (2, against Large, Gigantic).</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5c5d-6d84-50a9-b8fd" name="Grim Resolve" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="252f-0333-9b9e-0b2a" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="6823-f59b-9430-5940" name="Grim Resolve" hidden="false">
+                  <description>The model gains +1 Attack Value for each enemy model in base contact with it.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1c61-881c-5a78-f58d" name="Runic Smith" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd28-736f-8301-e93d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7f06-8021-67ba-9224" name="Runic Smith Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9f4c-906c-51e3-686d" name="Runic Smith Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a516-94f8-cba5-a9ba" name="Runic Smith Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="cd2c-69b6-8f66-90c6" name="Rune Craft Mastery" hidden="false">
+          <description>All model parts in the same unit as a model with Rune Craft Mastery gain +1 Armour Penetration on their Close Combat Attacks. 
+Each Runic Smith may select up to three different Battle Runes during Spell Selection, provided it payed for them.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f804-8054-863d-b90c" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4e12-96d7-48cc-830c" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ee3c-bc1c-0520-ebed" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="6c83-9a03-88a1-0295" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="2043-190f-fbd8-1190" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="995b-2261-aefd-fca4" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9460-ced2-009e-f4bb" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5da4-e3c3-0749-c465" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a4b8-b88f-f53f-e6d0" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9f2b-e233-1ccb-194f" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="924b-a577-d328-4a0c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="39fd-4c91-e231-1207" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2544-427b-1bdd-ce61" name="Ancestral Memory" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8ed-4f27-6198-28bb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a6c-d0f4-f208-fbba" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8845-66eb-735a-6f4b" name="Ancestral Memory" hidden="false" targetId="ee37-8a5e-19e2-d60c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cd84-124e-a173-d13e" name="Runic Items" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77f9-bb85-3d6b-a9d9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="663d-43f0-7110-d305" name="Runic Items" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="992a-4f19-0301-7f78" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b9dd-9e75-b80b-3694" name="Armour Runes" hidden="false" collective="false" targetId="cafc-e06c-3df7-5651" type="selectionEntryGroup"/>
+                <entryLink id="4ed3-c920-1b93-231f" name="Talismanic Runes" hidden="false" collective="false" targetId="2163-4457-52a1-d323" type="selectionEntryGroup"/>
+                <entryLink id="6c5c-0449-beab-cf94" name="Weapon Runes" hidden="false" collective="false" targetId="b35f-5d0c-dc14-7725" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aa1a-736f-a557-996b" name="Battle Runes" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d08-3f5c-36d5-4db6" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bbe9-ff3e-b1e7-2430" name="Rune of Resonance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="26f3-39e6-dae5-74db" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8980-dfaf-2156-4163" name="Army General" hidden="false" collective="false" targetId="b8ed-4f27-6198-28bb" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5ea1-9ad7-19cb-d835" name="Engineer" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe9-7e18-9dfb-2f20" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5ac3-a272-04d4-3b59" name="Engineer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="648c-0163-d5c9-eba4" name="Engineer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e471-7232-514c-3f7e" name="Engineer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a652-a4a6-86cc-44f7" name="Entrench" hidden="false">
+          <description>Right before the battle (during step 7 of the Deployment Phase Sequence), a model with this rule may Entrench a single War Machine. The War Machine counts as being in Hard Cover. The War Machine loses this rule permanently if it moves. </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="529e-800a-9ed2-b02a" name="Engineer" hidden="false" targetId="c16c-8e9f-3d9c-7a2a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="523f-2b72-fd75-6294" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="ffd7-9092-1b32-7aaa" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="a3d5-45e5-47d1-3e15" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="21b8-92b6-e60b-ca76" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="d89f-88a2-247c-8863" name="Engines of War (local)" hidden="false" targetId="d027-973a-954e-3377" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d4bb-ea14-9244-0043" name="Ancestral Memory" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8ed-4f27-6198-28bb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ca6-9cda-07f3-3ab8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b427-7c8c-05ac-914e" name="Ancestral Memory" hidden="false" targetId="ee37-8a5e-19e2-d60c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2ca4-8a95-5ffb-699a" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c2b-d904-425b-19dd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ad8f-e8c3-2d5e-0ca4" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="509e-69ad-2e9b-4972" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1114-34f9-ed80-71fd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8cd6-4d59-56a0-6ae7" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="668e-3095-120b-4fe1" name="Runic Items" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4999-ab2a-8df3-e53b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d158-e7e4-5f81-c97c" name="Runic Items" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d71c-5051-180d-3119" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ae29-b277-bec0-26cc" name="Armour Runes" hidden="false" collective="false" targetId="cafc-e06c-3df7-5651" type="selectionEntryGroup"/>
+                <entryLink id="80e4-0cec-bcde-bb61" name="Talismanic Runes" hidden="false" collective="false" targetId="2163-4457-52a1-d323" type="selectionEntryGroup"/>
+                <entryLink id="08d9-af09-0429-9eaf" name="Weapon Runes" hidden="false" collective="false" targetId="b35f-5d0c-dc14-7725" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="311b-539a-05c6-fc93" name="Rune of Resonance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a73-2636-da86-964a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="354d-7a73-b658-7cc0" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c8e-3265-7f25-5ddd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="441a-5edd-f79f-34c9" name="Pistol (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ac-3513-220d-aa99" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="aa12-c064-6b03-ebd6" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="eb84-9ae9-ec5f-62da" name="Guild Crafted Handgun (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e104-c776-4553-17cd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ea89-cff9-d9d3-4d6f" name="Guild Crafted Handgun" hidden="false" targetId="54b3-c31f-62e9-c8b8" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d4ce-e47f-90af-4b86" name="Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a78-10f8-db5c-e730" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c0e7-3503-8301-e522" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3150-b6c0-69d3-a9d7" name="Forge Repeater (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e1a-321f-637a-3785" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4ffb-c96b-7e70-1a84" name="Forge Repeater" hidden="false" targetId="6e5c-e216-9096-90a5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d30f-65a2-64a5-2fa7" name="Wyrm-Slayer Rocket (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="319e-b958-7059-d00a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b85a-0085-f042-21ae" name="Wyrm-Slayer Rocket" hidden="false" targetId="9613-9380-0ddd-8f78" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1949-ed07-9a8b-53e8" name="Army General" hidden="false" collective="false" targetId="b8ed-4f27-6198-28bb" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b79f-1005-d038-d80b" name="Anvil of Power" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5751-5553-8aec-3f6b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fc54-4c15-d80e-7dc5" name="Anvil of Power Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">3&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5c75-8aa9-ab16-745b" name="Anvil of Power Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a044-90e3-b240-6f5c" name="Anvil of Power Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="7268-07aa-da4f-c900" name="Runic Anvil" hidden="false">
+          <description>Each Anvil of Power may choose up to three different Battle Runes during Spell Selection.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f897-8a03-1ffa-c380" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fcfe-0d92-bce0-a6ef" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="5af1-0687-807a-f327" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="e1cd-4504-eb77-3ce9" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f5df-4361-761a-61e1" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="d084-33a5-ae00-7f8b" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="6f08-b165-247e-8220" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1f09-f6e1-a6a0-7960" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="185.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff59-eb26-f17d-edec" name="Clan Warriors" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="bb18-5f5a-1bbf-dc98" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="1617-4da6-b43c-29fa" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="0de9-a336-865d-e509" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="0221-c26a-5df7-654c" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5b80-866e-bc5d-066f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ca69-c095-29ef-7209" name="Clan Warrior" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebef-5339-c158-2271" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef6-6efa-4417-623d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e09e-01ea-34e1-0acb" name="Clan Warrior Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7794-f233-74f3-7014" name="Clan Warrior Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="92bf-57c0-1ee5-3b41" name="Clan Warrior Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="13.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0e0b-6dd0-c9e7-2109" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="ff59-eb26-f17d-edec" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca69-c095-29ef-7209" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ff59-eb26-f17d-edec" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca69-c095-29ef-7209" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="ed8e-9c82-8033-fc9b" value="1">
+              <repeats>
+                <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="840e-1af6-bc54-4f39" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed8e-9c82-8033-fc9b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e5-4b31-29cf-f884" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1223-6cf4-7389-412a" name="Vanguard" hidden="false" collective="false" targetId="1ff1-5f91-a260-b004" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="42c8-965f-0d71-edfb" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="ff59-eb26-f17d-edec" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca69-c095-29ef-7209" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="6ed4-82d4-13d9-05bf" value="1">
+              <conditions>
+                <condition field="selections" scope="ff59-eb26-f17d-edec" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38ac-1861-b7d4-7d3c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b888-e5d8-4b28-a09f" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ed4-82d4-13d9-05bf" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6cdb-0d24-13a7-182e" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="62c4-c61e-d0f8-32fe" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="ff59-eb26-f17d-edec" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca69-c095-29ef-7209" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afe-f9ad-3e0d-b07e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ab53-7b6d-178e-63fb" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="499d-f714-de0d-cc07" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcc9-74a4-f6f8-f092" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2b72-286c-e32b-8230" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="43c4-f4ea-c6ea-2e53" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="59aa-01c9-b6cd-1245" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ac-ebe2-5b5d-3f6c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="05b5-1d8d-3caa-20c1" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0678-3d0e-0963-4d88" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="98e0-058a-fb16-4166" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="38ac-1861-b7d4-7d3c" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="ff59-eb26-f17d-edec" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca69-c095-29ef-7209" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcbb-a739-0251-04bd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3638-d4f2-1540-de68" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3e8a-f61e-6004-38e3" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="ff59-eb26-f17d-edec" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca69-c095-29ef-7209" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2d-68fb-22d9-033d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5f35-809e-8b66-bc4f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="26dc-05c5-4c0b-ef47" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5161-f47e-7585-14be" name="Greybeards" hidden="false" collective="false" type="unit">
+      <rules>
+        <rule id="2fbb-a926-cf92-27af" name="Seen it All" hidden="false">
+          <description>Friendly units within 6&quot; of a Greybeards unit may reroll failed Panic Tests.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6d13-ef26-2983-d221" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="8498-f607-6f2b-8e24" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="f907-6e39-e364-9de2" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="5cf3-cce2-8489-5af9" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="3fb1-acc4-6aa7-5221" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6ca6-7e70-d21d-fc7c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1600-f3e4-8c0b-1bf1" name="Greybeard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11b1-acd2-5883-e09f" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8541-ef84-b5cf-2bd9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0702-5068-1238-f0ce" name="Greybeard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="71a1-593c-0c0e-ed55" name="Greybeard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="dd71-b2ed-ed3e-dafd" name="Greybeard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="840e-1af6-bc54-4f39" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="5161-f47e-7585-14be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1600-f3e4-8c0b-1bf1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="5161-f47e-7585-14be" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1600-f3e4-8c0b-1bf1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="efe7-795d-4ec7-e748" value="1">
+              <repeats>
+                <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e0b-6dd0-c9e7-2109" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efe7-795d-4ec7-e748" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf6-cf1c-ff65-f409" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3646-1b86-0272-4250" name="Vanguard" hidden="false" collective="false" targetId="1ff1-5f91-a260-b004" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef4c-4f82-d86a-be41" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="5161-f47e-7585-14be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1600-f3e4-8c0b-1bf1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce99-2cca-84df-9dd5" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef21-6864-0d6a-c94c" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a0eb-5a1c-9683-1a32" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a92e-7942-b733-1723" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="5161-f47e-7585-14be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1600-f3e4-8c0b-1bf1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="265a-8478-6b0b-620a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f3ab-625c-c3de-bc8a" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c07f-73af-d5b0-00d4" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a1-7d9f-607f-d554" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5dfd-5b44-575b-9289" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="f77d-118e-8ea3-247a" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0ce3-c182-5c37-b874" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="5161-f47e-7585-14be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1600-f3e4-8c0b-1bf1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45e5-709c-2738-29dd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="94e8-d0cb-b19b-651c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7f90-b30b-d782-41c5" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b182-d45c-005f-909f" name="Clan Marksmen" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2553-8743-f7f3-0d1f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="38fa-dfed-7e51-b460" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="8331-c8fe-7d7a-26d4" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="9a81-1794-7569-7b2e" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="722a-3f0a-8765-cb70" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="c382-3b37-55b2-b88e" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b182-d45c-005f-909f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d61-3776-4897-1909" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="501a-efa9-e24b-9b0d" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="b9c3-90a6-b60a-8491" name="Clan&apos;s Thunder (local)" hidden="false" targetId="1101-0d1e-0830-2bbb" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0649-481f-c6af-3c53" name="Clan Marksman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cf3-cde5-f161-fa46" type="min"/>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="683f-ed55-c72e-899f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="62aa-6388-e6de-8dee" name="Clan Marksman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5cce-672b-9ac9-99e7" name="Clan Marksman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f10d-7cd0-9268-17b8" name="Clan Marksman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="19.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3f93-359d-40b5-d0bc" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="b182-d45c-005f-909f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0649-481f-c6af-3c53" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f4d-3d0c-0d7c-14bd" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9ba-05c6-bb2a-3303" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="00f7-d74a-265b-1c5c" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4c35-8b43-d696-c802" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b182-d45c-005f-909f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d61-3776-4897-1909" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a95a-15bb-adcf-2060" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cf84-fee3-6561-0143" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="40a2-29e5-8c4d-6e91" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3934-34d0-7271-9a08" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88b7-744b-ddc6-f33b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1d8-2e72-b30d-1a3b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7d61-3776-4897-1909" name="Guild-Crafted Handgun (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="b182-d45c-005f-909f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0649-481f-c6af-3c53" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9e-ee70-a172-4bd0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c3a0-5df9-2817-a833" name="Guild Crafted Handgun" hidden="false" targetId="54b3-c31f-62e9-c8b8" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e699-cf79-899d-71fe" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="b182-d45c-005f-909f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0649-481f-c6af-3c53" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18b1-aa38-22b8-bb4f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bd48-b6d0-39c9-7b23" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="22e0-6efe-5b5e-6e5e" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f7bb-695a-222b-cd98" name="Deep Watch" hidden="false" collective="false" type="unit">
+      <rules>
+        <rule id="0354-56d7-7d2e-37e7" name="Wall of Iron" hidden="false">
+          <description>The model gains Aegis (5+, against Close Combat Attacks). This rule can only be used against attacks from enemies Engaged in the model&apos;s unit’s Front Facing.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="986c-9285-4a7f-708a" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule"/>
+        <infoLink id="d0dd-3b88-4d1a-c30d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2a35-752b-9c27-fd2f" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="fd06-eb1b-f48a-9687" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="4658-5e5a-542f-d5f9" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0d2c-f296-8382-e6c5" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5502-e6a7-727e-2ca1" name="Deep Watch" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e886-cafe-25d6-8789" type="max"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fc0-4d6b-efd7-9dd6" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="7ed6-eb66-6723-56ad" name="Deep Watch Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a0e0-42a5-2d56-0a7b" name="Deep Watch Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="78ad-da69-991a-9684" name="Deep Watch Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="27.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d30-9fe0-f208-70b3" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd82-16c8-33c1-7570" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="baf9-7d36-3892-e3d0" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="d568-bedc-6177-e79e" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="377a-e3f1-428c-d535" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="36e3-13ba-e9ee-21ec" name="King&apos;s Guard" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5694-8f5f-2b6c-3ae1" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="5645-6fd5-afe7-83e9" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (General, King)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="399f-8f78-5225-c7e6" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2abd-7ab9-c793-fea7" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="2b50-6f35-3599-8573" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="2282-35b1-41bb-7497" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="5c98-2970-2177-d4fd" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="95c2-ad8f-e519-84f9" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="33f1-58e4-169a-5420" name="King&apos;s Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c38-b331-1a9c-9b05" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68b-dfc7-4d2f-04e6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5c0b-4334-fcd8-f92f" name="King&apos;s Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ad3f-8acf-3b41-f366" name="King&apos;s Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="39a1-b0d0-1701-b7fb" name="King&apos;s Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="27.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bbae-248e-679f-9017" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2536-a2cf-b2f5-a27d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a881-6817-52a3-f984" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="91e1-bc05-7da4-97bf" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7d6d-9092-6b0b-271b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="94ba-c3c4-6288-56a9" name="Miners" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="31cb-ab98-5b35-65a4" value="1">
+          <repeats>
+            <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c7fd-7a34-e49d-5d2a" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31cb-ab98-5b35-65a4" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c310-8f11-af4b-bcba" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+        <infoLink id="14e7-598b-a3f6-5977" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="560b-d6f3-16cc-b207" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="d3e0-5b5b-a2a8-1106" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="ad4f-16c4-ee17-5dff" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="eb55-27f5-71e4-8202" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="cb22-2b73-0521-9a7b" name="Miner" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47e2-366d-4521-ee56" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b66-218c-6f3a-8f07" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a4b8-6fc9-ca82-585d" name="Miner Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5bf0-d651-e3f1-f882" name="Miner Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8b26-3d9f-f572-b4bd" name="Miner Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fea1-1a7e-d21c-5962" name="Equipment" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeb9-9b89-0d96-890d" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6d47-e049-b138-c864" name="Great Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="94ba-c3c4-6288-56a9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb22-2b73-0521-9a7b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0591-f0fe-2934-dc49" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="be15-9f20-08cd-7c69" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d25e-9252-1bbf-8edb" name="Shields" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="94ba-c3c4-6288-56a9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb22-2b73-0521-9a7b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bed-63a7-b479-f0d7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3dd7-8e9f-c3fa-b06a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6c95-a138-13be-4791" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="94ba-c3c4-6288-56a9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb22-2b73-0521-9a7b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf9-d6b6-4cbc-18a2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="28f4-8801-6978-9a8a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f04a-4705-37af-ffed" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c7fd-7a34-e49d-5d2a" name="Miners - Ranged Weapons" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="1df8-e17d-2ac1-283f" value="1">
+          <repeats>
+            <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94ba-c3c4-6288-56a9" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1df8-e17d-2ac1-283f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a62e-172c-1ad6-a244" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+        <infoLink id="fc60-cc49-c2be-cb28" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5b93-d45c-60e4-1f51" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="274b-c320-f912-88b5" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="f6e6-4349-b195-2c8d" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="71a4-a3df-9c58-b2cd" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="2f66-4dc4-d23a-5545" name="Clan&apos;s Thunder (local)" hidden="false" targetId="1101-0d1e-0830-2bbb" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0add-7c82-3e50-656d" name="Miner" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11dc-648b-001d-2533" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0686-b238-5ac2-9a5d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8dc8-5590-ae82-b195" name="Miner Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7663-6032-7cde-c1f1" name="Miner Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f73d-9015-5258-44ff" name="Miner Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ebdd-7534-fcb0-8c31" name="Equipment" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e33b-77db-b9ec-1527" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="226e-9cb1-a071-d3e7" name="Great Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="c7fd-7a34-e49d-5d2a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0add-7c82-3e50-656d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c21d-ed50-a9bb-3b2a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f7bd-e780-baaa-a591" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fafd-4c85-57fc-b079" name="Shields" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="c7fd-7a34-e49d-5d2a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0add-7c82-3e50-656d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e6-dedc-8e1d-eb22" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9039-8c9d-c9c0-2ac0" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="af1a-ea9b-5f1c-7e5f" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="c7fd-7a34-e49d-5d2a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0add-7c82-3e50-656d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45f3-0267-88ec-9ab7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="460d-2318-5fab-d5d9" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4fec-5902-0378-6cda" name="Pistol (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="c7fd-7a34-e49d-5d2a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0add-7c82-3e50-656d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf1c-f757-cef2-e644" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b8a7-a8a1-b683-3d8e" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7ce7-d789-357b-7803" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="c7fd-7a34-e49d-5d2a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0add-7c82-3e50-656d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a41-c55d-f2b5-5f83" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="496e-2aad-a4d4-69c8" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a0f5-3fb3-6759-07c2" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1e0-e897-4085-58ff" name="Rangers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="34d2-0beb-e029-e478" value="1">
+          <repeats>
+            <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ae3-eb4b-744a-bfb5" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34d2-0beb-e029-e478" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e95b-ac68-ad56-a7e9" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e1e0-e897-4085-58ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b3df-cdd4-b9d7-fb13" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="810d-d682-f727-68ee" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ccee-ab11-78fe-7b6b" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="729e-a09f-8e5f-a16b" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="3a6e-7e2f-bfe1-3f7a" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="f971-a037-50e6-fc9a" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="49c9-12f0-bb7f-8cfa" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="861c-dcb2-7ca1-fcac" name="Ranger" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c662-815d-f8fd-5fae" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="437c-986c-1b2a-9910" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="59a1-98d8-5db1-98f8" name="Ranger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ef16-728e-5484-3f3b" name="Ranger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cc63-240e-a49f-1ef8" name="Ranger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b3df-cdd4-b9d7-fb13" name="Crag Warden" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="e1e0-e897-4085-58ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="861c-dcb2-7ca1-fcac" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e1e0-e897-4085-58ff" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="861c-dcb2-7ca1-fcac" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f957-7a27-b657-52cb" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cf51-cc27-3c61-e067" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+            <infoLink id="7bc1-5a40-1b2e-6e6b" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="1e79-9bc0-c74a-49fb" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b9c7-c2dd-5c03-e4c6" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="e1e0-e897-4085-58ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="861c-dcb2-7ca1-fcac" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a02b-ac86-d4e2-98fd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3e66-7b97-aaf0-2c8f" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3503-b942-01f4-493d" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a047-5e73-0e79-f7a4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bb10-57bf-7a17-d448" name="Great Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="e1e0-e897-4085-58ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="861c-dcb2-7ca1-fcac" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35e-f1b0-911f-0fda" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cd14-68fc-7e12-2816" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2faf-cbe3-c74e-86f7" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="e1e0-e897-4085-58ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="861c-dcb2-7ca1-fcac" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d08-e0fb-ad70-f910" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a6d0-8879-c368-2e9c" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c28e-a4ed-eab7-9409" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4ae3-eb4b-744a-bfb5" name="Rangers - Ranged Weapons" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="f540-7962-ce20-3df2" value="1">
+          <repeats>
+            <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e1e0-e897-4085-58ff" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f540-7962-ce20-3df2" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6966-0dcf-1736-aa84" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="cfed-5984-b991-1c5f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="484f-0bbb-da3b-3452" name="Shield Wall" hidden="false" targetId="f704-0b70-3e99-cad1" type="rule"/>
+        <infoLink id="a206-c261-9601-8245" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="5dcf-d68a-ddf6-4fa1" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="1ab8-7eb5-1e34-d8e6" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="afe7-be95-3170-3d17" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="02ca-22bb-005d-10b4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="c892-9a82-0724-dfbe" name="Clan&apos;s Thunder (local)" hidden="false" targetId="1101-0d1e-0830-2bbb" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e285-6307-de72-0c80" name="Ranger" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6954-b769-c15d-b99c" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94e8-3101-ad95-0731" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="600e-0b19-a721-03ab" name="Ranger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="64b7-0512-0f3e-7296" name="Ranger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8fa4-88b3-1d44-846f" name="Ranger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="afe7-be95-3170-3d17" name="Crag Warden" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4ae3-eb4b-744a-bfb5" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a89f-b569-010d-4417" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="be9e-15fc-c89c-52f1" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+            <infoLink id="b9ef-19fb-0f90-f23c" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+            <infoLink id="7bf5-1ca4-b3ec-1db8" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="53a4-70df-2912-1feb" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a2b-ddbb-822d-bf16" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="dc68-0a58-5cab-4726" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6be2-9bbb-3c56-7b5c" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0276-5639-ea4f-4b62" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c3d6-d69c-5035-2d79" name="Great Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1efc-dbe2-6569-3221" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a354-b644-3bf2-7bd2" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="03dd-7992-55ba-4b9f" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6310-8d34-7a16-53ee" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ce2e-17dc-72d8-72ad" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4b70-84a7-0dea-e0e0" name="Ranged Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d01-6774-9204-2806" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="45b5-3e16-9d13-81ee" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb2f-05b7-5ac6-13ed" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e08a-aaf1-ae30-81fc" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e472-dd91-f4ec-8d19" name="Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="4ae3-eb4b-744a-bfb5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e285-6307-de72-0c80" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aec9-5758-96b8-f118" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6d75-9487-4b1d-091a" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8961-6896-08de-6817" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4029-837f-4759-365b" name="Seekers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b099-86e8-acdd-f269" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d1e2-0ff6-dc3d-991b" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="1c34-20ca-3145-16fa" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2916-2292-f632-35a6" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="f969-1b69-aa7c-8a0e" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+        <infoLink id="f9c4-c912-8f5b-14fc" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="931e-5084-c43a-bd95" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+        <infoLink id="e256-61c7-fafe-fd9b" name="Yer comin&apos; with me!" hidden="false" targetId="d49d-b447-96aa-51d3" type="rule"/>
+        <infoLink id="8623-8609-bb6b-aac8" name="The bigger they are..." hidden="false" targetId="43a8-01e9-7da5-0c42" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4071-9c05-279c-9552" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c00c-584e-56da-673b" name="Seeker" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f794-89c0-b7bd-7932" type="min"/>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8aa-8868-7a87-8242" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b533-ce91-a5f9-29f5" name="Seeker Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="75a4-c3e1-fac3-9c88" name="Seeker Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="83f3-7565-3d76-6493" name="Seeker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="21.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9e29-23ae-835f-f097" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="4029-837f-4759-365b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c00c-584e-56da-673b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58bd-3719-764c-df25" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f0f1-dfc7-2be3-97d9" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="40bd-8373-644e-a639" name="Brothers of Vengeance" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4029-837f-4759-365b" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c00c-584e-56da-673b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="4029-837f-4759-365b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c00c-584e-56da-673b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d00-45a3-89ff-ac9b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77d1-047c-7e15-4f6a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ba56-94ff-ef65-712e" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+            <infoLink id="3dee-7a76-a826-94c5" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+            <infoLink id="6d00-8580-46e9-914c" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="e589-4e74-431a-db89" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b57-4385-75c1-bff0" name="Vengeance Seeker" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85f0-80b4-4bfe-ea38" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6378-af23-d552-9f2b" name="Vengeance Seeker Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a8e7-ccc5-c5a3-87aa" name="Vengeance Seeker Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="827a-45d5-7fab-afd9" name="Vengeance Seeker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3D3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="ee46-6346-8931-0de2" name="Whirling Chains of Doom" hidden="false">
+          <description>Attacks made with this weapon gain +1 Strength, +1 Armour Penetration, and always strike at Initiative Step 10 (regardless of the wielder’s Agility). A model with this weapon cannot be joined by Characters. </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7f61-889e-7011-7792" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="33e8-6952-368e-a8e1" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="be25-50d9-2a06-b7a4" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="2cef-ea28-330b-5dff" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3a85-4261-0f84-b6ee" name="Yer comin&apos; with me!" hidden="false" targetId="d49d-b447-96aa-51d3" type="rule"/>
+        <infoLink id="c129-8e9e-e97f-3de7" name="The bigger they are..." hidden="false" targetId="43a8-01e9-7da5-0c42" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c6eb-e599-3252-9828" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b86e-fc1e-4a80-d595" name="Hold Guardians" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a254-9949-550c-006c" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="e5eb-f5a0-0390-60e0" name="Runic Engravings" hidden="false">
+          <description>At step 8 of the Pre-­Game Sequence (after Spell Selection), each Hold Guardian unit must choose one of the following effects, which is applied for the duration of the game:
+- +1 Strength and +1 Armour Penetration.
+- Vanguard.
+- +2 Agility.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="86ec-717b-46b6-5bcc" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5d57-5fa5-1100-c87e" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="6057-3b4c-b3de-8490" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="d4a5-1fa5-0a77-5474" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0c01-e6a4-d028-18ae" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7cb0-2ed5-8e97-9760" name="Hold Guardian" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91b2-0d05-9ccf-5ebe" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bc6f-e565-449d-a5ac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5bc4-771f-1ab8-7e9b" name="Hold Guardian Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="119f-3c75-c049-1237" name="Hold Guardian Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8fcf-bf4e-793d-fd1f" name="Hold Guardian Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="102.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d4d-341a-f392-1c38" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b87-ce86-c6a1-8dcb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4447-6788-7092-345a" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="aedb-3163-1e68-dc3d" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8841-dfc8-f5bc-9597" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-26.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ea5-26f3-4f05-09cc" name="Grudge Buster" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b9-a61d-7eb8-3754" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="80a3-dfb0-1e27-49ae" name="Grudge Buster Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">1&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">1&quot; (8&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d66b-ed73-a106-54a4" name="Grudge Buster Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e5ed-5b16-f708-ace2" name="Grudge Buster Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2407-03e5-469e-9ca2" name="Grudge Buster Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="cd77-9ff5-fa5c-2dd6" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="d053-6b8d-afb8-d6f2" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="ac0b-0cc4-ceb4-34b7" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="5af0-d87d-634e-f26e" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="47d6-bdc6-42c0-897f" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0d3f-e117-59ba-7f1d" name="Forge Repeater (4+)" hidden="false" targetId="6e5c-e216-9096-90a5" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3115-6757-7eb6-19cd" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="350.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff8b-52ae-01f6-cf2d" name="Forge Wardens" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="f9db-730f-617f-8be4" name="Forge Gun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Flaming Attacks, Always hit on 2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="dfdf-eb2d-e151-fff6" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2b8d-9642-8cc0-eaf4" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="5565-3576-46dc-ab53" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="4bed-f6d0-4ea1-9e3c" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2+, against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="81b7-c7fc-947c-8139" name="New CategoryLink" hidden="false" targetId="1101-0d1e-0830-2bbb" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="94a7-0c9f-335c-4345" name="Forge Warden" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d168-4f5a-d89a-7aec" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6593-6c8e-1cab-ca36" type="max"/>
+            <constraint field="selections" scope="roster" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0daa-9eb5-3a75-9ca3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="345d-36f7-b3f4-c7f6" name="Forge Warden Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="59fb-86c6-ca52-e690" name="Forge Warden Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9847-f4a3-da76-e775" name="Forge Warden Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="22.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8794-f341-8662-25d2" name="Runic Standard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe4-58ff-9316-10e5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c41f-8db9-307c-ae49" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="3fc5-df95-98a0-acb7" name="Runic Standards" hidden="false" collective="false" targetId="82ba-77be-be53-fcef" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="a089-8503-0700-49c0" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6617-9441-1a82-1c6c" name="Steam Copters" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8cd-c0b5-1309-9adc" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7189-dd35-49cb-39a4" name="Steam Copter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">1&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">2&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0dce-62b2-2794-0676" name="Steam Copter Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5bd5-dc66-2714-ad5e" name="Steam Copter Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3585-952f-f99e-18d1" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (8&quot;,16&quot;)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6da4-f136-1c1e-a4a2" name="Tall" hidden="false" targetId="229b-fa84-b9fe-b1ff" type="rule"/>
+        <infoLink id="922e-0293-d42c-1a8a" name="Forge Repeater" hidden="false" targetId="6e5c-e216-9096-90a5" type="profile"/>
+        <infoLink id="d375-fb24-06e2-85f7" name="Cannot be Stomped" hidden="false" targetId="0919-4c3c-87d8-78a8" type="rule"/>
+        <infoLink id="ccb4-c9da-e86d-4d91" name="Sweeping Attack" hidden="false" targetId="3fff-f85c-3747-6634" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4be6-e6b6-d640-0a53" name="New CategoryLink" hidden="false" targetId="1101-0d1e-0830-2bbb" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8b90-0f0b-1c9f-2bfd" name="Attack Copter" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e930-bd2a-f212-e9c9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe9f-7ff4-a840-944e" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cd4-3a28-70e7-b85b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="1e7e-c7ea-2678-8fb0" name="Shrapnel Grenades" hidden="false">
+              <description>Sweeping Attack which can be used once per game. The enemy unit suffers D3 hits for each Steam Copter in the unit. Hits are resolved with Strength 3 and Armour Penetration 0. </description>
+            </rule>
+          </rules>
+          <selectionEntries>
+            <selectionEntry id="72da-8365-adb5-4b18" name="Additional Copter" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb0b-78d1-7e31-7d7f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="175.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e930-bd2a-f212-e9c9" name="Steam Bomber" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b90-0f0b-1c9f-2bfd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56a6-6621-f27b-a2bb" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b83-f5e4-2029-e3bd" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="1f94-e46b-d9e4-9f37" name="Shrapnel Bombs" hidden="false">
+              <description>Sweeping Attack. The enemy unit suffers D6*2 hits with Strength 3 and Armour Penetration 1. If a natural &apos;6&apos; is rolled for the number of hits, after the attack has been resolved, the Shrapnel Bombs cannot be used anymore during this battle.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="18e3-74f4-fcc3-b5f6" name="Field Artillery" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="f65b-8899-1eac-c143" name="Field Artillery Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">3&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f1d8-da9c-f6a5-91d2" name="Field Artillery Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0d98-e764-411d-673a" name="Field Artillery Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="555a-517f-b0ce-f0b3" name="Engineering Rune" hidden="false">
+          <description>Field Artillery adds +4 to any roll on the Misfire Table.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7450-7bc4-88f7-5611" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="3a56-4cbf-c409-4102" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="c58f-d2fb-5e88-5f1c" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="94cf-0252-373a-963b" name="New CategoryLink" hidden="false" targetId="d027-973a-954e-3377" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="01cd-826d-aeaf-be9e" name="Flaming Shot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acde-02c5-f2e9-edd4" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="bba4-da72-5f9f-d080" name="Flaming Shot" hidden="false">
+              <description>All hits caused by Field Artillery’s Shooting Attacks gain Flaming Attacks and Magical Attacks.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9a99-ca88-7347-a097" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a35-1ca8-2068-617d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67f1-f2a6-c82b-1098" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2e8b-d125-3265-4e32" name="Dwarf Ballista (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dc9-e9db-bc0d-9f94" type="max"/>
+                <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b64-8693-d8ef-70e9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0132-8e04-88c0-d766" name="Dwarf Ballista (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [6]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3)]</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="5d5a-bbc8-68e9-f863" name="Rune Crafted" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7314-6e91-3066-7cd7" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="6a9d-b839-6c2d-583d" name="Rune Crafted" hidden="false">
+                      <description>All shots by a Dwarf Ballista gain Magical Attacks and Accurate.
+The model gains Scout with the following exception: It must be deployed within the owning player’s Deployment Zone.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b91d-011e-8878-22b5" name="Flame Cannon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e10a-37b0-ebf9-2544" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f9c-9eb7-c5ff-fca9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8ebf-eba6-475c-cd4f" name="Flame Cannon" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4 [5]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">1 [2]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3)], Flaming Attacks</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="bd5b-159e-e275-ca79" name="Rune Crafted" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b4-f4f2-023b-30fb" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="c419-be11-d437-3ec5" name="Rune Crafted" hidden="false">
+                      <description>The Flame Cannon&apos;s Size is changed to Large.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="79cc-b1b7-75a9-87fd" name="Catapult (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3473-31a3-0665-6668" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cdce-92ef-01d4-a17f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="387a-076a-3e79-b6b1" name="Dwarf Catapult (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12-60&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [7]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0 [4]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3, Clipped Wings)]</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="73b7-1ec3-af6a-4133" name="Rune Crafted" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34dc-d3c3-b009-aac5" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="9adc-060a-471a-5064" name="Rune Crafted" hidden="false">
+                      <description>All hits caused by the Catapult gain +1 Strength, +2 Armour Penetration and Magical Attacks.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a2fb-2e90-51d3-99c0" name="Cannon (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdf4-354c-f19c-455f" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13bb-0f45-7cd1-226d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7f5c-82c3-0907-5358" name="Cannon (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">60&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4 [10]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0 [10]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3+1, Clipped Wings)]</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="66e5-74ec-72e5-f487" name="Cannon (Volley Gun) (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">4</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="d2d9-7389-b180-7eee" name="Rune Crafted" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5f7-fa5e-75b9-15d8" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="39e3-ca42-0d2a-0799" name="Rune Crafted" hidden="false">
+                      <description>All hits caused by the Cannon gain +1 Strength, +1 Armour Penetration and Magical Attacks.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="255.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="db4d-8fcd-9225-b89f" name="Organ Gun (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49e3-7c2f-55e1-1160" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cad4-04a0-e12b-aeb0" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="22e8-6493-1296-40ad" name="Organ Gun (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">30&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6*2</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <selectionEntries>
+                <selectionEntry id="ff9f-430d-cd4b-28bb" name="Rune Crafted" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1448-e30e-1d88-2b8c" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="d74a-ba9f-7116-4e86" name="Rune Crafted" hidden="false">
+                      <description>All hits caused by the Organ Gun gain a +1 to-wound modifier and Magical Attacks. </description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="270.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="b8ed-4f27-6198-28bb" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05f0-15a4-3267-a22a" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c370-f649-08a7-aa40" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6394-fe68-32a5-a5b3" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="4e65-6dad-00b1-6fa9" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd73-483a-7e65-8399" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f577-e2e5-7b2b-d4a1" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a12c-9bec-7d4b-5f99" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b2ee-0a77-2973-5654" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1ff1-5f91-a260-b004" name="Vanguard" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456c-3428-b707-3acf" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecf1-6b1d-9fe1-2df5" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e49-8e0b-f86e-99b7" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ff2f-2ed6-4be3-fd5b" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6dc5-a7b2-9231-8851" name="Shield Bearers" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="957b-93a8-d364-4cb9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="e94c-09fd-051f-7497" name="Shield Bearers Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="83ab-ea19-19da-5217" name="Shield Bearers Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="310d-302b-0c8d-6700" name="Shield Bearers Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="58cb-f1c9-510a-cfe8" name="Tall" hidden="false" targetId="229b-fa84-b9fe-b1ff" type="rule"/>
+        <infoLink id="9527-eec4-4d9a-61e2" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3fd9-a012-0cb2-72f3" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="06e9-e094-a2d1-b804" name="War Throne" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ee5-439b-7963-ba45" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8679-39d5-b79e-db9b" name="War Throne Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1990-b807-73e1-046c" name="War Throne Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d721-f2d5-e35f-8e2f" name="War Throne Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="97fe-9285-a60f-44f5" name="Majesty of High Kings" hidden="false">
+          <description>A General mounted on a War Throne increases the range of its Commanding Presence to 18&quot;. </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3cad-e488-09ba-6fa7" name="Tall" hidden="false" targetId="229b-fa84-b9fe-b1ff" type="rule"/>
+        <infoLink id="0e53-6cdc-7b7d-4a0c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="90bf-c440-2b72-c482" name="Sturdy" hidden="false" targetId="4e71-c719-2df9-9741" type="rule"/>
+        <infoLink id="2537-0cb5-6498-d2a2" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="245.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="b35f-5d0c-dc14-7725" name="Weapon Runes" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="8bfb-fbc9-b4bb-25d1" name="Rune of Destruction" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36d7-58fc-17dc-f955" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22ba-08fb-264e-a8ac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bf53-edd7-f2d8-ee4a" name="Rune of Destruction" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with a weapon engraved with this Rune gain Multiple Wounds (D3).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="16cb-9698-54a0-738d" name="Rune of Penetrating" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9136-3027-d0f3-0647" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5333-3660-2727-90a9" name="Rune of Penetrating" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with a weapon engraved with one or more Rune of Penetrating gain +3 Armour Penetration.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8c18-b6bf-4e0d-0f15" name="Rune of Smashing - On foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1320-c8a5-dc5e-bc6e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="207d-c7f6-9003-4cfb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0d9c-0c3c-bfa5-ce87" name="Rune of Smashing - Models on Foot only" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with a Weapon engraved with this Rune that are allocated towards a model with a Resilience of 5 or greater have their Strength set to 10 and Armour Penetration set to 10.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="83b9-db36-e685-47bf" name="Rune of Might" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="ebfc-11ac-c72c-a6f6" name="Rune of Might" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">For each Rune of Might engraved on a weapon, attacks made with it gain +1 Strength and +1 Armour Penetration.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2af0-1dea-a6e3-0a7a" name="Rune of Precision" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9db-2303-7655-fbe1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="55da-bbd3-c587-b50c" name="Rune of Precision" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder of a weapon engraved with this Rune gains Lightning Reflexes.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="be33-ccec-33ac-b3fc" name="Rune of Craftsmanship" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f70-048f-45ac-abcb" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f674-4697-558b-7b25" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="da6c-689a-2bde-04b8" name="Rune of Craftsmanship" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A weapon engraved with this Rune becomes a Great Weapon.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f1fc-caab-a3d2-6f9d" name="Rune of Quickening" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="a422-c653-3936-ad03" name="Rune of Quickening" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">For each Rune of Quickening engraved on a weapon, the wielder gains +3 Agility when using it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5a10-355d-d882-b880" name="Rune of Fury" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="6886-8fc7-6501-fffe" name="Rune of Fury" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">For each Rune of Fury engraved on a weapon, the wielder gains +1 Attack Value when using it.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d50-8b70-7429-0a15" name="Rune of Lightning" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e29-307b-6c89-5117" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1f7a-ef17-61d4-20c1" name="Rune of Lightning" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If the wielder scores at least one successful hit with a weapon engraved with one or more Rune of Lightning, the attacked enemy unit additionally suffers D3 hits for each instance of this Rune. The hits are resolved with Strength 4 and Armour Penetration 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="608b-7afc-d809-5fa6" name="Rune of Returning" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe1e-b436-fdde-3fbe" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f5b9-6739-f151-5f4a" name="Rune of Returning" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A weapon engraved with this Rune can be used as a Shooting Weapon with Aim 2+ and the following profile: Range 8”, Shots 1, Str as user, AP as user, Quick to Fire, Accurate, Reload!. This Shooting Attack is affected by all Weapon Runes on the engraved weapon (even if the effects are normally restricted to Close Combat Attacks).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dab3-e48e-89b9-9af0" name="Rune of Fire" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db50-a291-1285-286a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3df1-c47a-bef2-fa21" name="Rune of Fire" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand weapon or Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of any Phase or Round of Combat, this Rune may be activated. If so, attacks made with a weapon engraved with this Rune gain Flaming Attacks until the end of the Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="cafc-e06c-3df7-5651" name="Armour Runes" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4f6-b749-d513-c973" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="7472-68a9-359e-cab2" name="Rune of Resistance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db4c-55fe-f4aa-db01" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6295-7675-c1d6-a792" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c904-3f9f-036b-42f7" name="Rune of Resistance" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Successful to‐wound rolls against the wearer of an armour engraved with this Rune must be rerolled. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c754-6af2-7432-a28b" name="Rune of Retribution" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18e1-49aa-aaa4-e7e6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7a06-832e-cc11-74c4" name="Rune of Retribution" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Whenever the wielder rolls a successful Shield Wall Aegis roll (including Shield Wall stacked with Rune of Shielding), the attacking model suffers a hit with the Strength and Armour Penetration of the saved attack.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d253-0fc6-51f7-bb37" name="Rune of Steel" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="126e-e708-3ab6-d99d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6ba9-5a5a-eaa8-b532" name="Rune of Steel" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer of an armour engraved with this Rune must reroll failed Armour Saves.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1b0c-a4c6-be7f-037c" name="Rune of Iron" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78d2-c9a0-7732-9f92" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="99e8-23dc-926d-fa49" name="Rune of Iron" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer of a single Rune of Iron gains +1 Armour. The bearer of two or more Runes of Iron gains +2 Armour.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bbca-d60c-a66d-fc26" name="Rune of the Forge" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbc1-53f2-d079-89cb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1fc3-6a82-e9c3-0354" name="Rune of the Forge" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer of an armour engraved with this Rune gains Aegis (2+, against flaming attacks).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2163-4457-52a1-d323" name="Talismanic Runes" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="777f-9032-510c-3f15" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="00b9-63d0-5214-73d6" name="Rune of Harnessing" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c61-881c-5a78-f58d" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dde-66fd-7c58-51bc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e02d-f99c-bb13-fe70" name="Rune of Harnessing" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Enemy models within 24” of the Runic Smith have their Channel value (the value within brackets) reduced by 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7ac4-c395-e493-7578" name="Rune of Courage" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="facf-0cde-6ba5-0f23" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3b24-1cd8-1d1f-4c87" name="Rune of Courage" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any Round of Combat. For the duration of the Phase, the bearer gains Stubborn.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a8bc-1f97-428c-acfa" name="Rune of Dragon&apos;s Breath" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1df-4f22-810f-8f4e" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6ff-2eec-9c2b-eefe" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="091c-59ca-14d6-f48f" name="Rune of Dragon&apos;s Breath" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Breath Attack (Str 4, AP 1, Flaming Attacks, Magical Attacks). A single friendly Rune of Dragon&apos;s Breath may be made per round of combat.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f9ac-72d4-d0dd-93f0" name="Rune of Grounding" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c61-881c-5a78-f58d" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f44b-aeb9-7ff4-8044" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b53-f68e-65a3-e9ad" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9b98-c77c-3859-63d8" name="Rune of Grounding" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any Melee Phase. All spells with Duration: Lasts One Turn affecting the bearer’s unit and enemy units in base contact with the bearer come to an end.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bea2-b168-b0ea-d822" name="Rune of Readiness" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bf3-98bd-b64e-79cb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7bd6-fa33-d0df-fd39" name="Rune of Readiness" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the end of the Charge Phase, directly after all Charge Moves have been resolved. If the bearer’s unit was successfully charged during this phase, it may perform a Combat Reform (following the normal rules for Combat Reforms). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7278-42cf-e62d-b1a6" name="Rune of Shielding" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="4005-51b8-15ea-256a" name="Rune of Shielding" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (+1, max 4+). The Aegis from this Rune only stacks with itself and/or Shield Wall.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee60-95a5-47af-dbed" name="Rune of Storms" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d844-de33-365c-2e20" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c716-1ff3-c849-cff7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ebf4-c28f-1fc3-f149" name="Rune of Storms" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. Effects last one turn. May be activated at the start of the opponent’s Player Turn. Choose a single enemy unit within 24” of the bearer. All models with Fly in that unit have their Advance Rate and March Rate (both for Ground and Fly Movement) halved, rounding fractions up.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="93e4-f755-68e0-16c9" name="Rune of Mastery" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39ae-981b-671c-6fdf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="128d-2a89-d064-daee" name="Rune of Mastery" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated just before the Bearer casts a Bound Spell. Adds (+2/+2) to the Power Level of this Bound Spell.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9884-0084-1462-3e2e" name="Rune of Mining" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba8c-8c80-5835-628a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="392b-42cb-6e46-7d78" name="Rune of Mining" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">After Determining Deployment Zones (at the end of step 6 of the The Pre-Game Sequence), choose a Terrain Feature on the Battlefield. As long a the bearer is on the Battlefield, all friendly models may treat this as Open Terrain when making Advance Moves or March Moves, but must still follow the Unit Spacing rule at the end of their movement.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6aad-9d24-16d9-eab9" name="Rune of Kinship" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16b7-97ff-4604-6813" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e5ea-4327-b520-7b7b" name="Rune of Kinship - Cannot be taken by model on War Throne " hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Scout and Ambush.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="249a-d8a5-c50c-ec77" name="Dominant Talismanic Runes" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4183-3a53-e61a-a60e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d2e1-5875-4d27-8aec" name="Rune of Denial" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04e2-a2c4-207f-b302" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b3d-808d-7f79-87c7" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="02ea-1b24-d581-c1de" name="Rune of Denial" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+                  <characteristics>
+                    <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                    <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The bearer may choose to use this Rune instead of making a Dispel Attempt. The spell is automatically dispelled.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bf71-9aed-fffb-7632" name="Rune of Devouring" hidden="true" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c61-881c-5a78-f58d" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f537-a5bb-01e4-a4b1" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4431-8871-78a8-621d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7cba-13e1-8d0f-794e" name="Rune of Devouring" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+                  <characteristics>
+                    <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                    <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The player may choose to use this Rune instead of making a Dispel Attempt. The spell is cast as normal but is afterwards lost and the Caster may not cast it again for the rest of the game.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="82ba-77be-be53-fcef" name="Runic Standards" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5f0-eeac-5ca6-bb1f" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d13d-5172-dae7-2498" name="Runic Standard of Shielding - Only BSB, Deep Watch, King&apos;s Guard." hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8780-e286-a7e0-adc9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b161-05ae-cf41-d0e4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ccbe-5164-dea7-b507" name="Runic Standard of Shielding" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">All friendly units within 6&quot; of the bearer gain Aegis (5+) against Shooting Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e6fa-515c-4de5-9de4" name="Runic Standard of Dismay" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825f-b755-9f01-4690" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37ad-724b-2908-161e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3a41-8e1a-bb0a-4964" name="Runic Standard of Dismay" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Units charging the bearer’s unit suffer -2&quot; Advance Rate for their Charge Range roll. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9271-de57-4d42-d747" name="Runic Standard of Swiftness" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a42-8552-4db4-5474" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3450-52b3-b875-ec7a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="18e0-f91e-1834-559e" name="Runic Standard of Swiftness" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Vanguard.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="11cd-e8e8-47bc-16a3" name="Runic Standard of the Hold" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e89-2158-7974-438f" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d542-fa01-d104-c2a9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1baf-c85d-cdaa-1666" name="Runic Standard of the Hold" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A unit with one or more Runic Standards of the Hold counts as having an additional Full Rank for the purpose of Steadfast and Disrupted. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cdbf-f44c-33f6-79e0" name="Runic Standard of the Anvil" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fef-d231-125b-fb9f" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9180-663d-2693-b224" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a574-f517-ca50-1003" name="Runic Standard of the Anvil" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Friendly units charging enemy units Engaged in Combat with the bearer’s unit must reroll Failed Charge Range rolls.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="21b2-3b18-dd7c-61a8" name="Runic Standard of Wisdom" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d0-9343-85c0-288c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7015-f461-9ba0-3d2b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4558-ae4d-54a1-6d14" name="Runic Standard of Wisdom" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer may select a single Battle Rune during Spell Selection. This Battle Rune can be cast by the bearer and has Range: Caster’s Unit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d08-32b5-87da-76c9" name="Runic Standard of Steadiness" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78fb-d351-443d-9f7d" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64e8-6eb0-9ac1-d2fd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dddc-0ccd-2cf5-d45c" name="Runic Standard of Steadiness" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any Movement Phase. The Bearer&apos;s Unit gains Quick to Fire antil the end of the player turn.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="fe74-52fb-12a6-a82b" name="Hewn out of Mountains" hidden="false">
+      <description>As long as at least one friendly model from a Dwarven Holds Army is on the Battlefield, all spells cast by enemy models have their Casting Values increased by +1.</description>
+    </rule>
+    <rule id="4f6b-22d8-27cf-3d81" name="Ancient Grudge" hidden="false">
+      <description>Dwarven Holds Armies have a number of Ancient Grudges which confer a bonus when attacking specific enemies. The total number of Grudges held by a Dwarven Holds Army is calculated in the following manner:
+
+- One Grudge for a General with Ancestral Memory.
+- One Grudge for each King in the Army.
+- Two Grudges for each War Throne in the Army.
+
+Right before the battle (during step 7 of the Deployment Phase Sequence), you must choose a single unit from the opponent&apos;s Army List for each Grudge in your Army (This may also be a Character). The models of this Unit are considered &quot;marked&quot;. All models in the Dwarven Holds Army gain Hatred against all marked models, and against models joined to units with more than half of their models marked.</description>
+    </rule>
+    <rule id="0bef-02bf-bec5-e90f" name="Holdstone" hidden="false">
+      <description>One use only. May be activated at the start of any Round of Combat. Effects last until the unit is no longer Engaged in Combat. Apply the following effects:
+- Enemy units cannot claim Combat Score bonuses for being in the Flank or the Rear of the unit.
+- The unit cannot be Disrupted.
+- Shield Wall, Wall of Iron and Parry can be used in any Facing.
+- For the purpose of Supporting Attacks, all Facings are considered to be the Front Facing (i.e. a model can perform Supporting Attacks also to the Flanks and Rear). 
+The unit cannot Pursue (nor Overrun).</description>
+    </rule>
+    <rule id="ee37-8a5e-19e2-d60c" name="Ancestral Memory" hidden="false">
+      <description>A General with Ancestral Memory increases the number of Grudges held by a Dwarven Holds Army by 1.</description>
+    </rule>
+    <rule id="f704-0b70-3e99-cad1" name="Shield Wall" hidden="false">
+      <description>When using a Shield, the model gains Aegis (6+, against Close Combat Attacks) This is improved to Aegis (5+, against close combat attacks)  if the attacker is Charging. This rule can only be used against attacks from enemies engaged in the model&apos;s front facing.</description>
+    </rule>
+    <rule id="4e71-c719-2df9-9741" name="Sturdy" hidden="false">
+      <description>The model gains Devastating Charge (+1 Str, +1 AP) and it does not suffer from negative to-hit modifiers from a Stand and Shoot Charge Reaction. </description>
+    </rule>
+    <rule id="43a8-01e9-7da5-0c42" name="The bigger they are..." hidden="false">
+      <description>When rolling for Charge Range, if the charged unit contains at least one Large or Gigantic model, models with this Attack Attribute gain Swiftstride for this Charge Range roll (this does not apply to Pursuit and Overrun Moves).</description>
+    </rule>
+    <rule id="d49d-b447-96aa-51d3" name="Yer comin&apos; with me!" hidden="false">
+      <description>Close Combat attacks made by a model with this Attack Attribute may never wound on worse than 4+. In addition, when a model with this Attack Attribute is removed as a casualty during the Melee Phase due to a Melee Attack, it must immediately, before removal, make a single Close Combat Attack that is always resolved with Strength 5 and Armour Penetration 2, which  must be allocated either towards the model that caused the casualty or its unit (in this case, the hits are distributed onto the unit). 
+This Attack Attribute cannot be used against casualties caused by Impact Hits. In order to use this Attack Attribute, the unit must be at least as wide as it is deep at the start of the Round of Combat.
+
+
+</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="9613-9380-0ddd-8f78" name="Wyrm-Slayer Rocket" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">6</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Multiple Wounds (D3), Flaming Attacks, Reload!</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6e5c-e216-9096-90a5" name="Forge Repeater (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">4</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Flaming Attacks, Quick to Fire</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="54b3-c31f-62e9-c8b8" name="Guild Crafted Handgun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Unweildy, Accurate</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/empireOfSonnstahl.cat
+++ b/empireOfSonnstahl.cat
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1aa5-c442-6972-b551" name="Empire of Sonnstahl 2.0" revision="12" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1aa5-c442-6972-b551" name="Empire of Sonnstahl 2.0" revision="13" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="ecde-c284-9850-23e1" name="Imperial Armoury (local)" hidden="false"/>
-    <categoryEntry id="77b5-bf3a-88ad-b176" name="Imperial Auxiliaries (local)" hidden="false"/>
-    <categoryEntry id="bc79-f1f0-5d7d-cd9b" name="Sunna&apos;s Fury (local)" hidden="false"/>
+    <categoryEntry id="ecde-c284-9850-23e1" name="Imperial Armoury" hidden="false"/>
+    <categoryEntry id="77b5-bf3a-88ad-b176" name="Imperial Auxiliaries" hidden="false"/>
+    <categoryEntry id="bc79-f1f0-5d7d-cd9b" name="Sunna&apos;s Fury" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="bcde-f2bb-7f71-50d3" name="Empire of Sonnstahl (local)" hidden="false">
+    <forceEntry id="bcde-f2bb-7f71-50d3" name="Empire of Sonnstahl" hidden="false">
       <categoryLinks>
         <categoryLink id="678b-50fd-e273-0e61" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -1521,9 +1521,6 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
               <modifiers>
                 <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
               </modifiers>
-              <categoryLinks>
-                <categoryLink id="2cdf-fe80-cc58-01d2" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
-              </categoryLinks>
             </entryLink>
           </entryLinks>
           <costs>
@@ -1570,9 +1567,6 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="7969-f751-2dab-5247" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
               </costs>
@@ -1588,9 +1582,6 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="d48c-a201-2bcd-3f3e" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
               </costs>
@@ -1599,11 +1590,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8be2-58f8-e737-f847" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup">
-          <categoryLinks>
-            <categoryLink id="6a8a-2938-8e70-aba7" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
-          </categoryLinks>
-        </entryLink>
+        <entryLink id="8be2-58f8-e737-f847" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
@@ -2326,9 +2313,6 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="d3c7-3628-8b5a-fbb9" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
@@ -2653,9 +2637,6 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                   <description>Friendly units within 6&quot; of the model gains Distracting. The Arcane Engine can cast Perception of Strength from Cosmology as a Bound Spell with Power Level (4/8).</description>
                 </rule>
               </rules>
-              <categoryLinks>
-                <categoryLink id="a4c5-a39a-36da-76c2" name="New CategoryLink" hidden="false" targetId="2a59-0397-1496-1d3e" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
@@ -2669,9 +2650,6 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                   <description>Friendly units within 6&quot; of the model gains Lightning Reflexes. The Arcane Engine can cast Ice and Fire from Cosmology as a Bound Spell with Power Level (4/8).</description>
                 </rule>
               </rules>
-              <categoryLinks>
-                <categoryLink id="2af1-9fdf-73df-eff2" name="New CategoryLink" hidden="false" targetId="2a59-0397-1496-1d3e" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>

--- a/empireOfSonnstahl.cat
+++ b/empireOfSonnstahl.cat
@@ -1,0 +1,3868 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="1aa5-c442-6972-b551" name="Empire of Sonnstahl 2.0" revision="12" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="ecde-c284-9850-23e1" name="Imperial Armoury (local)" hidden="false"/>
+    <categoryEntry id="77b5-bf3a-88ad-b176" name="Imperial Auxiliaries (local)" hidden="false"/>
+    <categoryEntry id="bc79-f1f0-5d7d-cd9b" name="Sunna&apos;s Fury (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="bcde-f2bb-7f71-50d3" name="Empire of Sonnstahl (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="678b-50fd-e273-0e61" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="baf8-e7cc-e4ed-1597" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4ba4-caec-6561-489a" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="28c7-2135-e50d-904d" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3070-c574-1c71-dd75" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="177a-0254-27ea-ce3a" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="5018-187b-8a89-f704" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="abd3-8ff0-9b3a-2525" name="Imperial Armoury (local)" hidden="false" targetId="ecde-c284-9850-23e1" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="aa96-fd63-e2aa-1eab" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3058-f9ca-52a4-d731" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="fbf2-ea7a-d897-23f4" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="028f-4f2d-1812-7479" name="Marshal" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5b47-5103-55ff-7bb0" name="Marshal Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a141-5912-313b-e41a" name="Marshal Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="8265-800f-bc87-d00a" value="4">
+              <conditions>
+                <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5221-22b7-accf-79b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a2fa-99b7-0ff5-2188" name="Marshal Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="086e-6f45-69cc-e6ec" name="Orders" hidden="false" targetId="a061-bfd0-1d95-1b9e" type="rule"/>
+        <infoLink id="17f1-317c-5d70-83f2" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e1e4-9de2-97a0-2d81" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fde5-8f86-48d4-a53b" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d418-0b46-3c6c-756e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcd0-4261-a9f1-c9ca" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5407-426b-86f9-618f" name="Battle Standard Bearer" hidden="false" collective="false" targetId="53e0-007c-21bc-d3cc" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d418-0b46-3c6c-756e" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="a1ba-9c3b-9d41-748e" value="1">
+              <conditions>
+                <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5221-22b7-accf-79b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee4f-588b-f72e-63f9" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1ba-9c3b-9d41-748e" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="928e-f26d-84df-51e3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="4ee8-d126-eb7b-9be0" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e9d8-2ed3-ece1-c7a4" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7816-20a6-272e-9e2c" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="995d-6d2c-4fda-9f42" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="a607-da89-c200-ea41" value="100">
+                  <conditions>
+                    <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="a607-da89-c200-ea41" value="50">
+                  <conditions>
+                    <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5221-22b7-accf-79b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a607-da89-c200-ea41" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="86a4-9b90-8003-f8bf" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="4a99-27b4-0816-465d" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5221-22b7-accf-79b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="6500-6a5e-7bb3-1b50" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+                <entryLink id="65da-7dc4-7008-4f5d" name="Banner Enchantments" hidden="true" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="e9d8-2ed3-ece1-c7a4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a99-27b4-0816-465d" type="equalTo"/>
+                            <condition field="selections" scope="e9d8-2ed3-ece1-c7a4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="86a4-9b90-8003-f8bf" type="equalTo"/>
+                            <condition field="selections" scope="e9d8-2ed3-ece1-c7a4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6500-6a5e-7bb3-1b50" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="59ac-a985-3c55-5413" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d4d-3f43-746d-f60f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7f8c-8aba-0ee5-25f8" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eb00-4e0e-2023-9da1" name="Pistol (2+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfc-cc3a-c719-904d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b284-4da2-dad5-5c5d" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (2+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ad71-6323-cad9-6e5c" name="May become" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5544-9632-cf4a-c98f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d2d7-60b7-0057-5521" name="Great Tactician" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e9-68d2-c385-eac5" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="778c-4e97-963f-b476" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="19a3-4e42-cd61-6891" name="Great Tactician" hidden="false">
+                  <description>A Great Tactician may give two Orders per turn instead of one.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5221-22b7-accf-79b7" name="Imperial​ ​Prince" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37a2-7275-b6ac-4e01" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6bc-8719-1285-c0a2" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c1ff-1633-4cc4-db98" name="The Light of ​​Sonnstahl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+                  <characteristics>
+                    <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                    <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon wound automatically, always have Armour Penetration 10, and Magical Attacks.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="7427-c5c7-ee71-3dd5" name="Imperial​ ​Prince" hidden="false">
+                  <description>General Only. The model part gains +1 Attack Value, and is equipped with a Hand Weapon enchanted with The Light of Sonnstahl. An Imperial Prince may only take up to 50 pts of Special Equipment.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="175.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="93ff-9719-4dbd-7a44" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e00-fcae-19e0-05a5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7320-4510-ac1c-8b03" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3be3-fe8b-e518-6780" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="deff-b68d-c249-96dd" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="eeb0-b91d-78be-cd07" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37eb-4457-95b0-c0d9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0e49-7d6c-5e39-71b2" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0f0f-0572-09a3-006c" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0da-7910-fb04-d230" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9be8-b88b-b005-6124" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a3ec-d371-66fd-ebb1" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="028f-4f2d-1812-7479" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1dd-4694-0073-7783" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2c8-b285-8b92-a54a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5345-a9da-ab93-dcb8" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b1dd-4694-0073-7783" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bf7-23a7-a47a-3427" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2a16-6e2b-2809-008e" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bf5-7ff9-c539-5dfe" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b5f4-2ce4-8055-6aa7" name="Pegasus" hidden="false" collective="false" targetId="cacf-1879-9a46-9c66" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="75"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b73c-76f7-17f8-3903" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9cc7-9306-891c-5887" name="Great Griffon" hidden="false" collective="false" targetId="0ceb-e9be-fa78-150f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="150"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71c7-cdf0-f37d-4d1d" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="6fe4-ae8b-2fe7-f317" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="15b4-bc63-ae8e-3b1b" name="Dragon" hidden="false" collective="false" targetId="ca5d-3e42-5f9e-8e71" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="460"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="028f-4f2d-1812-7479" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5221-22b7-accf-79b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e81-49e6-d9ea-be79" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="373b-0f5e-74a3-d789" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="11c8-5e24-f965-a22b" name="Knight​ ​Commander​" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="15fc-335c-5598-26cb" name="Knight​ ​Commander​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1fa0-3f2e-c378-f34a" name="Knight​ ​Commander​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e517-597f-7d8e-0c94" name="Knight​ ​Commander​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5128-974f-58c2-600b" name="First Knight" hidden="false">
+          <description>When the model is joined to a unit of Knightly Orders, the unit gains Fearless, and if the model is the General, the unit also gains Parent Unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e523-339b-1a77-f8f7" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="496b-f0d6-9b2c-b239" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d6e6-5758-aec0-1cf5" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a667-b05b-f30a-174b" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="a9d5-d25f-5a80-242a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="e418-6953-4307-838f" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8293-0c1c-c0f9-660d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95e6-731e-4b93-941c" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d775-ecf5-6ca3-d17a" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc0f-a94e-f3de-c30b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="7e9f-e4d1-6798-a262" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="812f-e66a-e990-83cc" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="07dc-120c-cc32-eb28" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c04c-0180-7ac5-bd26" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53ee-679e-8b1f-5479" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0f8c-44fe-48c8-60ac" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="62aa-5036-3bcb-908a" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="800a-d15c-d730-075a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f164-7caa-e2fb-d479" name="Cavalry Pick" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b09-015d-f8be-08d4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="eba0-6f05-8be1-6c53" name="Cavalry Pick" hidden="false" targetId="ab25-b231-cec4-12f6" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e896-c62f-a29b-cf2d" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e441-a660-a1fb-13b9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="52e6-043b-6c6d-3463" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2d39-1ca3-f6ac-a7cf" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0414-31de-6ecb-af85" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="191a-e99b-3f4e-b0de" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2871-3cac-8e68-ae22" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f80c-60d7-6762-cb8f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3e37-62a3-7cc5-484f" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c682-a874-5805-a375" name="Mount" hidden="false" collective="false" defaultSelectionEntryId="d277-2cd7-b6fe-cea5">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="916b-cd49-2cc7-20fe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fbf-e4ab-435a-bcab" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d277-2cd7-b6fe-cea5" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed4-d376-0cc4-4b22" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="4b80-f9ad-c35f-e6ef" name="Young Griffon" hidden="false" collective="false" targetId="f733-dce6-f27c-3607" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c1c-c937-81c5-e61e" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e69-caa4-e244-5abf" name="Prelate" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="70a4-51ec-742c-c2b2" name="Prelate​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7ec8-4876-86cb-70e1" name="Prelate Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a6a9-c6ea-0733-7d84" name="Prelate​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4215-867a-4cd3-fde0" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1e69-caa4-e244-5abf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36bd-7551-d73e-6fed" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f9f7-132e-f246-02a3" name="Blessings" hidden="false" targetId="5543-ae42-0f1d-d5d3" type="rule"/>
+        <infoLink id="4760-07db-9def-9154" name="Divine Attacks" hidden="false" targetId="030a-8283-3ebb-93f1" type="rule"/>
+        <infoLink id="3a6c-da97-d3c1-a6df" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="14f6-6e1b-4c73-05de" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b0a4-448c-5f26-9a6a" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02f-d6fa-268e-1218" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="bec1-3faa-2e9a-eea5" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="7940-11db-ed88-3130" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7d8f-4c02-e412-6f62" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35c1-79f3-2a4b-4728" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1c42-6ac9-b3f9-f55a" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5c5-271d-fdea-a2b4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8c34-d099-9736-77c1" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="2681-8e4d-0ab9-7b2e" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="1fe5-1652-8aaa-0cdf" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a389-48a0-8d18-9ad7" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a74e-eae7-aeaa-febd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6b6a-deb6-ac02-162e" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="36bd-7551-d73e-6fed" name="Plate Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08d8-9fab-a366-9365" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="bc45-ef24-eea1-a1ec" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3b3e-118c-271b-fefe" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b3d-5520-3218-eab0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8488-3294-a7a4-b39c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b98f-d60f-a871-8087" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6868-4eff-080e-ecfc" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a256-ae1f-b845-ab2a" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f412-c6d2-79f9-5e4a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d087-2d5b-c651-d5eb" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="19de-5012-e602-b644" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03d9-f645-0466-01fb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="37bc-7e78-2a50-fd78" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="40"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde7-636f-1da8-a260" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="54a5-a274-d7de-da1f" name="Altar​ ​of​ ​Battle" hidden="false" collective="false" targetId="8d97-387f-45ee-5f63" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="370"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6721-c00f-df72-7c50" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="b628-16ae-ab0c-18f6" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="53b0-be9b-6101-a832" name="Wizard" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="bb96-8de6-a655-a3e0" name="Wizard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2594-19c8-ebf2-3308" name="Wizard Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2a36-2419-8d3b-1d9a" name="Wizard Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="c095-565e-dfa5-99c3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="77d5-33d9-cfa8-78ea" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a444-f949-f053-53bc" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="8c12-a8c4-1ea8-5b3c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="fc32-fedd-5074-be71" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a0ee-cbd3-b553-1141" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4426-c74b-6f64-eaec" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9c56-3b42-463a-fd9d" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="bfb0-cc48-e20b-85c6" value="200">
+                  <conditions>
+                    <condition field="selections" scope="53b0-be9b-6101-a832" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9846-7ae9-7020-e330" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfb0-cc48-e20b-85c6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b100-5cde-7bfa-2913" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="c9d4-ad50-1603-a4ed" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="287b-3747-47c2-486a" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="68d0-f364-1f9b-c844" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596c-0751-ae31-aa10" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6ffa-886c-838a-ada6" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3638-a7bd-58cc-b465" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56a4-999f-a81f-412c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d61c-571c-a807-7ae4" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="20"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e0-7097-d525-5b14" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="0bd8-d6f3-2cfd-c290" name="Arcane Engine" hidden="false" collective="false" targetId="6944-42d1-8941-6450" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="200"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c22-df46-4497-bc1e" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="734c-36a5-bf1b-2191" name="Pegasus" hidden="false" collective="false" targetId="cacf-1879-9a46-9c66" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="50"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49c3-6422-aeee-0737" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e1d7-8a59-0b79-d7e1" name="Great Griffon" hidden="false" collective="false" targetId="0ceb-e9be-fa78-150f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="100"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d29-4197-785d-6e4e" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="91db-ae46-9515-6b33" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f2f0-fed2-03ca-70e7" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="f9bd-97e5-61e0-01aa">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ab3-de94-d645-53d1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f77-2970-8735-ad4d" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f9bd-97e5-61e0-01aa" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb93-c7ee-39b8-9f37" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="962f-b9bb-0e85-acfe" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6062-c823-724f-4b60" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1aa-57f5-6f54-9e83" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0981-4893-ee63-2c06" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9846-7ae9-7020-e330" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8787-b19b-150c-e5e1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5c61-46c8-94d4-fa8c" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4598-de87-7a2a-8e9a" name="Path of Magic" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="cfe3-bd36-e265-fd9e" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfe3-bd36-e265-fd9e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="934a-d251-eff0-8376" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7866-df55-6d30-979c" name="Alchemy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d32-dab4-05f8-b602" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d114-6659-4145-ff89" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f77-0a28-fe4c-7176" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="946d-b325-86b9-e176" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4532-33f0-a70c-b3fd" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d66e-1363-fb49-a8aa" name="Cosmology" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00ed-964c-5fe5-d230" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc6a-e224-1943-b715" name="Inquisitor​" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="bc46-5c2c-1579-ecff" name="Inquisitor​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dcd2-0afe-b09e-2328" name="Inquisitor​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="768a-0c71-91fe-487a" name="Inquisitor​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f03a-f704-bc27-30ae" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="2731-d158-61a6-2056" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="5e6d-9ea2-1094-ad15" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="e222-5d15-8ee5-ee20" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="f8a8-6a79-8098-f879" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b718-5872-71e9-1c1e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="cc6a-e224-1943-b715" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4fa0-1c53-8045-9348" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="49e6-3fa8-3976-858f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4d18-6cd0-60d5-a2c9" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e7c-9509-5e1b-5c9b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="303d-e830-732d-2ba5" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e12-6ef3-5dc5-f85f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="364c-0bac-6393-c475" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="c9e1-57fc-250b-1553" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="2f59-070d-63a0-cc5c" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fcc9-feb6-6464-a2ff" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7310-00b0-9ef1-8321" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ef0f-b5c0-d250-33e2" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9547-6d94-0629-94b9" name="Blessed Steel" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c511-b3ae-22a6-383c" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="0920-2fa8-b273-5161" name="Blessed Steel" hidden="false">
+              <description>Attack Attribute - Close Combat.
+The model part gains +2 Agility. Close Combat Attacks made by the model part gain +1 Strength and +1 Armour Penetration.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b7ab-45e0-7344-94f6" name="Close Combat Weapons" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="652b-d679-c4b4-9ba1" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a376-8e15-e4ec-5dea" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3193-eb08-c1f4-77f1" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9af2-f82c-1873-be78" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e3d-babf-cdcf-127d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="13a9-3b76-502c-4ebe" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aa2c-fc29-a4f1-0015" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a73a-9566-1201-9705" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ab76-2941-ec0f-1c7a" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="91c0-f4af-fbbc-5bad" name="Shooting Weapons" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37b9-12d8-4ad9-e956" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9c35-72ab-d2f8-a93d" name="Crossbow (2+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b9-87bf-50ea-bb10" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7b2a-d3da-7191-5edd" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (2+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="50e5-0833-8e67-6411" name="Brace of Pistols (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="228c-0c05-6aed-137e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="53dc-406c-ed7f-4ec0" name="Brace of Pistols" hidden="false" targetId="0a78-70b9-c34e-5752" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0718-9858-b705-3f92" name="Repeater Pistol (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="911f-a493-bc51-c5fe" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cae9-8c0b-ea83-ec62" name="Repeater Pistol" hidden="false" targetId="ceb6-ffaa-c9f3-a019" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4fa0-1c53-8045-9348" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af01-9279-253c-fbb9" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bb34-a3af-2ede-80dd" name="Artificer" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="487c-ba82-ce2b-6101" name="Artificer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8a46-66a6-345b-9f49" name="Artificer Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e23c-af3c-bdb2-ffdf" name="Artificer Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="099e-2c56-791e-11e0" name="Master​ ​Artificer​" hidden="false">
+          <description>The Master Artificer may give the Order Ready! Aim! Fire! ​to a Parent Unit or Support Unit it has joined.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="4333-3a7d-62bb-116c" name="Engineer" hidden="false" targetId="c16c-8e9f-3d9c-7a2a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7354-edc9-cd4e-47b2" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6a2d-c41f-4c24-3e31" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="7a50-1ca3-b741-6b4b" name="Imperial Armoury (local)" hidden="false" targetId="ecde-c284-9850-23e1" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="acb5-4d20-6d87-978e" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3151-47d2-7ea2-6ea3" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1f63-ccda-0dfe-5757" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8acc-8ee9-29ca-9a89" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3538-4191-0fdb-038c" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="ca41-5928-7054-336b" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="102a-4dc8-587c-5d70" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7b16-d5b5-bfc7-0d24" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7266-cf91-0be5-442a" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="339c-e7c1-53d5-6bca" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="c8ba-d7b9-a993-809d" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="699c-0158-b18c-f9f2" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85e8-68b5-5daa-d8c7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8161-a98e-2da1-252b" name="Repeater Pistols (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e8-5cd5-bed6-93b9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="05be-58f4-5edc-88dc" name="Repeater Pistol" hidden="false" targetId="ceb6-ffaa-c9f3-a019" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ded9-49da-1019-69e0" name="Handgun (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e38-b74f-d688-c1b9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2322-75c6-1a93-f7da" name="Handgun" hidden="false" targetId="b092-dbc5-4c60-9a80" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bcbb-3880-0076-5494" name="Long Rifle (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="451c-9803-4008-cea8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a4dd-2d89-e044-7677" name="Long Rifle" hidden="false" targetId="d874-cc96-339c-1817" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="904b-b913-f084-71a6" name="Repeater Gun (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f9-a7b3-d0d9-2dad" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1de3-6ce3-9778-dbe3" name="Repeater ​Gun" hidden="false" targetId="29fc-4011-201c-832c" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a068-123b-131c-9790" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="20"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a7a-8b86-9708-9109" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd21-fe43-e8e5-42de" name="Heavy Infantry" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="61e2-24cd-1856-0d21" name="Heavy Infantry Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2379-fca9-05bf-f245" name="Heavy Infantry Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a0d3-12d8-ba01-3454" name="Heavy Infantry Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="eff9-7de6-dbeb-e40e" name="Parent​ ​Unit" hidden="false" targetId="f5ec-3ab9-9101-55c4" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="cd21-fe43-e8e5-42de" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0367-6d81-4202-fd07" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8f70-38c7-10f6-50b8" name="Support​ ​Unit" hidden="false" targetId="490a-c098-12b6-5697" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="cd21-fe43-e8e5-42de" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0367-6d81-4202-fd07" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b980-cf5d-7032-e964" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="4a05-3129-b421-10a7" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="c550-d087-7bea-0246" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9826-5abf-f8d8-8c7b" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0367-6d81-4202-fd07" name="Heavy Infantry" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3ea-5d47-26f1-c150" type="max"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4f3-3752-65de-ff9f" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b27-15c1-7bc9-5a3e" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="cd21-fe43-e8e5-42de" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b12b-636e-fd90-95c6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="557c-89e8-6710-b11a" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="985e-e09e-e995-fb70" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f96-209d-9876-c20d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ef6c-8a23-6a35-6874" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="cd21-fe43-e8e5-42de" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0367-6d81-4202-fd07" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88dd-2a38-5946-a0e9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="67b5-7ab7-3cce-5338" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6853-60b8-71f0-c03d" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="cd21-fe43-e8e5-42de" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0367-6d81-4202-fd07" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="409e-768b-fd54-277a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7dca-3033-71d3-eadf" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f440-0d40-8d87-43c4" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6217-1fc8-7a46-c411" name="Light Infantry" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="a17b-cfef-41cd-178f" name="Light Infantry Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ab94-21f6-7274-9b50" name="Light Infantry Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cfe3-1832-4f81-2316" name="Light Infantry Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8db3-ce37-642c-9bbb" name="Support​ ​Unit" hidden="false" targetId="490a-c098-12b6-5697" type="rule"/>
+        <infoLink id="1dcb-349e-3ec9-9b0a" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6217-1fc8-7a46-c411" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c93-8db0-0ada-4d05" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="de3e-e557-4f96-3f48" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8579-53cf-add1-b40f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="e611-46b3-5976-d6fb" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="52a4-3d10-5048-5e66" name="Light Infantry" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2fd-e5e8-a956-a5cd" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5060-3705-414c-ac92" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="13.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e026-d748-f05e-120d" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6217-1fc8-7a46-c411" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a29-7686-2a95-f307" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fd6a-9af7-5633-d522" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
+              </modifiers>
+              <categoryLinks>
+                <categoryLink id="2cdf-fe80-cc58-01d2" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c93-8db0-0ada-4d05" name="Replace Crossbow with Handgun (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b23-d277-b759-4ff4" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2439-fb7b-ce7b-49e2" name="Handgun" hidden="false" targetId="b092-dbc5-4c60-9a80" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="291a-d489-fe1f-50b6" name="Champion Weapon" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6217-1fc8-7a46-c411" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6cb-a235-adec-be10" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4aa9-2e34-9704-a752" name="Long Rifle (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="921f-2e51-20ab-2a6f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ea6a-c7e3-8163-8117" name="Long Rifle" hidden="false" targetId="d874-cc96-339c-1817" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="7969-f751-2dab-5247" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3a7a-c10b-ebe9-d1e7" name="Repeater Gun (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="422b-33de-d0bf-2258" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b028-dd55-a5e1-b8f7" name="Repeater ​Gun" hidden="false" targetId="29fc-4011-201c-832c" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d48c-a201-2bcd-3f3e" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8be2-58f8-e737-f847" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup">
+          <categoryLinks>
+            <categoryLink id="6a8a-2938-8e70-aba7" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cb4-3838-613c-723a" name="State Militia" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f7c-d5a8-60f4-c11a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4bfa-9e78-4f2e-de7f" name="State Militia Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a06e-d9d3-ec3b-8763" name="State Militia Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="973f-2d88-c1a7-341c" name="State Militia Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="ef05-7224-8c49-08aa" name="Reserves" hidden="false">
+          <description>The unit is treated as Insignificant by Parent and Support Units.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6c7b-1ea5-2cc6-c979" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6017-b832-9de5-3dc3" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="52ec-05ca-ce17-28f4" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dc9c-06fd-a0f4-a0b3" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="1468-2b81-e9d0-290a" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e036-5a83-75f4-8eb6" name="State Militia" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b63e-54d8-cfb1-2604" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7283-c866-be6b-eb2d" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9388-27ad-26f8-f692" name="Gain Skirmisher" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="2cb4-3838-613c-723a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e036-5a83-75f4-8eb6" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2cb4-3838-613c-723a" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e036-5a83-75f4-8eb6" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ad5-8535-376d-2a0f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a60c-acc5-6776-9bec" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="dbd8-09c3-04db-baf3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="994f-59e8-ca5c-eced" name="Electoral​ ​Cavalry​" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a463-1cb5-99ba-0332" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9f42-9600-d1d2-0767" name="Electoral​ ​Cavalry​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="214c-d11f-f705-9170" name="Knight Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="7a8c-adb0-d1b8-a1b6" value="1">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="7d3b-bb95-3d29-26f7" value="4">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="4d4a-2100-804f-99e5" value="4">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="abf4-1320-3f87-6564" name="Electoral​ ​Cavalry​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="160d-4624-273f-2114" value="4">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8bfb-9d66-49cc-d68b" name="Horse Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c9ac-1f42-e18e-ca5a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="7ff2-7aa1-8a7f-ab7c" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="c67e-6d14-5dab-a434" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1d58-71d4-a327-1b65" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="aac5-f506-0a44-23a0" name="Knight" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8127-420c-e175-4751" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b29-bbce-6931-fc0f" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="29.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2a01-37e3-f9b2-3b95" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d364-11ff-9faa-ddb0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fdc4-740a-1099-0b59" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6d56-4c57-7b29-6de8" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac5-f506-0a44-23a0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="037b-2575-e37f-7d8f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="964c-1a89-999d-a4c6" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8be5-6fb8-7f1f-3f0e" name="Knightly Orders" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="9">
+              <repeats>
+                <repeat field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac5-f506-0a44-23a0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="4ec3-01a7-afe6-29d8" value="-1">
+              <conditions>
+                <condition field="selections" scope="953d-22cd-7ee1-36dc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11c8-5e24-f965-a22b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6488-6dd2-2f03-95d3" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ec3-01a7-afe6-29d8" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6760-472d-d228-8314" name="May take a Cavalry Pick" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a250-fa1f-00c3-3ed5" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0578-f7ee-3ca6-6f2a" name="Cavalry Pick" hidden="false" targetId="ab25-b231-cec4-12f6" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4155-806d-ca25-390e" name="Close Combat Weapon" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6760-472d-d228-8314" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5806-73ba-1c42-4c90" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="94e5-4c04-ee9c-319a" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac5-f506-0a44-23a0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="782a-a52d-3462-15a0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5d0c-861d-cda4-26ee" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="528f-4eea-3844-0aa9" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac5-f506-0a44-23a0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0998-c359-37da-0042" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2cce-7c28-80f8-11f0" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="329a-9dd5-ed28-6791" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e284-efdf-ac17-ba70" name="Imperial​ ​Guard​" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="cda6-9512-e022-74ea" name="Imperial Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="44ca-ba45-52fd-83d2" name="Imperial Guard Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cdf2-9b2a-10d0-8c51" name="Imperial Guard Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="30c1-f5fb-d768-c02d" name="Parent​ ​Unit" hidden="false" targetId="f5ec-3ab9-9101-55c4" type="rule"/>
+        <infoLink id="9f73-af7a-9339-4ab9" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule"/>
+        <infoLink id="8973-30bf-f9e3-1dbe" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="ed1c-b545-6942-72bd" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e284-efdf-ac17-ba70" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f361-aecd-aca7-2ce5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0bba-6c24-45b8-8e9c" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="03f9-1f1c-0511-ccf8" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1099-6f76-ef83-8b96" name="Imperial​ ​Guard​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46af-4244-35e6-502c" type="max"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b719-ffbd-d73f-bc60" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="19.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ae51-4103-3617-8898" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e284-efdf-ac17-ba70" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a5a-f215-3621-5d8f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="60ea-836e-e056-4fab" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f361-aecd-aca7-2ce5" name="Replace Shield with Great Weapon" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="e284-efdf-ac17-ba70" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1099-6f76-ef83-8b96" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e56-b7fd-26a1-22de" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2e08-d11c-1ad5-4537" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="3496-5e04-8294-efc3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-105.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e18c-3280-0d47-8b63" name="Knights​ ​of​ ​the​ ​Sun​ ​Griffon​" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0224-b90b-8cdb-c4d3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0b75-5583-44ff-9f1c" name="Knights​ ​of​ ​the​ ​Sun​ ​Griffon​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cb7e-8366-ee0b-6a9f" name="Knight Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="16ae-2d3d-a7ba-eea6" name="Knights​ ​of​ ​the​ ​Sun​ ​Griffon​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cec9-e8dd-c076-48e8" name="Sun Griffon Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b3ac-7d7f-17be-ccbc" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="9c38-b675-8da5-f522" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="fa5e-8091-17ae-50cf" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="fa28-1565-d6f1-2f2e" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e18c-3280-0d47-8b63" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a06b-4dcc-f1a5-2293" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d91b-f8ef-e1ad-e52e" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="39c2-2fed-4f61-5240" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="83e3-a360-62ad-7262" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8e78-cdf8-2353-9755" name="Knights​ ​of​ ​the​ ​Sun​ ​Griffon​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d423-bd89-3e00-a066" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8e7-e221-3fe9-3891" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7612-f40e-9eb2-f996" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e18c-3280-0d47-8b63" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d08-a084-a71f-a19e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4fa2-22f4-31b9-fb9a" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a06b-4dcc-f1a5-2293" name="Replace Halberd with Lance" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+              <repeats>
+                <repeat field="selections" scope="e18c-3280-0d47-8b63" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e78-cdf8-2353-9755" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9b9-2fda-8c28-55b6" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4546-7939-3f13-940a" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="62b8-45ab-4c72-7c13" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a7dd-0b66-d973-431e" name="Imperial​ ​Rangers​" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fbd-740d-4551-66f8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d622-cbfc-2675-415a" name="Imperial​ ​Ranger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9d7d-d16c-61c8-9845" name="Imperial​ ​Ranger Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e26a-7caa-ac74-8ca5" name="Imperial​ ​Ranger Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f626-d2b2-7997-d2cc" name="Frontiersmen" hidden="false">
+          <description>The model automatically passes Panic Tests caused by Terror.</description>
+        </rule>
+        <rule id="4212-695d-1892-00e8" name="Beast​ ​Hunters" hidden="false">
+          <description>When using a Bow, the Shooting Attack gains Shots 2 and Lethal Strike (against Beast).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9677-2317-34a4-8d23" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="bf7b-e41f-2ce9-e6b7" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7d3f-8712-1893-b9a1" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="de39-0fc7-3c5e-809c" name="New CategoryLink" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8b8a-5853-9792-0286" name="Imperial​ ​Ranger" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d2d-b879-c5e3-0cc3" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c591-0a1e-5e99-c1b6" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4a2b-c06f-9a49-11b7" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1862-0173-68e8-a6ae" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0e1-5d93-be07-31b0" name="Reiters​" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="74cf-1f9b-f0f8-4348" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="83e1-37b7-79c1-1869" name="Reiter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="959f-5e10-bab1-add5" name="Reiter Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e332-bba7-4ef3-848f" name="Reiter Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e93c-97d9-43af-9248" name="Horse Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b727-b4ae-3d21-2500" name="Fire on Impact" hidden="false">
+          <description>Attack Attribute - Close Combat.
+A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, or a Repeater Pistol always strikes at Initiative Step 10, and has the Strength of its Close Combat Attacks set to 4 and their Armour Penetration set to 2 (regardless of the user&apos;s Agility, Strength, and Armour Penetration).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0fdf-9176-d6dd-78a4" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="ec3f-0b32-34bc-2e02" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e0e1-5d93-be07-31b0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b96-da38-7eea-a609" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="cf32-240d-42b5-e5ac" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="887a-d717-48a1-2156" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="530b-e7f4-b6a6-4da9" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="c30c-c04a-a256-e731" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="e0e1-5d93-be07-31b0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="791b-d7b5-c7af-f7a5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="afc7-2bad-fa99-85d6" name="New CategoryLink" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="25e2-52e6-5a70-ea68" name="Reiter" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af72-bc10-a245-14eb" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f516-17e4-716b-c48b" type="min"/>
+            <constraint field="selections" scope="roster" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b01-fdcd-5136-e5e0" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="29.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a99b-d095-e353-ad0a" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04a3-0255-65a3-4270" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b2e5-74a5-dcc3-2028" name="Repeater Pistol (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b71-f144-f767-2793" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="71dd-7472-ec58-4bf0" name="Repeater Pistol" hidden="false" targetId="ceb6-ffaa-c9f3-a019" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d3c7-3628-8b5a-fbb9" name="New CategoryLink" hidden="false" targetId="cf04-8e72-df44-eac3" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6fbc-08ad-df19-63e9" name="Musician" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="213a-35e4-a30a-6b42" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="791b-d7b5-c7af-f7a5" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="e0e1-5d93-be07-31b0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25e2-52e6-5a70-ea68" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f1c-e887-11f7-1565" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4b96-da38-7eea-a609" name="May replace Pistol with" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c748-a25a-8992-9e3d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d1f7-f1bd-f31b-37de" name="Brace of Pistols (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="e0e1-5d93-be07-31b0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25e2-52e6-5a70-ea68" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3e3-053c-b737-81d4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1fc4-e35a-25fd-5935" name="Brace of Pistols" hidden="false" targetId="0a78-70b9-c34e-5752" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0264-fc40-7fb3-8d44" name="Repeater Gun (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="e0e1-5d93-be07-31b0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25e2-52e6-5a70-ea68" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2af1-4513-cec6-d508" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5730-38e5-95fb-9df9" name="Repeater ​Gun" hidden="false" targetId="29fc-4011-201c-832c" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="57a0-8f67-1424-4d79" name="Light Lance and Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e13e-1b8a-88e5-74db" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cc30-6a9d-ade6-e7c9" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+                <infoLink id="5c9e-e56b-d17e-e0c6" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1dca-cb02-030a-ef74" name="Artillery" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6176-b01f-f219-cc1d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="84e2-6dff-642f-7e18" name="Artillery Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="be8c-e8d6-9b6d-e6bd" name="Crew Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="39cd-f8b0-2563-c7a2" name="Artillery Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5cc3-28b8-3201-5cf1" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a436-6e21-c5ed-e563" name="New CategoryLink" hidden="false" targetId="ecde-c284-9850-23e1" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bdc8-69c7-c94b-d115" name="Must become one" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b32-155c-0894-b687" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29f3-f085-411c-16e6" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9aa4-a175-5a2b-d960" name="Cannon​​ (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f34-3f08-9ded-0cab" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8063-9c70-ba44-b25d" name="Cannon​​ (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">72&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4[10]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0[10]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Cannon, [Multiple Wounds (D3+1, Clipped Winds)]</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="f237-49c4-9df4-3c6a" name="Cannon​​ (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">4</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="250.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a1bf-8bbf-2437-9757" name="Volley Gun (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7dd0-6d9c-a298-1f57" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="1ded-ec94-d6df-279b" name="Volley Gun (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3D6*2</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="55c3-ea0c-777b-00ce" name="Mortar (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3027-d35d-ae43-1130" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="3cfa-75d5-a206-86ac" name="Mortar (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;-48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3[6]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">1[4]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (6), [Multiple Wounds (D3)]</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="095f-c036-8c94-0b45" name="Imperial​ ​Rocketeer​ (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6778-42ff-6d35-83a4" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8c6d-487f-cb69-4e82" name="Imperial​ ​Rocketeer​ (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">15&quot;-48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (1), Multiple Wounds (D3), This weapon treats all results on the Misfire Table as Malfunction (each shot can cause a Misfire).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="23fa-443a-7d84-7fc2" name="Arcane Engine" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d1c-8555-899f-a986" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b82e-d61a-2371-44ee" name="Arcane Engine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9461-172e-4804-c945" name="Horse (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4d52-0b8e-6cca-dd7c" name="Arcane Engine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4a9b-6025-3c5d-313d" name="Crew (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dadf-986f-4395-e434" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="037c-3e4a-a0d8-594f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="abc9-73f8-b538-436a" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="7941-2547-d2b7-1c68" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8bf1-216f-1688-7573" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="e75d-e295-4e87-96ba" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="76e7-02ab-ecbb-cc4a" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ac79-cc5c-06a6-bcbb" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c4a3-d099-ece3-6059" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc99-c06e-982d-7c60" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94aa-cc17-6830-b0e1" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="75ca-3095-8c52-8471" name="Arcane Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc35-f630-a416-2516" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="e0bb-affb-a80c-d632" name="Arcane Shield" hidden="false">
+                  <description>Friendly units within 6&quot; of the model gains Distracting. The Arcane Engine can cast Perception of Strength from Cosmology as a Bound Spell with Power Level (4/8).</description>
+                </rule>
+              </rules>
+              <categoryLinks>
+                <categoryLink id="a4c5-a39a-36da-76c2" name="New CategoryLink" hidden="false" targetId="2a59-0397-1496-1d3e" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="95d3-4682-f3f3-9e1e" name="Foresight" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfcc-fc55-da7b-634f" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="074b-ce1c-83bf-c633" name="Foresight" hidden="false">
+                  <description>Friendly units within 6&quot; of the model gains Lightning Reflexes. The Arcane Engine can cast Ice and Fire from Cosmology as a Bound Spell with Power Level (4/8).</description>
+                </rule>
+              </rules>
+              <categoryLinks>
+                <categoryLink id="2af1-9fdf-73df-eff2" name="New CategoryLink" hidden="false" targetId="2a59-0397-1496-1d3e" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="290.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9362-c4d4-f0fe-84e7" name="Flagellants" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9514-182f-3593-a8d2" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0ab0-4d67-97a8-3a91" name="Flagellants Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="82bb-2fae-0668-16c6" name="Flagellants Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d05a-f8b2-da1e-6e6c" name="Flagellants Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="dd23-22c9-2c13-d5ca" name="Zealots" hidden="false">
+          <description>Prelates may join this unit and gain Unbreakable while in the unit.</description>
+        </rule>
+        <rule id="92fd-ed10-2350-b93f" name="Fanatical" hidden="false">
+          <description>When a model with Fanatical is killed by a Melee Attack, remove it as a casualty only at the end of Initiative Step 0.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="cf64-f64b-39c2-564b" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="733d-2cf1-f60e-414b" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="8d92-20bc-716e-1765" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="4eea-a8da-d85b-014c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fe74-3905-a70f-a0de" name="New CategoryLink" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4cf4-4e59-2140-83dc" name="Flagellant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47a8-b710-fc02-6826" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bf9-eff8-e360-3a03" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b09-082d-f0fb-a8f2" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfaa-00c2-59ce-fda3" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="92cc-2df6-7b8c-4b24" name="Steam​ ​Tank​" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="553b-90bc-f2f9-b376" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="dd72-55a8-db97-e32d" name="Steam​ ​Tank​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4D3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3ea8-b372-c6fe-a0a1" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8eb3-29fc-a15f-6d49" name="Steam​ ​Tank​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="264f-e284-9a23-4447" name="Steel Ram Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5e30-5c14-f241-2f87" name="Steam Cannon (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">36&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3[7]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">0[6]</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3, Clipped Wings)]</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a7c2-a1ca-b229-e373" name="Steam​ ​Powered" hidden="false">
+          <description>The model may choose not to move despite having Random Movement, and cannot Pursue or Overrun. Before Moving in the Movement Phase, the model may choose to replace its Random Movement (4D3) with Random Movement (5D3) until the end of the Movement Phase. If so, the Steam Cannon cannot be used during this Player Turn.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="dccb-ccaf-382b-b682" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="8cfb-0f2c-c9b7-cb31" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="7d7e-c518-fd67-771e" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="34d4-3532-fec2-0ea9" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4700-e8bb-62be-5106" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e8c7-7b62-ec2a-71ad" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 2, AP 3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a584-e6c0-6608-84b8" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="09f3-f1d6-396e-08c5" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a5b2-dc0c-02b3-b74e" name="Imperial Armoury (local)" hidden="false" targetId="ecde-c284-9850-23e1" primary="false"/>
+        <categoryLink id="415d-abd7-8b0a-b9e2" name="New CategoryLink" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="475.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="53f6-c4b8-4420-0d89" name="Inquisitor​ (Silver Shots)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a98b-7228-5c28-bbe4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c705-d0a3-f8a8-123d" name="Inquisitor​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2652-a8be-34ef-e8ef" name="Inquisitor​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b560-8fc4-5aec-5a86" name="Inquisitor​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a0c1-fed8-c82f-0de8" name="Silver Shots" hidden="false">
+          <description>Attack Attribute - Shooting.
+The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-wound rolls.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="bfde-fa63-fcd2-2a3d" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="5517-77a8-8dc7-7e5e" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="2b54-7008-d1bb-b151" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="55b7-a067-d479-f74e" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="5f58-d4bf-6571-45bd" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="eabb-3bb6-8481-969e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="53f6-c4b8-4420-0d89" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b403-cb82-ea15-3b55" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5823-7885-c1c7-ecfc" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="a988-3b01-6d75-5209" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6965-ce4c-e264-2d0a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d99e-c69a-9b66-c433" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d1dd-ffee-4176-f37a" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf60-af6b-1635-bcd2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="30a9-c058-f831-8c82" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
+                <entryLink id="e7c1-314e-bc7c-265c" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="5d6e-8d7c-43ad-10d9" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2278-3552-d27e-4be6" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e64-628d-3970-31c8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="acac-8d60-ae83-206e" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4b08-1f6d-feb5-279b" name="Close Combat Weapons" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="c76d-f5cb-0c51-d02d" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a10-b0f3-76a5-6538" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3b1d-d230-1014-eb6f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1a34-e0c6-a9e5-f2be" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d07-0b92-9195-f026" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ca4b-75a5-9911-10ac" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1817-25a5-db63-6d17" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bd-e626-761d-e389" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2dd2-3960-b372-874a" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d060-6761-317f-eb27" name="Shooting Weapons" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="672b-f023-8032-7c8a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f8cf-300a-5043-0089" name="Crossbow (2+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b003-bd68-9ddc-998a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="114a-21c9-a169-de85" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (2+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7561-de75-393d-e503" name="Brace of Pistols (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="398d-1ebc-a29a-8a2e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="644d-0ae1-30aa-52f4" name="Brace of Pistols" hidden="false" targetId="0a78-70b9-c34e-5752" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e143-fb35-43f2-f63b" name="Repeater Pistol (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c8-c990-92e3-d52f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3e08-5e15-955d-ee52" name="Repeater Pistol" hidden="false" targetId="ceb6-ffaa-c9f3-a019" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b403-cb82-ea15-3b55" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cda-8d4a-30fb-070a" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="205.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="10e6-5007-fc0c-e82a" name="Horse" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3cd3-fa7c-d9e3-a065" name="Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ee6e-4f6e-83aa-8750" name="Horse Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3fb8-deb2-4a68-929a" name="Horse Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a074-a310-5eee-6605" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cacf-1879-9a46-9c66" name="Pegasus" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="90fb-367a-8527-c30c" name="Pegasus Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 7&quot;, Fly 8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 14&quot;, Fly 16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1c15-2c79-6987-b66d" name="Pegasus Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f284-8e39-4d04-19dd" name="Pegasus Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6d86-203c-8493-95ad" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f733-dce6-f27c-3607" name="Young Griffon" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7f3f-9ed3-1579-5203" name="Young Griffon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6d12-bb94-1e4a-be71" name="Young Griffon Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f410-be14-02b6-1629" name="Young Griffon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="da47-9202-57b1-c1ef" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="bac0-42a6-27af-00d3" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0ceb-e9be-fa78-150f" name="Great Griffon" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="0ecb-630c-a410-944f" name="Great Griffon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 7&quot;, Fly 8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 14&quot;, Fly 16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0a79-e875-e4f7-d544" name="Great Griffon Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5c08-aa4f-2bbb-0b7b" name="Great Griffon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8531-90ee-a808-e3e9" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="6e17-3bb5-a05d-68aa" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="2f1b-ed21-5439-b7d2" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ca5d-3e42-5f9e-8e71" name="Dragon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="41ed-1978-8365-ba01" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="51be-2a26-9fe7-ccd0" name="Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 6&quot;, Fly 7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 12&quot;, Fly 14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0afd-b153-6565-3984" name="Dragon Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cce9-b8f4-1992-f0f7" name="Dragon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8c12-85bc-ecd4-3478" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="c00b-1c0c-5afd-d701" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP 1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6944-42d1-8941-6450" name="Arcane Engine" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="9a63-293f-1639-cd4d" name="Arcane Engine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0181-bc8b-9d44-fc2a" name="Horse (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a28f-53b3-67e5-6b58" name="Arcane Engine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="358b-5ec0-b4bd-8533" name="Crew (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bb25-217c-91dd-f971" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="75c9-2d14-391e-f142" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="2787-1dff-7b78-eef5" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="8d49-cb57-96e1-93a1" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="33ac-34c9-45cc-f538" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="43d0-5a08-3239-91eb" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="9bf1-7b14-dffa-89f7" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e360-520d-5691-dcf9" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="329b-d367-8e95-de8e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f54-3eac-02f0-0cd8" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e378-ad9a-9196-d17a" name="Arcane Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ee0-56f8-9aec-5e4c" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="a8cf-8d4b-0cdf-5627" name="Arcane Shield" hidden="false">
+                  <description>Friendly units within 6&quot; of the model gains Distracting. The Arcane Engine can cast Perception of Strength from Cosmology as a Bound Spell with Power Level (4/8).</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d3f6-9f45-8606-55bc" name="Foresight" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9443-0d87-2d77-459a" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="d814-a81a-e121-6c15" name="Foresight" hidden="false">
+                  <description>Friendly units within 6&quot; of the model gains Lightning Reflexes. The Arcane Engine can cast Ice and Fire from Cosmology as a Bound Spell with Power Level (4/8).</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8d97-387f-45ee-5f63" name="Altar​ ​of​ ​Battle" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b146-a4ee-df82-a2c8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6aeb-dfa7-6f9e-0267" name="Altar​ ​of​ ​Battle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e4f8-24f7-98ee-bb1e" name="Horse (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="56c1-de65-fe71-ed3f" name="Altar​ ​of​ ​Battle Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="097e-e47e-25a1-fec0" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="d009-c2a9-f946-bcd5" name="Holy​ ​Relic" hidden="false">
+          <description>All models in friendly units within 6&quot; of the bearer gain Hatred. Model parts with Harnessed are not affected.
+All Blessings Bound Spells cast by the rider have Type: Aura and Range 6&quot; (replaces Type: Caster’s Unit).
+The model can cast Unerring Strike from Divination as a Bound Spell with Power Level (4/8).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b2ae-9459-4ec8-c83c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="42c0-5538-cd2b-8e2e" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="7d2e-a93f-3c4b-be67" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1a08-5814-f60b-c919" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="297c-be89-00dc-26c8" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="78c2-4134-a773-4061" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1ca8-e2bf-3564-9c1f" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="60e0-a887-6970-1fc7" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0b6-d79f-6d3b-c644" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7d-dd32-dd7d-9feb" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4ec-d9b4-be05-7db0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11d2-db14-910f-55a3" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e61a-1249-7943-abae" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="53e0-007c-21bc-d3cc" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ac-d9b3-2e5d-a685" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="946c-19e4-caac-d0d4" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d982-8333-5616-0f97" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a273-4302-85fb-4c70" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="c8f1-3b4d-c247-25ea" name="Weapon Enchantments - EoS" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d16-0a92-72b1-ae91" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="3b29-9455-2fff-c706" name="The Light of ​​Sonnstahl" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fe8-06a8-c838-0fbb" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78dd-1451-bda0-c1a4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="48d1-1427-d485-ff39" name="The Light of ​​Sonnstahl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon wound automatically, always have Armour Penetration 10, and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="155.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fb7f-0cdc-3f83-58a3" name="Death​ ​Warrant​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b68-c562-f664-5368" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f85c-cbaf-4555-29ce" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8fa4-7cc2-66e7-473e" name="Death​ ​Warrant​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Battle Focus and Magical Attacks. If a hit is scored with it against an enemy unit, friendly models with Parent Unit or Support Unit gain Battle Focus with attacks allocated against the same enemy unit in the same Phase in subsequent Initiative Steps.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="b3e9-ea03-aa2d-d834" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9fd6-43b0-e619-fa1a" name="Hammer​ ​of​ ​Witches​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f71-65f9-5590-9250" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe61-fba0-2cec-cda7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0947-ffd4-4a69-84cf" name="Hammer​ ​of​ ​Witches​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer has its Attack Value set to 5 when using this weapon, and attacks made with it gain Battle Focus (against Channel) and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ba32-8574-fdc2-2a91" name="Armour Enchantments - EoS" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="1d6a-8a6d-6e0d-ad36" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d6a-8a6d-6e0d-ad36" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6016-da9f-68db-372d" name="Blacksteel​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f627-9b66-685e-0909" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="671b-086d-1435-d634" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="59f7-b13f-63d2-8249" name="Blacksteel​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and Fear. If taken by a model on foot, the wearer gains an additional +1 Armour.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8efe-4463-a54c-b67b" name="Imperial​ ​Seal​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a7-fec3-6102-c131" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3729-ada6-7485-db0e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1bc0-7239-c448-1872" name="Imperial​ ​Seal​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour enchantment. Models on Foot Only</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +3 Armour and +1 Discipline. The wearer’s unit cannot voluntarily declare Flee as a Charge Reaction.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d059-f85a-e731-1bb1" name="Shield​ ​of​ ​Volund​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbef-bdef-8a41-49a2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e6ac-578c-7048-fa31" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e44b-2051-7c2d-bc85" name="Shield​ ​of​ ​Volund​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, attacks against the bearer with Lethal Strike and/or Battle Focus lose these Attack Attributes.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="afe4-7ba9-ceb4-611c" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1cc6-87e4-05ec-b8d6" name="Witchfire​ ​Guard​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8788-3be3-22a2-cea1" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23d7-6180-837e-5824" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6617-cd27-45dd-d87a" name="Witchfire​ ​Guard​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (4+) against Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="2bd6-e08d-7f11-eda6" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="834d-a309-413c-9419" name="Atefacts - EoS" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30d5-3d00-2c00-d344" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="14ff-c20b-88f8-ccb3" name="Winter​ ​Cloak​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f24-9352-f700-7ef8" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58e5-54ae-5ca2-2a55" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="302b-fecb-81ef-5253" name="Winter​ ​Cloak​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Distracting, Aegis (5+), and Aegis (2+, against Flaming Attacks).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="0b7d-bd28-7bf1-7b30" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="8e46-a3fd-7f58-5ac3" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+            <infoLink id="bcb1-c30f-50ef-5511" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value="(2+, against Flaming Attacks)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3907-d67c-4902-fd03" name="Exemplar’s​ ​Flame​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="051a-85ae-2c66-7368" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cedc-1e48-d8f9-ab64" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3727-404e-a918-384a" name="Exemplar’s​ ​Flame​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Wizards only. Dominant.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Choose a single Parent Unit after Spell Selection (at step 8 of the Pre-Game Sequence). At the start of any friendly Melee Phase, if the bearer is within 18” of the chosen unit, the controlling player may choose to discard a single Veil Token from their Veil Token pool to grant all R&amp;F model in the chosen unit Lethal Strike and Magical Attacks until the end of the Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e1a3-307a-ba39-b0d4" name="Locket​ ​of​ ​Sunna​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e8-7021-7296-4104" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a464-14f3-deeb-ca1d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="db1d-6005-6df8-dce5" name="Locket​ ​of​ ​Sunna​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When fighting in a Duel, choose a single model part with neither Harnessed nor Inanimate that the bearer is fighting with.  The bearer must swap its Characteristic values of Strength, Armour Penetration, Resilience, Agility, and Attack Value with those of the chosen model part. This is done before applying other modifiers.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="59d7-48fb-e8c5-3340" name="Mantle​ ​of​ ​Ullor​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="533d-e570-8dc6-482f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29db-1391-af09-fba3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="29dd-dacc-35ee-68cf" name="Mantle​ ​of​ ​Ullor​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Enemy units within 6&quot; of the bearer do not gain +1 Agility for Charging Momentum.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="35b1-4d99-c535-6586" name="Karadon&apos;s Courser " hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed0a-f43c-7cf7-a0d1" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="edf2-5b34-9fc0-374f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f97c-2375-5e90-2fb3" name="Karadon&apos;s Courser" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Knight Commanders and Marshals mounted on Horse only.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any friendly Player Turn. For the duration of this Player Turn, all friendly units within 6” of the bearer must reroll failed Charge Range rolls.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1818-95b1-17ee-cc01" name="Banner Enchantments - EoS" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc21-b0c1-8041-011d" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d88a-1dab-f22a-19f9" name="Banner​ ​of​ ​Unity" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b89-4817-ceb5-df30" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57f1-527d-8460-65a0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="482e-62d4-4093-97e7" name="Banner​ ​of​ ​Unity" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Parent Units Only</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Whenever the bearer’s unit is targeted by an Order, an additional Order can be given (for free) to a single Support Unit within 8&quot; of the bearer’s unit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5366-4998-8b9b-e744" name="Household​ ​Standard​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aab-38f5-646b-21dd" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b09-d919-1c16-e062" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e0aa-7ac1-473a-83fd" name="Household​ ​Standard​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If the General is part of the bearer’s unit, its Commanding Presence range is increased by 6”.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f8e9-a3e5-a1e0-bc3e" name="Marksman’s​ ​Pennant​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a66-1208-9576-9e57" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9552-3fe4-0ec3-e452" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dac6-4f2f-6641-2a2d" name="Marksman’s​ ​Pennant​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit does not suffer the -1 to hit penalty for Stand and Shoot Charge Reactions.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="98d6-19e5-b41f-5703" name="Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="6e51-a7b5-42f1-6f1f" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e51-a7b5-42f1-6f1f" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="ee86-8621-10a6-876b" name="Armour Enchantments - EoS" hidden="false" collective="false" targetId="ba32-8574-fdc2-2a91" type="selectionEntryGroup"/>
+        <entryLink id="3002-aeb6-ca5d-e72a" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b0ad-eb3e-4b5c-29c0" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cca-78a8-6b6e-86ca" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="18b3-f897-4a24-a3af" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+        <entryLink id="6676-45eb-a748-cfa5" name="Atefacts - EoS" hidden="false" collective="false" targetId="834d-a309-413c-9419" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b7c0-c16c-b10e-715e" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dad5-3527-20f0-59c7" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="9efa-ce4f-ced5-2227" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+        <entryLink id="75bd-1d03-1407-90f2" name="Weapon Enchantments - EoS" hidden="false" collective="false" targetId="c8f1-3b4d-c247-25ea" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c931-0039-b6cd-89b2" name="Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0bb4-1b2d-c3b8-aea4" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="91ee-1934-23f2-a6be" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+        <entryLink id="e7da-64e1-45b7-cc6d" name="Banner Enchantments - EoS" hidden="false" collective="false" targetId="1818-95b1-17ee-cc01" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="5543-ae42-0f1d-d5d3" name="Blessings" hidden="false">
+      <description>Blessings
+All models in the bearer&apos;s unit gain Hatred. Model parts with Harnessed are not affected. The model can cast the following three Bound Spells with Power Level ( ​4/8 ​) with Type: Caster’s Unit and Augment, and Duration: Lasts One Turn:
+Ullor’s ​ ​Blessing - The ​ ​target ​ ​gains ​ ​Aegis ​ ​(5+) ​ ​against Melee ​ ​Attacks.
+Sunna’s ​ ​Blessing - The ​ ​target ​ ​gains ​ ​Flaming ​ ​Attacks. ​ ​All enemy ​ ​units ​ ​in ​ ​base ​ ​contact ​ ​with ​ ​one or ​ ​more ​ ​targets ​ ​of ​ ​this ​ ​spell, ​ ​when ​ ​the spell ​ ​is ​ ​cast, ​ ​suffer ​ ​D6 ​ ​hits ​ ​with Strength ​ ​4, ​ ​Armour ​ ​Penetration ​ ​1, Flaming ​ ​Attacks, ​ ​and ​ ​Magical ​ ​Attacks.
+Volund’s ​ ​Blessing - The ​ ​target ​ ​must ​ ​reroll ​ ​failed to-wound ​ ​rolls ​ ​with ​ ​Melee ​ ​Attacks.</description>
+    </rule>
+    <rule id="f5ec-3ab9-9101-55c4" name="Parent​ ​Unit" hidden="false">
+      <description>A unit is considered a Parent Unit if at least half of its models have this Universal Rule. Parent Units treat all Support Units ​ ​as ​ ​Insignificant.
+When a Parent Unit rolls successfully on a Charge Range roll against a non-fleeing enemy unit ​, before performing the Charge Move, any Support Units within 6” of the Parent Unit may perform a support charge. To do so, the Support Unit Declares a Charge against the same enemy unit. Apply all of the usual rules for charging for this out-of-sequence charge (such as Line of Sight, Front Arc, must roll Charge Range, max one Wheel, etc.), with the exception that the enemy cannot choose a Charge Reaction other than Hold. For the purpose of Charge Moves, treat this as any other case of Multiple Charges. When calculating Combat Resolution in the following Melee Phase, combine the Rank Bonus of both the Parent Unit and up to one Support Unit that performed a successful support charge (following all normal restrictions), up to a maximum ​​of ​​+6.</description>
+    </rule>
+    <rule id="490a-c098-12b6-5697" name="Support​ ​Unit" hidden="false">
+      <description>A unit is considered a Support Unit if at least half of its models have this Universal Rule. Support Units are treated as Insignificant ​by ​Parent​ ​Units.
+Support Units within 8” of at least one Parent Unit gain Fight in Extra Rank and may use Shooting Attacks from the 3rd rank (in addition to the 1st and 2nd). ​If the Support Unit has at least one Full Rank, it counts as having the same number of ​ ​Full ​ ​Ranks ​ ​as ​ ​a ​ ​Parent ​ ​Unit ​ ​within ​ ​8&quot; ​ ​for ​ ​the ​ ​purpose ​ ​of ​ ​​being ​ ​​Steadfast. During ​ ​the ​ ​opponent&apos;s ​ ​Charge ​ ​Phase, ​ ​Support ​ ​Units ​ ​may ​ ​perform ​ ​one ​ ​of ​ ​the ​ ​following ​ ​actions:
+1. Immediately after a Parent Unit within 8&quot; ​voluntarily ​chooses a Charge Reaction, the Support Unit may Stand and Shoot as if ​the enemy had Declared a Charge against them in their current position (apply the normal rules for​ ​the​ ​Stand​ ​and​ ​Shoot​ ​Charge ​ ​Reaction).
+2. Immediately after all enemy units have completed their Charge Moves, Support Units within 8” of any Parent Unit that was successfully charged in this Phase may counter charge. To do so, choose one enemy unit that successfully charged the Parent Unit and Declare a Charge with the Support Unit. Apply all of the usual rules for charging for this out-of-sequence charge (such as Line of Sight, Front Arc, must roll Charge Range, max one Wheel, etc.). When calculating Combat Scores in the following Melee Phase, combine the Rank Bonus of both the Parent Unit and up to one Support Unit that performed a successful counter charge (following all normal restrictions), ​​up​ ​to​ ​a ​ ​maximum​ ​of ​+6.</description>
+    </rule>
+    <rule id="a061-bfd0-1d95-1b9e" name="Orders" hidden="false">
+      <description>A Character with Orders may give a single order to a Parent or Support Unit within 8&quot;. A General with Orders may instead give a single order to a friendly Parent or Support Unit within the range of its Commanding Presence. Orders are given at the start of each friendly Player Turn. The effects of orders apply immediately to the target unit and last until the end of the next Player Turn. A unit cannot receive the same Order more than once during the same turn. Only ​models of Standard Size ​are affected. The available ​ ​orders ​ ​are ​ ​listed ​ ​below:
+On ​ ​The ​ ​Double! - The ​ ​target ​ ​gains ​ ​​+1 ​ ​Advance ​ ​Rate ​ ​​and ​ ​+4 ​ ​March ​ ​Rate. 
+Steady, ​ ​Men! - Discipline Tests taken by the target are subject to Minimised Roll. A unit that receives this Order and passes a Rally Test doesn’t become ​Shaken, and the Reform that is made after Rallying doesn’t prevent the unit from moving and/or shooting (but it still counts as having moved for shooting purposes).
+Ready! Aim! ​Fire! - The target​ ​gains​ ​​Accurate.
+Brace ​For​ ​Impact! - The​ ​target​ ​gains​ ​Fight ​in​ ​Extra​ ​Rank.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="ab25-b231-cec4-12f6" name="Cavalry Pick" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">-</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+      </characteristics>
+    </profile>
+    <profile id="29fc-4011-201c-832c" name="Repeater ​Gun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Unweildy</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ceb6-ffaa-c9f3-a019" name="Repeater Pistol" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire. If the model is also equipped with a Pistol or Brace of Pistols, this weapon gains ​​Shots​ ​4.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d874-cc96-339c-1817" name="Long Rifle" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">​Multiple​ ​Wounds​ ​(2,​ ​against ​​Standard), ​​Unwieldy</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0a78-70b9-c34e-5752" name="Brace of Pistols" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick​ ​to ​Fire. Counts ​as ​Paired Weapons in Close Combat.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/highbornElves.cat
+++ b/highbornElves.cat
@@ -1,0 +1,4190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="66f6-8610-3962-63fa" name="Highborn Elves 2.0" revision="24" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="7eaf-eaa2-9211-8018" name="Ancient Allies (local)" hidden="false"/>
+    <categoryEntry id="3eec-2473-17c3-c831" name="Naval Ordnance (local)" hidden="false"/>
+    <categoryEntry id="0bd4-287b-6755-4532" name="Queen&apos;s Bows (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="e28c-c4d0-2f7b-2de3" name="Highborn Elves (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="c39e-d4ff-c08d-e33a" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="de08-1e1c-8e24-124f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0221-212b-4cad-cd3b" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="73a3-4484-1236-aa8d" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6014-5f16-1814-e4c3" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="41ea-ea29-b44d-273f" name="Queen&apos;s Bows (local)" hidden="false" targetId="0bd4-287b-6755-4532" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="c490-16de-56d5-d43a" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7c3b-0fe3-0ba8-5974" name="Naval Ordnance (local)" hidden="false" targetId="3eec-2473-17c3-c831" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="15.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="67e3-d33b-8d99-76e1" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d31f-b26d-5f8a-9b8c" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="1446-332c-07d0-e5b3" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="903c-ad61-5d7b-1be7" name="Highborn Elves - Queen&apos;s Cavalier (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="d41a-302c-9d94-99fb" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="50.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="dc9a-6413-9142-ae3b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6717-e715-99a2-058c" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="774b-fe80-bcb5-509b" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="db1b-141f-653a-4cc6" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="19b6-ced5-16b8-617d" name="Naval Ordnance (local)" hidden="false" targetId="3eec-2473-17c3-c831" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="0.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="d082-5c88-dcc6-62eb" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6625-c256-4a0a-1c62" name="Queen&apos;s Bows (local)" hidden="false" targetId="0bd4-287b-6755-4532" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="452a-72d2-d59a-a569" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8444-96a4-c5ad-52dc" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="3c9b-1cc3-6a33-3705" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="3979-e311-2b38-8142" name="High Prince" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="57eb-6b38-b4c6-bf8c" name="High Prince Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="db46-d344-a6b6-2133" name="High Prince Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ba65-46e7-234d-33dc" name="High Prince Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">8</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6475-1eb3-5d67-b528" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="3d71-acaa-ac9f-0ee9" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="33b3-0d8d-5529-0a13" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7fc3-5a6a-782e-1d28" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6ac-e804-e9ab-de0a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4801-cf44-1bb7-44d3" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e076-3f59-a2a6-b7a7" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="13c3-8489-2e7a-7fab" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df5c-0bba-15be-9a49" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="fa42-3054-d0c9-1e46" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="e8ce-5ed9-2777-6dbb" name="HBE Weapon Enchantments" hidden="false" collective="false" targetId="aa7f-2c1a-a9af-1543" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5947-c17e-d7e4-84ca" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="bed7-e933-1f7d-f642" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bed7-e933-1f7d-f642" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="97c7-6b84-6b87-526b" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="9b51-3ecb-b9ce-8e0d" name="HBE Armour Enchantments" hidden="false" collective="false" targetId="6fe8-7e32-a5cf-f641" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="fa38-4568-9bef-5187" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e3-1e9f-af32-6cd2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7b7c-a4cd-32d8-5a11" name="HBE Artefacts" hidden="false" collective="false" targetId="8bcf-f60e-eb31-1ec0" type="selectionEntryGroup"/>
+                    <entryLink id="640d-cdbf-201f-9014" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="90d1-ffec-5d1d-a11a" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2d0f-48a2-5a26-6609" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e365-c5b5-fbbb-19ff" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e8e5-26df-b27e-9ad1" name="Longbow (0+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d391-2b75-4575-dc97" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="47a8-b00c-3ba1-acb6" name="Longbow (0+)" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="586b-0f2a-831a-f1f7" name="2 Additonal Learned Spells" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3979-e311-2b38-8142" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="378a-7742-6b0d-d086" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="821f-2b38-0976-9bc6" value="1">
+              <conditions>
+                <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="378a-7742-6b0d-d086" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a83b-75f3-ddc8-aea9" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="821f-2b38-0976-9bc6" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d13-b803-296b-823f" name="Lion Chariot" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3979-e311-2b38-8142" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="338e-140a-5bf6-c4fb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d8d-1681-55c9-3768" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cd9b-5c34-cc3f-049e" name="Lion Chariot" hidden="false" collective="false" targetId="e85b-912f-e4f6-f8ce" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0feb-ad59-610f-f176" name="Honour Selection" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7748-1a8b-0d87-1a64" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f41f-b77c-292b-958b" name="Fleet Officer" hidden="false" collective="false" targetId="1046-7ee6-1763-0b9c" type="selectionEntry"/>
+            <entryLink id="2d0f-48a2-5a26-6609" name="High Warden of the Flame" hidden="false" collective="false" targetId="5e2c-210f-96a8-ad7c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="2290-c38d-155f-dceb" name="Master of Canreig Tower" hidden="false" collective="false" targetId="378a-7742-6b0d-d086" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="d951-e3e5-3138-0104" name="Queen&apos;s Cavalier" hidden="false" collective="false" targetId="2b96-4325-e083-d85d" type="selectionEntry"/>
+            <entryLink id="aa3e-6c3d-386c-3ea0" name="Queen&apos;s Companion" hidden="false" collective="false" targetId="af32-94dd-d346-92a4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="4246-5191-d124-3223" name="Royal Huntsman" hidden="false" collective="false" targetId="338e-140a-5bf6-c4fb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5ded-97d9-76a5-8e29" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="8600-6a28-239c-5cbb">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3195-b620-1bb9-7550" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b56-9c27-d669-1094" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8600-6a28-239c-5cbb" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430e-db9e-d76a-e333" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b381-de46-4408-99cf" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="835a-7e73-542d-4695" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9aa-297b-61a8-bab6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="228e-63c0-6a58-9731" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7aa6-dfe3-9f38-7c8c" name="Dragonforged Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4569-2c02-62af-2878" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9798-19b4-3d3b-94f0" name="Dragonforged Armour" hidden="false" targetId="0605-22a2-3f43-283b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="58b1-6ffe-aa1b-d56b" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49c-cefc-d120-38fb" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3cc9-7254-7459-2169" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f9-c66c-42f1-6c61" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5edd-dcf4-86d7-dcab" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3f58-9f73-aa6e-4e60" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80cd-39d0-25ec-89f0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a7c9-2384-5f46-7d61" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e91b-e4da-9dc5-5a64" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="768b-aa41-8318-ebac" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2659-22fb-6cec-20b7" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a9f0-b6a6-6344-5278" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1471-2110-9fae-c494" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5222-3963-bc90-abfa" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f538-d023-b200-97e2" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6de-a579-6dda-bf71" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c2d2-ebda-1733-7210" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="849c-fae0-f37e-3362" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fa2-884b-50fd-cd9a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6ac7-34e1-f951-7e2d" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1513-fcb4-21d5-aa7e" name="Mount" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af32-94dd-d346-92a4" type="equalTo"/>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e2c-210f-96a8-ad7c" type="equalTo"/>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="378a-7742-6b0d-d086" type="equalTo"/>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="338e-140a-5bf6-c4fb" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="a65d-f119-56bb-4c89" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1212-0b66-1621-5e36" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a65d-f119-56bb-4c89" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="358b-ef4e-d71f-0a2b" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2b96-4325-e083-d85d" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b732-51b7-b4b1-03ea" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6df2-c3ac-1624-5182" name="Elven Horse" hidden="false" collective="false" targetId="55a1-2dd1-f1fc-bb21" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d4fa-0102-73fe-796b" name="Reaver Chariot" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bb5-3711-f9cd-1ad7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1182-ff89-f22f-5434" name="Reaver Chariot" hidden="false" collective="false" targetId="292e-a62e-9869-72f7" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0bb9-972e-1e48-e7f9" name="Giant Eagle" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f0a-2c6b-b2f4-b06a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="bfc4-290e-db21-4186" name="Giant Eagle" hidden="false" collective="false" targetId="e2c2-7f6c-f9f1-96b1" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f072-b3f5-0666-6b31" name="Griffon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="056b-cc6f-991e-0a27" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="a3f4-e4e3-3f0b-358a" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="3c64-6b57-0dba-0210" name="Griffon" hidden="false" collective="false" targetId="e46d-3516-6589-74fb" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b370-191f-8eeb-a3ab" name="Young Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0925-ceb3-47bf-48b9" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="a9df-d614-d523-a736" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="e5a0-68a3-d8e7-f957" name="Young Dragon" hidden="false" collective="false" targetId="2ba2-764c-ebda-0b5f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="290.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="996f-f7d3-de1d-3477" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8538-b4e2-e755-2f6d" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="9107-e633-d6e6-12f3" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="58a6-d6b7-ccfa-7fc3" name="Dragon" hidden="false" collective="false" targetId="17f6-887c-55b0-d586" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="460.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ad30-cf2c-1c38-079c" name="Sky Sloop" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3979-e311-2b38-8142" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2167-79ea-e53c-2a53" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="6b1f-5148-ccf0-2cd8" name="Naval Ordnance (local)" hidden="false" targetId="3eec-2473-17c3-c831" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="f50b-f467-d159-cb35" name="Sky Sloop" hidden="false" collective="false" targetId="c38f-edee-96c0-2d37" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8626-41ba-536f-b033" name="Army General" hidden="false" collective="false" targetId="0594-306e-6847-ad1c" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="250.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="feba-b90c-ff10-7f72" name="Commander" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="18ed-85af-6547-a088" name="Commander Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="78ce-5ad3-74d5-6977" name="Commander Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8ce0-0747-c868-dc2f" name="Commander Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b737-0619-6126-7771" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="7da8-f599-b4c8-bb2d" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7cf3-163f-cefc-b9d0" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="dbf0-2518-7feb-913b" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="375b-a753-7edb-3042" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1536-5736-51b8-4196" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c85-2d76-570a-bc1c" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a36d-07c2-49ba-1026" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6af-2d9b-2b36-61ed" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2a7a-f873-0d76-f122" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="42bf-054d-0a47-7507" name="HBE Weapon Enchantments" hidden="false" collective="false" targetId="aa7f-2c1a-a9af-1543" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="09c3-d77f-d8fd-69ce" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="3661-72b1-ee1e-b677" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3661-72b1-ee1e-b677" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4b11-8b75-d78b-c7ec" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="6488-1bdd-9c3c-bcc2" name="HBE Armour Enchantments" hidden="false" collective="false" targetId="6fe8-7e32-a5cf-f641" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="b565-6fc0-a820-0288" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b35f-996a-ed2f-0033" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="61ae-6f47-e279-7520" name="HBE Artefacts" hidden="false" collective="false" targetId="8bcf-f60e-eb31-1ec0" type="selectionEntryGroup"/>
+                    <entryLink id="afcc-6c92-4dc2-ee69" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="ad50-51ea-33fb-2af0" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="feba-b90c-ff10-7f72" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ddbf-9800-2ae7-57df" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="489e-92da-1eb5-d500" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6ddb-33b1-2ab2-3f61" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="373f-f30e-a058-6225" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bae0-f875-2cb6-892d" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dad2-dcfb-c135-323c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d897-9ec8-efbf-981c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2314-9a10-11c1-19f6" name="Longbow (1+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74a6-161d-4618-496e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="16e6-dcc8-92f0-e7a1" name="Longbow (1+)" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6231-ff00-85f3-bd4b" name="Lion Chariot" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="feba-b90c-ff10-7f72" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="338e-140a-5bf6-c4fb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8747-60bc-4ef2-508f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6ab5-763f-d3a8-d954" name="Lion Chariot" hidden="false" collective="false" targetId="e85b-912f-e4f6-f8ce" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="88c8-a4fb-52bf-0452" name="Honour Selection" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e96a-e9c3-6caa-4a21" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="50fc-49e4-f184-4f70" name="Fleet Officer" hidden="false" collective="false" targetId="1046-7ee6-1763-0b9c" type="selectionEntry"/>
+            <entryLink id="dad2-dcfb-c135-323c" name="High Warden of the Flame" hidden="false" collective="false" targetId="5e2c-210f-96a8-ad7c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="e249-5b5e-94cf-310d" name="Master of Canreig Tower" hidden="false" collective="false" targetId="378a-7742-6b0d-d086" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="55a5-6f32-4e49-6093" name="Queen&apos;s Cavalier" hidden="false" collective="false" targetId="2b96-4325-e083-d85d" type="selectionEntry"/>
+            <entryLink id="5a50-a313-29e0-af72" name="Queen&apos;s Companion" hidden="false" collective="false" targetId="af32-94dd-d346-92a4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="6ccc-eba1-8547-c463" name="Royal Huntsman" hidden="false" collective="false" targetId="338e-140a-5bf6-c4fb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="89e7-0722-642f-dff8" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="0ddf-4879-4392-ceb6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9737-37e1-1c86-3019" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fb1-0cf5-5123-18c4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0ddf-4879-4392-ceb6" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dfe-a18c-46d8-402a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9fd4-4d6e-ff25-62b9" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e54a-f3a7-ff1e-b4de" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0db-7ddd-2fb6-71f9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="db5f-2cee-e2a9-7c55" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1a18-8386-0c06-3e52" name="Dragonforged Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aee3-f6aa-8994-48e1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ea49-1afe-0c08-3103" name="Dragonforged Armour" hidden="false" targetId="0605-22a2-3f43-283b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8e56-31f1-6bc1-905a" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fc5-b09e-0dab-286b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d420-280d-d505-81d6" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69a9-3474-c8a4-8c0b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="11c7-eaa5-ea99-1f1a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ea83-6082-41b0-e757" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa14-6b7a-7e8d-e011" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d891-8f73-d31e-898a" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d06c-8711-2247-65df" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74b2-8561-d767-8004" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="abd5-9d3b-8db3-e8ae" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="53a7-287f-3222-8be8" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4128-5f0b-aa0d-d850" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b491-475f-81a6-3adb" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bba4-7c78-a5af-44fc" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18ee-e6e3-bc94-0bb0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="94e2-7c3f-8522-d536" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9bf9-47af-86cf-bcd8" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6348-0751-8af7-c740" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d7fd-89db-8a30-415f" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="882a-bfeb-1e18-97a9" name="Mount" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="378a-7742-6b0d-d086" type="equalTo"/>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e2c-210f-96a8-ad7c" type="equalTo"/>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af32-94dd-d346-92a4" type="equalTo"/>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="338e-140a-5bf6-c4fb" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="6f30-9c60-12d7-6ff6" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93ab-6fa8-c2d5-2d80" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f30-9c60-12d7-6ff6" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f715-5daa-5329-7a1e" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="20">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2b96-4325-e083-d85d" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0796-be01-6831-a402" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a44b-92a0-4d54-aba3" name="Elven Horse" hidden="false" collective="false" targetId="55a1-2dd1-f1fc-bb21" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6b50-c28c-878a-fda3" name="Reaver Chariot" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3208-72c5-79c5-4463" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2c59-c878-b99b-3d62" name="Reaver Chariot" hidden="false" collective="false" targetId="292e-a62e-9869-72f7" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="df6b-e8b0-08c0-fb2f" name="Giant Eagle" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edc8-e9e4-65a6-f37c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4075-ef1a-f8cc-68ea" name="Giant Eagle" hidden="false" collective="false" targetId="e2c2-7f6c-f9f1-96b1" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b454-9735-c7f3-9c88" name="Griffon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="706b-1538-c5f4-74fc" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0edd-4e78-8f00-24c3" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="ef56-445b-b271-53d0" name="Griffon" hidden="false" collective="false" targetId="e46d-3516-6589-74fb" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9a65-144a-730c-d317" name="Young Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a99-cf7d-ba30-4368" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="e995-800c-2826-e252" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="71b5-8627-dac7-39ba" name="Young Dragon" hidden="false" collective="false" targetId="2ba2-764c-ebda-0b5f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="290.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dabc-6ed2-0d35-e207" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2de-a3c6-ab9d-1afa" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="abb0-b492-323a-14e3" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="7148-c7e8-57ba-0054" name="Dragon" hidden="false" collective="false" targetId="17f6-887c-55b0-d586" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="460.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="76a1-a085-c5da-b49e" name="Sky Sloop" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="feba-b90c-ff10-7f72" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc1c-56e4-bfeb-bf08" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="eb30-c351-8ea2-5569" name="Naval Ordnance (local)" hidden="false" targetId="3eec-2473-17c3-c831" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="2d33-ff5a-beb4-3de0" name="Sky Sloop" hidden="false" collective="false" targetId="c38f-edee-96c0-2d37" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c45d-a2d3-066e-e678" name="Army General" hidden="false" collective="false" targetId="0594-306e-6847-ad1c" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ddbf-9800-2ae7-57df" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="4e6e-716c-fae0-8006" name="Battle Standard Bearer" hidden="false" collective="false" targetId="ddbf-9800-2ae7-57df" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0594-306e-6847-ad1c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e35-ad25-73d4-961b" name="Mage" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="a1b3-ed4a-7158-86a6" name="Mage Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4856-fe02-c0fe-c074" name="Mage Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e7dc-bc6c-b6b0-1132" name="Mage Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2417-8486-6650-389c" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="8dc1-23c5-1d87-da1e" name="Master of Spellcrafting" hidden="false" targetId="5ee0-1156-d7b5-5997" type="rule"/>
+        <infoLink id="43d1-b4a5-cacc-6d62" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="58a0-957f-9e06-0188" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2706-8539-6f13-a55a" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="814f-e793-b66e-eff8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e616-8cb7-a894-42b4" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e6ac-bcf1-e85c-29b0" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bde-b91b-8628-78a7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="791c-6c19-79ee-324c" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="efd3-1596-3dc2-941d" value="200">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4569-38ae-6a20-ead7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efd3-1596-3dc2-941d" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1110-bcf9-c779-05c4" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e80-2645-e6aa-0e7c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2c5e-1287-c11a-81e6" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="86b7-c80e-14e0-dc86" name="HBE Weapon Enchantments" hidden="false" collective="false" targetId="aa7f-2c1a-a9af-1543" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="0fa5-02eb-8558-ff7d" name="Armour Enchantments" hidden="true" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2706-8539-6f13-a55a" type="equalTo"/>
+                            <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a7f9-bdd7-7a83-796e" type="equalTo"/>
+                            <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc77-7c95-8714-f2d4" type="equalTo"/>
+                            <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="79d7-25c8-07a5-29bd" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="3adf-08ab-9517-8e0c" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3adf-08ab-9517-8e0c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c147-dc98-b5f1-1b3e" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="ddc6-f4b4-d07b-16f5" name="HBE Armour Enchantments" hidden="false" collective="false" targetId="6fe8-7e32-a5cf-f641" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="88f4-9fab-2efe-5c95" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cdf-2c92-43b2-f099" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="57f4-2ce3-75ba-c0bf" name="HBE Artefacts" hidden="false" collective="false" targetId="8bcf-f60e-eb31-1ec0" type="selectionEntryGroup"/>
+                    <entryLink id="201d-c7d9-9874-10b4" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6c63-2ff7-0881-7534" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="1674-63b0-ab5b-7dc7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c2-9e33-cbc3-522f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c239-1032-8726-0671" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1674-63b0-ab5b-7dc7" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee1b-9279-d27e-a466" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f251-ce97-3608-74ca" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7c25-ef42-eca3-c63b" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4569-38ae-6a20-ead7" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c14-340d-8517-99cb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="198f-453d-df10-b2f9" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f671-295d-2fca-a7ab" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="5de2-4a1a-5b96-62fe" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6bc-b218-467e-cbd3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5de2-4a1a-5b96-62fe" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="da6e-339f-d57e-d869" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bee-c255-0ec9-7158" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bc23-87d6-295b-c8a6" name="Divination" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="967c-e387-bb40-f544" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="693e-2e78-dca6-ea0c" name="Cosmology" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7809-c305-6da5-14ef" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0c66-3445-cb03-2b25" name="Alchemy" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9f-758f-3ae9-de6d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="231c-2a4a-cee3-137e" name="Honour" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d64b-4654-6fc9-2c36" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ee1b-9279-d27e-a466" name="Asfad Scholar" hidden="false" collective="false" targetId="122a-4f7d-4c5a-a8c4" type="selectionEntry"/>
+            <entryLink id="453b-b2bf-2f0b-9ae1" name="Order of the Fiery Heart" hidden="false" collective="false" targetId="9313-7e5d-0656-101c" type="selectionEntry"/>
+            <entryLink id="9c0e-4441-7f26-7675" name="Queen&apos;s Cavalier" hidden="false" collective="false" targetId="2b96-4325-e083-d85d" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="80d0-8719-36fa-b5bf" name="Fiery Heart Upgrades" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1e35-ad25-73d4-961b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry id="fc77-7c95-8714-f2d4" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5447-e35b-aef9-7a46" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8342-a972-971f-1bcc" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a7f9-bdd7-7a83-796e" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e099-4c24-a78a-5362" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d52d-4a15-db7d-9208" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="79d7-25c8-07a5-29bd" name="Dragonforged Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="078d-d2be-6dc9-26a7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8554-bf15-4415-6692" name="Dragonforged Armour" hidden="false" targetId="0605-22a2-3f43-283b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0333-f3bf-e1dd-892a" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f638-1e5d-7298-21b7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="19c0-e08f-4599-11fa" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="06a7-7f45-97b0-fe32" name="Mount" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="7b3c-f0f7-321a-f1f0" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41f5-8ff8-170e-68b3" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b3c-f0f7-321a-f1f0" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b1ff-b73e-7f92-419d" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="70">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e3f-9fd7-eed7-993b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="aa4b-953f-7059-f4f6" name="Elven Horse" hidden="false" collective="false" targetId="55a1-2dd1-f1fc-bb21" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dafb-f38f-98f9-c40b" name="Reaver Chariot" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4431-1d0d-0dba-7834" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ff42-0334-2596-3732" name="Reaver Chariot" hidden="false" collective="false" targetId="292e-a62e-9869-72f7" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b711-bb1c-bfe3-7419" name="Giant Eagle" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b96-4325-e083-d85d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7f8-0196-faca-3839" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2a68-df08-abc8-817d" name="Giant Eagle" hidden="false" collective="false" targetId="e2c2-7f6c-f9f1-96b1" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a589-171d-e7ac-976a" name="Griffon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4569-38ae-6a20-ead7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f1a-9602-77e0-eccf" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="b1f6-c78c-c303-8c37" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="7e26-b342-bd8b-01ec" name="Griffon" hidden="false" collective="false" targetId="e46d-3516-6589-74fb" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="31cb-9294-fb30-efcb" name="Young Dragon" hidden="true" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4569-38ae-6a20-ead7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="330">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd3-50cb-1a14-6894" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="e132-3d5d-2b5e-4560" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="e0b8-4623-7824-ea6b" name="Young Dragon" hidden="false" collective="false" targetId="2ba2-764c-ebda-0b5f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="57c2-164d-9459-4980" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4569-38ae-6a20-ead7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="540">
+                  <conditions>
+                    <condition field="selections" scope="1e35-ad25-73d4-961b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453b-b2bf-2f0b-9ae1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2193-503c-31ac-2a8e" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="50d4-b47e-47c3-f511" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="41c4-a4f4-1b20-17bd" name="Dragon" hidden="false" collective="false" targetId="17f6-887c-55b0-d586" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="460.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b533-bd92-1846-12df" name="Army General" hidden="false" collective="false" targetId="0594-306e-6847-ad1c" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="042e-35ec-7dab-c3e9" name="Citizen Spears" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="e4d5-6a4e-963a-28fa" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="d97a-ae2e-cba6-82d9" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5e4c-7dc9-db12-7777" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="5df7-59d0-2b2c-c9c5" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="ffd7-5abd-ae6d-7318" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="3851-34a5-8de9-cc23" name="Fight in Extra Rank" hidden="false" targetId="f07b-fa49-1de5-8a2b" type="rule"/>
+        <infoLink id="59e6-a5a0-89bd-da5b" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b0c3-a901-1696-e09a" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="af5c-bce3-798e-499a" name="Citizen Spear" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70ad-8caa-09f7-e29b" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a43-969f-e035-6023" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b3d7-97f4-ae2a-aba4" name="Citizen Spear Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c177-117a-6dea-1b9e" name="Citizen Spear Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="abea-8d2d-4bfd-8a68" name="Citizen Spear Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6adf-610a-5346-aa84" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f8c-10ef-e74d-c147" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1027-50d9-8b0d-bcee" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4045-f675-f8c3-e384" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f3d5-0c3d-0393-081c" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="10e3-9c82-2528-b880" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="1b65-7d6e-1aef-33aa" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a84a-0998-7725-7442" name="Highborn Lancers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb00-60b9-f9ac-1f53" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="5c1c-bef1-6eaf-e526" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="726b-4bc4-1b86-81c0" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="6eb8-4692-2115-a8e2" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="c8c1-9605-2efd-cfac" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="bdc3-ecbc-8bd5-f8c7" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="d4d2-bfae-15cd-b751" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="b2a9-ee5b-6654-6d7d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9d80-9934-1ed7-03d8" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2a13-05d4-b8cc-9f3e" name="Highborn Lancer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d3d-8c9d-e95e-6a6c" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a95-5685-c781-86ad" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3afe-0b30-2735-deaf" name="Highborn Lancer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9206-1cf3-5cc1-1512" name="Highborn Lancer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5260-b416-9e67-530f" name="Highborn Lancer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f47c-e136-d8e8-bef8" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="34a5-d220-9da7-7c25" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="609f-98ec-4c18-9df1" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="707e-8141-f156-092c" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0aa-9a66-6984-2b4e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ed18-8308-9b66-f3d9" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="a0c8-bc7c-ca22-5138" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="3781-ff52-807d-4de9" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b231-bb8d-00af-c31f" name="Citizen Archers" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="af4e-24af-8120-3f67" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="72cb-7d5e-87de-cc67" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="f2f7-79a6-5e74-f272" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="7fd9-605d-f1fd-3497" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="66e6-41fb-d334-9b44" name="Longbow (3+)" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2b88-0789-94dd-e659" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="7362-4819-94ec-2de7" name="Queen&apos;s Bows (local)" hidden="false" targetId="0bd4-287b-6755-4532" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d0da-fe31-b07f-b1c7" name="Citizen Archer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3aa8-5aa7-da4b-c330" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3162-aaf2-e7ed-e685" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ea77-a00d-7b5a-1f02" name="Citizen Archer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9f51-8f26-a4c2-4d55" name="Citizen Archer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="65ff-3482-aac4-9ed9" name="Citizen Archer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="09a0-f7e4-c294-adfe" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4005-94f1-6679-3c41" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7142-a6a6-dde0-0e4d" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7ed-fa25-3770-e180" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9d5d-fcee-c233-fba6" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="b4f1-9397-8a4e-1c29" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="1847-35ed-4f0e-b274" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c969-b456-2e78-06a4" name="Sea Guard" hidden="false" collective="false" type="unit">
+      <rules>
+        <rule id="33b3-bff8-fdde-942d" name="Steady Aim" hidden="false">
+          <description>The model can shoot from the third rank (in addition to the 1st and 2nd) and it does not suffer to-hit penalties for Stand and Shoot Charge Reactions.</description>
+        </rule>
+        <rule id="c525-bfb9-6f70-27bf" name="Cover Volley" hidden="false">
+          <description>When an enemy unit Declares a Charge against a unit with Martial Discipline, a single friendly unit with Cover Volley may immediately perform a Stand and Shoot Charge Reaction with the following conditions and restrictions:
+● The distance between the charger and the charged unit must be greater than the charger&apos;s Advance Rate (using the lowest value among the charging models if there is more than one).
+● The unit with Cover Volley is within 12&quot; of the charged unit.
+● Only models with Cover Volley may shoot.
+● The unit must use Stand and Shoot before the charged unit declares its Charge Reaction.
+● The Stand and Shoot Charge Reaction is performed as if the enemy had declared the Charge against the unit with Cover Volley in their current position (apply the normal rules for the Stand and Shoot Charge Reaction, i.e. the Charging unit must be in the Front Arc of the unit with Cover Volley, the unit with Cover Volley cannot be Shaken or Fleeing, etc.).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="34bb-5297-cd87-ca96" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="45cf-796c-9203-f97b" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="c953-5f69-b102-0fb3" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="a517-e98f-409c-229f" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="9bee-481d-74ae-d7c6" name="Bow (3+)" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+        <infoLink id="3b9e-0c0e-829a-bfc8" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="642b-1f0d-a86b-f155" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6e2a-7713-8eeb-1b46" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="04f5-f0f4-5d9b-3945" name="Queen&apos;s Bows (local)" hidden="false" targetId="0bd4-287b-6755-4532" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9fb6-af24-dcc7-9d7a" name="Sea Guard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b79-ae82-2b89-7551" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cb2-9f5a-6356-7146" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a248-176c-2e1c-96b4" name="Sea Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9a3a-1fa7-9d12-90e6" name="Sea Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9a18-0509-7b81-f8ba" name="Sea Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="21.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="320f-9fa9-3733-2d54" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b59-a05c-fc11-bc11" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d527-c16f-da43-8e76" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a302-9857-9110-2124" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4375-1288-e0ca-b179" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="1b79-1dee-57f1-3174" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="f714-79e9-4758-9568" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup">
+                  <categoryLinks>
+                    <categoryLink id="8c3b-689f-e3f8-71a0" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f62c-9f22-b82d-ea7c" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db73-defa-403c-7942" name="Elein Reavers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59bc-4d69-ff82-1fce" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f628-ba93-0afd-430c" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="84c8-88f0-7708-f4f2" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="b896-e6a6-274f-9e60" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="6616-64d4-f066-0ce1" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="d115-addd-0813-9451" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="252c-3873-79db-8bf2" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="c34c-f679-462b-905c" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="a29f-e30e-467d-2610" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="be40-148d-e026-932d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5923-81cd-d4bb-bef6" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="2d49-b629-ffae-87aa" name="Queen&apos;s Bows (local)" hidden="false" targetId="0bd4-287b-6755-4532" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="654b-77e5-cc9d-d4ce" name="Elein Reaver" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64f9-0045-0094-8232" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="626b-9be7-67f5-7b41" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="77b8-f8a9-d087-5dd8" name="Elein Reaver Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c048-98d4-bee8-647e" name="Elein Reaver Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9e71-13cd-8991-a700" name="Elein Reaver Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e800-88d4-ae6a-98cd" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd99-7065-aacb-4423" name="Bow (3+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="db73-defa-403c-7942" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="654b-77e5-cc9d-d4ce" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="513b-faa7-ff59-cc1d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="000e-920c-2c72-ee91" name="Bow (3+)" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="ea8b-e7cd-a4ca-e0ef" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f38-9719-a634-da24" name="Sword Masters" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50bb-5e6e-5bb4-0fb8" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c151-30d3-dfc2-9a7a" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="cf49-3f89-c943-803d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="16c1-5fec-ecd5-9013" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="3f47-aba2-238d-925c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="a63e-1934-ed28-8c71" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="fd56-1612-a7fa-6ef6" name="Sword Sworn" hidden="false" targetId="bbf3-feb9-2c88-f0c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0896-378a-9cb9-6910" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0cd9-e0eb-9a60-a4b9" name="Sword Master" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fd-be23-c449-6183" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="583a-9b92-3de1-0545" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9408-ffc2-a9e9-18d8" name="Sword Master Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="655e-53e6-ffdf-c86d" name="Sword Master Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8a88-d465-01da-1bd8" name="Sword Master Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="23.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4eb1-8b6a-5622-abf7" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edbc-8c82-2562-fed3" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c01a-2d82-6bb8-9001" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6cf-aa85-0ec2-caa0" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="dd86-c187-bf0c-0510" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="f0c4-3aca-56ca-fa7e" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="5cbb-b8de-43ae-243e" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3306-b0a4-3283-2494" name="Lion Guard" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3eb-1775-be77-78d9" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1923-e399-938f-ffc7" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="4023-2f1e-d0f8-2ad2" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3306-b0a4-3283-2494" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a83-918c-d757-53bf" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6bae-f156-991e-c1cb" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="aeb1-b5ae-a79f-5dd0" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="7239-167e-31c8-b994" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="6f48-f05c-c9ce-c0d7" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6df5-5a51-383b-85f2" name="Valiant" hidden="false" targetId="8147-757d-433f-6fe7" type="rule"/>
+        <infoLink id="0db9-48cb-57c3-a8ea" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (High Prince General)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b301-66c4-8204-f5f1" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, Large Beast, Large Cavalry, Gigantic)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0697-2987-bf98-4b3e" name="Lion&apos;s Fur" hidden="false" targetId="9ecf-68c3-07c3-ae0a" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d626-64d6-5a79-8b7d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d94c-c889-ee37-1f90" name="Lion Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45b1-25f9-6e89-2345" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3db-842b-4e03-864c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7c7f-2845-7f02-7aa6" name="Lion Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="34a4-2384-7156-740e" name="Lion Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ba37-17e4-4f48-58eb" name="Lion Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="28.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d623-bb82-0edb-5944" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c58-7390-ca4c-27e4" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fd96-5c31-4b9d-e3c3" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0188-2605-dae1-74e4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="174b-b145-e78e-33b9" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="318f-71d2-5eb6-1bbf" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3a83-918c-d757-53bf" name="Gain Skirmish" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="3306-b0a4-3283-2494" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d94c-c889-ee37-1f90" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3306-b0a4-3283-2494" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d94c-c889-ee37-1f90" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dedc-bb45-20b9-2d17" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aec7-c568-e36b-a96c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f69b-3836-3252-9af0" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="1bc5-939a-0aaf-f6a2" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12b9-caa3-2425-f8f1" name="Flame Wardens" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fdf-7ff1-26f9-5ca5" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8021-c0bd-eca5-d3f7" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="e05b-c437-d7cb-2c95" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="bb27-ff76-f2f6-9188" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="c522-7c87-50f5-8162" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="529c-448a-1451-84e5" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="11f9-622e-e328-7f81" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="0fa4-d4a0-7719-3c3e" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e6a0-1994-005c-0637" name="Fight in Extra Rank" hidden="false" targetId="f07b-fa49-1de5-8a2b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2f3c-01ef-9b5e-ea58" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6815-e856-a1ca-63c9" name="Flame Warden" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1e-9789-0bc8-8e0e" type="min"/>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ade8-bdd9-10a7-8c9a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="561c-b35d-9c91-1138" name="Flame Warden Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d3b9-5634-62a4-f409" name="Flame Warden Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2399-e394-3e16-c6bb" name="Flame Warden Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="28.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="82bd-6e7c-2b4c-e911" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="690e-611b-cd73-a328" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4a7c-4824-4992-84a1" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1be0-4db2-ef88-c6cf" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5e4a-8e2c-0f07-f32d" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="7936-f153-34e6-db2d" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f9fa-956e-a0f1-2e24" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="88b1-8d20-aa6f-3255" name="Knights of Ryma" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9936-a7ea-e191-f650" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b872-ddf1-d7f8-5dee" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="ebd9-a6ce-0db9-5185" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="53b1-b961-f951-9b5d" name="Dragonforged Armour" hidden="false" targetId="0605-22a2-3f43-283b" type="profile"/>
+        <infoLink id="7acb-2d3c-1333-ba06" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="7a3c-6f10-2dc2-1544" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="a895-bc3d-d194-b68d" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="8b61-9cce-1da8-3be4" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2289-df60-21a9-607b" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6323-0047-7736-dc6d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e4cc-e4bc-6b8a-8cf2" name="Knight of Ryma" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cddd-e92d-105c-4515" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="163c-07e0-91e1-e11f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="03a9-f29a-8e5f-968b" name="Knight of Ryma Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a179-4b14-e034-6d4c" name="Knight of Ryma Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="963d-e7aa-868e-338a" name="Knight of Ryma Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f47a-d4ee-2b2b-ae08" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="54.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="920a-0c23-3dd0-38ef" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25cc-2f26-5574-4ffb" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8e72-6d95-f5c4-4342" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de46-3cbc-4a39-49ad" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="7e00-1c81-2ab6-89b3" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="e3ff-f9e5-6cf3-bb04" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="490b-9ff8-a4cc-d65a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4b27-7c04-197a-49b4" name="Reaver Chariots" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1157-74b7-5fa0-b56a" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d322-3191-401f-1f48" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="f97d-373d-bdd6-a54d" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="bebe-cca8-67fe-3277" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="b036-34fa-e783-de7b" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="9614-477b-db81-6018" name="Longbow (3+)" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+        <infoLink id="7e17-fe9e-02c3-71df" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="e890-1a8a-f85a-ff5d" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="7bba-b502-50af-0852" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9c48-0b60-248a-b61c" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9198-64c8-c87b-f91f" name="Reaver Chariot" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3915-2135-42bd-3de5" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c97-9cb4-e5fc-8ce0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c337-f61c-bb6b-330d" name="Reaver Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4517-67eb-deff-f0c8" name="Reaver Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="11f2-d4db-a1d4-b6e2" name="Reaver Chariot Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f4b1-8308-a0ea-4c1e" name="Reaver Chariot Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="faa0-dfa9-8da3-73ef" name="Reaver Chariot Horse (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="6abc-d02c-5318-56d2" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ead3-55f2-a6dc-82eb" name="Lion Chariot" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe41-674a-0556-c2f2" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8a1d-4773-22ee-79f6" name="Lion Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6b45-f737-1c17-556e" name="Lion Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b6e7-9e36-41b6-13f7" name="Lion Chariot Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e39c-c6f0-1476-f96b" name="Lion (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="060b-4071-aeba-75f9" name="Lion Chariot Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="126e-f766-9e03-0672" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="d56d-96c3-767d-c0ed" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="7f30-9ae4-a5f2-4238" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="7ad7-c471-ed98-1cdd" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="bf13-6b94-4f10-5106" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="885d-d124-9a60-e6b8" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6 +1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8d1f-e849-a22f-f6ac" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="fe55-c579-f6ed-268c" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, against Large Beasts, Large Cavalry, Gigantic)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8f2b-9dfc-b872-1466" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ae2d-e724-0e20-1bf0" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="215.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fb8c-a31f-8e6d-6f60" name="Giant Eagles" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28d9-7a9d-8fd6-6a53" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e214-3f72-779f-a699" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="72d3-91c0-2e82-38f1" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4bab-0d89-501e-9242" name="Giant Eagle" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ec1-a36c-9359-b2c6" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0922-dc86-63cb-683e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6c31-454b-892e-e260" name="Giant Eagle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d96a-af53-a1ee-1501" name="Giant Eagle Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="51b1-0656-d52c-aa36" name="Giant Eagle Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c428-47f9-f508-8db3" name="Queen&apos;s Guard" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e63-f10c-7940-3052" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="065d-976e-0407-dd46" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="7c87-df2c-1c65-c53b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="cc02-a056-0f02-373c" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="5c8a-7fd3-6039-64a9" name="Moonlight Arrows" hidden="false" targetId="ab0f-f771-45ad-7c68" type="rule"/>
+        <infoLink id="1a45-0d50-2545-ea4b" name="Longbow" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+        <infoLink id="d624-b9e8-a0a9-9913" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="50ef-2141-db71-e5d6" name="New CategoryLink" hidden="false" targetId="0bd4-287b-6755-4532" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c066-1826-9f40-b92a" name="Queen&apos;s Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c35-d8af-24aa-1e9e" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34e2-1417-e40f-1234" type="max"/>
+            <constraint field="selections" scope="roster" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08a0-4f8a-583d-d055" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8556-a236-f800-a165" name="Queen&apos;s Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a7c8-b5ce-51bf-be49" name="Queen&apos;s Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b1d5-8241-55b3-0493" name="Queen&apos;s Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="29.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5109-76bb-6a3b-a59c" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe5f-2a1c-a740-e0ea" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="52ba-a0bd-fda9-67fe" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="babb-6964-4301-4f14" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a0f0-c3b1-3d31-d632" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="fe5e-faa8-0c86-f6fd" name="HBE Banner Enchantments" hidden="false" collective="false" targetId="bc60-004f-88a6-231e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e122-3a91-c30e-d378" name="Spear" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="c428-47f9-f508-8db3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c066-1826-9f40-b92a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="decc-4aa2-4fca-f430" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="bf19-25ed-d67a-09bd" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e951-be7d-a4aa-3031" name="Grey Watchers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="072c-cf2b-b623-3fcc" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9bcc-4aa0-5241-e583" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="05ff-14bb-dc26-b32a" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="76a1-5e9d-6632-2d3d" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="0c19-b6f1-9fb2-7f7b" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="4f46-cf5f-46f1-926e" name="Longbow (2+)" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+        <infoLink id="60ec-9baf-a543-d0e4" name="Fae Miasma" hidden="false" targetId="eb07-a267-aa2c-5bf6" type="rule"/>
+        <infoLink id="7465-41f9-a7e5-82c7" name="Accurate" hidden="false" targetId="68aa-b60b-ae0b-158b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="52bb-e754-262f-a2c9" name="Queen&apos;s Bows (local)" hidden="false" targetId="0bd4-287b-6755-4532" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4e64-eae4-7e7b-6d1b" name="Grey Watcher" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a773-e111-8f9a-f419" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="afb7-6a7d-3f22-5b9a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="02c2-bce3-017c-aa31" name="Grey Watcher Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ea60-ebcf-e559-deec" name="Grey Watcher Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2698-7153-5430-f982" name="Grey Watcher Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0c21-9ed1-f1e5-f1e3" name="Scout" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="e951-be7d-a4aa-3031" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e64-eae4-7e7b-6d1b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8011-d7e9-a431-470e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dac6-cc79-fbee-7468" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6a84-34e6-f3f3-5706" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ca7c-4408-1f45-e799" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d23c-0fa6-2652-6e27" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ea94-543f-50f2-17e6" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="e951-be7d-a4aa-3031" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e64-eae4-7e7b-6d1b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e6ef-13ed-137d-221d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2b9a-d72b-df6b-e5bc" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1bd4-6e9e-da3e-cf49" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="e951-be7d-a4aa-3031" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e64-eae4-7e7b-6d1b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f274-84a4-923c-d07f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c820-8fd7-c3ba-0c6b" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d480-0b26-57d3-a886" name="Sea Guard Reaper" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="98eb-2e82-b4b8-f207" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b1c6-ff78-9e55-6f7d" name="Sea Guard Reaper Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">5&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7e12-13d4-ea37-6cba" name="Sea Guard Reaper Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0299-955a-edc2-ae48" name="Sea Guard Reaper Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7932-dc73-2ac8-61d3" name="Reaper Bolt Thrower (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [6]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3)]</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f47a-ad72-56c4-664b" name="Reaper Volley Gun (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">6</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c784-63f7-40d3-aac9" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule"/>
+        <infoLink id="8bf2-2929-aa6d-0b4d" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="9f8b-561f-66a6-1706" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="68d4-5176-af2e-a4a0" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3c72-18b5-c57e-ce05" name="New CategoryLink" hidden="false" targetId="3eec-2473-17c3-c831" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db8c-e27a-4364-612b" name="Sky Sloop" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c0b-4105-6248-c614" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f7c4-d4ef-cdba-db09" name="Sky Sloop Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b480-5991-2424-5066" name="Sky Sloop Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="74ff-517e-0a01-034b" name="Sky Sloop Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c84c-84b5-accf-1217" name="Hawk Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ba9d-2f71-cdde-9986" name="Sky Sloop Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8726-9666-c959-f835" name="Sky Reaper (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">4</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b90c-3d21-9475-425b" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="531d-a7ac-4a02-0571" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="98a0-4ec1-751c-09fe" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="14f2-a44c-38e2-fddf" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="8a97-d105-9c3e-0236" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="77e1-f0c7-6429-b8d5" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="3199-efce-6dd7-c99b" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="785b-4d48-eb62-dc52" name="New CategoryLink" hidden="false" targetId="3eec-2473-17c3-c831" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="265.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b63c-836b-5fba-8c49" name="Phoenix" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83e5-2882-580e-555d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8d8d-08af-b8e1-7deb" name="Phoenix Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="be28-67a6-2280-9eaf" value="9">
+              <conditions>
+                <condition field="selections" scope="b63c-836b-5fba-8c49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2703-1229-cf7c-37d1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1ebd-f66a-17c6-5656" name="Phoenix Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="29f0-1d25-7ec8-90bf" name="Phoenix Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e305-9a00-b55a-7d6f" name="Rebirth" hidden="false">
+          <description>The first time a Phoenix loses its last Health Point, the owner must roll a D6. On a roll of 5+ (or 3+ if the model has Warden&apos;s Bond), place a marker on the centre of the model’s final position. If the roll fails, the model counts as a casualty. Otherwise, at the start of step 3 of the Movement Phase Sequence (after Rallying Fleeing units) in the next Player Turn, the Phoenix model is placed back on the Battlefield. The centre of the model must be placed within 3&quot; of the marker and the model must be placed more than 1&quot; away from other units and Impassable Terrain, facing any direction (if this is not possible, the Phoenix cannot return and counts as a casualty). The returned model is the same model that left the game, including any and all ongoing effects (such as spells affecting the model), with the exception that it always returns with only 1 Health Point left and counts as Rallied in case it was Fleeing when it lost its last Health Point (and thus is Shaken until the end of the Player Turn).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d5a9-6c13-8c05-0bd6" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="0e94-0608-9a48-2970" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="8ff6-2baa-c85b-1ed0" name="Martial Discipline" hidden="false" targetId="3104-5801-50e1-a9c6" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2703-1229-cf7c-37d1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="58b8-63ad-cd8e-76a7" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2703-1229-cf7c-37d1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f195-6edb-8b1f-1afc" name="Ancient Allies (local)" hidden="false" targetId="7eaf-eaa2-9211-8018" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2703-1229-cf7c-37d1" name="Warden&apos;s Bond" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd9c-d59a-f1b0-18e7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="90d1-3d6b-b374-4417" name="Warden&apos;s Bond" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6a74-3bb4-ed4d-7d33" name="Must become:" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a625-116b-bc3a-435a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="074d-d471-deb6-2136" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2088-98e2-894a-91ad" name="Fire Phoenix" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5076-6bbd-9f04-42a4" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="3560-c349-7684-7cb6" name="Fire Phoenix" hidden="false">
+                  <description>The model may perform a Sweeping Attack. The enemy unit suffers D6 hits and an additional D3 hits for each rank after the first.
+
+The Grind Attacks and Sweeping Attacks are resolved with Strength 4, Armour Penetration 1, and Flaming Attacks.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="f46c-e675-0925-7586" name="Flaming Attacks" hidden="false" targetId="49e5-2d9a-1ecc-101f" type="rule"/>
+                <infoLink id="ca10-a166-357e-3b2e" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (2+, Against Flaming Attacks)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="b817-b894-2c9b-9281" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (D6)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="6a56-8d28-30f9-f931" name="Sweeping Attack" hidden="false" targetId="3fff-f85c-3747-6634" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4e43-d5d9-f344-e8ca" name="Frost Phoenix" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23ac-447b-dcfe-1aca" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="a4a7-0203-1778-a32c" name="Frost Phoenix" hidden="false">
+                  <description>Enemy units in base contact with one or more Frost Phoenixes suffer -2 Agility, -2 Offensive Skill, and -2 Defensive Skill</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="f2be-4c5f-6df9-c7a0" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="1efa-f28f-2858-62e9" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="375.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="378a-7742-6b0d-d086" name="Master of Canreig Tower" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01e1-b294-19de-c5a4" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="0e30-10b3-24f9-e127" name="Master of Canreig Tower" hidden="false">
+          <description>The model gains Wizard Adept, Protean Magic, Master of Spellcrafting and Sword Sworn (see Sword Masters Special unit). The model has access to Alchemy, Cosmology, Druidism, Shamanism, and Witchcraft. It knows 3 spells, and always knows The Oaken Throne in addition to these spells. Fountain of Youth becomes the Attribute Spell for all non-Bound Spells cast by the model, replacing the spells&apos; corresponding Attribute Spells where applicable.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="2616-3ae1-7a2a-1401" name="Protean Magic" hidden="false" targetId="9c73-bbca-fd62-c017" type="rule"/>
+        <infoLink id="0f92-1276-5183-7ef7" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+        <infoLink id="3535-91b2-0515-3277" name="Master of Spellcrafting" hidden="false" targetId="5ee0-1156-d7b5-5997" type="rule"/>
+        <infoLink id="f163-af8c-cb75-bf0a" name="Sword Sworn" hidden="false" targetId="bbf3-feb9-2c88-f0c8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b96-4325-e083-d85d" name="Queen&apos;s Cavalier" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="f6a9-725c-a68b-4a86" value="1">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90db-1ff0-a85b-224b" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6a9-725c-a68b-4a86" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="a72f-38fa-09ef-9ba0" name="Queen&apos;s Cavalier" hidden="false">
+          <description>If the bearer’s model is Large or Gigantic:
+The limit of Ancient Allies is increased to 25%, Characters is increased to 50%, and all Characters in the Army must be Large Cavalry or Gigantic Beasts. Dragons become 0-2 Mounts per Army. Sea Guard Reapers and Sky Sloops may not be taken in the Army.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d7af-52b5-66f6-ad5b" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att, Fear)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1046-7ee6-1763-0b9c" name="Fleet Officer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b56a-dd27-09fd-1439" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="ef99-66b0-70e1-3453" name="Fleet Officer" hidden="false">
+          <description>The bearer gains Steady Aim, Cover Volley (see Sea Guard Core unit), and +2 to-hit when using a Sky Reaper. When rolling to determine which player chooses Deployment Zones, add +1 if there are one or more Fleet Officers in the Army. All models with Martial discipline within the model&apos;s range of Rally Around the Flag or Commanding Presence (If applicable) also have their Panic Tests subjected to Minimised Roll.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5e2c-210f-96a8-ad7c" name="High Warden of the Flame" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b04-c637-0f47-b43b" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="c936-e968-8682-20e0" name="High Warden of the Flame" hidden="false">
+          <description>The bearer gains Aegis (4+), Fearless and Magic Resistance (1), Flaming Attacks, and cannot be equipped with a shield.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af32-94dd-d346-92a4" name="Queen&apos;s Companion" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fbd-b17e-f767-f36c" type="max"/>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="321e-341a-301b-6b40" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="4fdb-5a89-b918-4f29" name="Queen&apos;s Companion" hidden="false">
+          <description>The model’s unit gains Quick to Fire. When shooting with a Longbow without Weapon Enchantment, the weapon gains Shots 3.</description>
+        </rule>
+      </rules>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ccd3-bac3-ed3a-d5f3" name="Additional Options" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8990-d6e1-1ae7-b683" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="529d-ccf2-8bb3-d10c" name="Moonlight Arrows" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81e6-7ce9-a373-166f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2460-ae41-60bf-2f36" name="Moonlight Arrows" hidden="false" targetId="ab0f-f771-45ad-7c68" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="be22-cf2a-bf86-a86c" name="Scout and Fae Miasma" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e53-f8fc-4ab4-556b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5b94-daa7-9771-9a3e" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+                <infoLink id="e0eb-dbe7-aded-2825" name="Fae Miasma" hidden="false" targetId="eb07-a267-aa2c-5bf6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="338e-140a-5bf6-c4fb" name="Royal Huntsman" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="089d-ee6f-179c-1b25" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="0673-f3e6-29ff-b182" name="Royal Huntsman" hidden="false">
+          <description>The model gains Lion’s Fur and the model’s unit gains Valiant. When using a Great Weapon, the bearer gains Multiple Wounds (2, against Large Beasts, Large Cavalry, Gigantic). </description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="122a-4f7d-4c5a-a8c4" name="Asfad Scholar" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3cd-3083-7716-33ec" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="a283-1823-bb26-b264" name="Asfad Scholar" hidden="false">
+          <description>The Range of spells cast by the Wizard is increased by 6&quot;, except for Aura spells which only increase in range by 3&quot;.Spells with the Type Caster or Caster’s Unit, and Bound Spells are not affected. The Wizard may cast Drain Magic as a Bound Spell with Power Level (4/8).
+
+Drain Magic: Range 18&quot;, Type Universal, Duration Instant.
+All spells with Duration Lasts One Turn affecting the target immediately come to an end. If any of these spells had more than one target, their effects also end for these targets.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9313-7e5d-0656-101c" name="Order of the Fiery Heart" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ef7-5adb-f890-ac26" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="2f6e-29f5-c8df-9340" name="Order of the Fiery Heart" hidden="false">
+          <description>The bearer&apos;s model gains Flaming Attacks. The model must select spells from either Alchemy or Pyromancy, and ignores the Missile and Damage spell Types for Molten Copper (Alchemy) and all Pyromancy spells, but only when targeting units which are Engaged in Combat with the model. 
+
+The first time in each Magic Phase that the bearer successfully casts a Learned Spell, its mount (if there is any) gains +1 Advance Rate, +2 March Rate, and +2 Attack Value. The effects last until the start of the owner’s next Magic Phase.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1b18-9f0b-45b6-ab87" name="Flaming Attacks" hidden="false" targetId="49e5-2d9a-1ecc-101f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="55a1-2dd1-f1fc-bb21" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="590f-f050-9620-ca42" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e901-4f81-783b-aed1" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0913-2eea-1bc2-10bd" name="Elven Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8bd8-a48d-3e7f-5d1f" name="Elven Horse Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a60f-576d-6ed8-f54e" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0141-ee1c-27c0-8983" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e2c2-7f6c-f9f1-96b1" name="Giant Eagle" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25ce-1db4-21ea-71aa" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5402-ec83-c6a9-a2cd" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4943-09d9-b5be-6f90" name="Giant Eagle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="06a5-0f12-bf8a-9389" name="Giant Eagle Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7524-01fc-f355-0290" name="Giant Eagle Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="dbd5-58d2-b455-b5c0" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="86d1-bcbb-d77b-2713" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e46d-3516-6589-74fb" name="Griffon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3124-3da4-ab5a-8298" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b51-ef45-9f53-c325" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c3ed-7a0e-1fcc-e7e1" name="Griffon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4143-8d52-fd76-4f75" name="Griffon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e18c-bc6e-685f-9d00" name="Griffon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0070-80e3-7500-e77f" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="9591-f328-1376-3810" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="363c-1cf4-55ea-40e2" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="9cd5-302b-8299-586d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="de35-f90e-0bb9-aa2c" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="b406-8797-ea6a-20e2" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP, +1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ba2-764c-ebda-0b5f" name="Young Dragon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ef7-03de-8f06-b579" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5936-bb74-10ad-c858" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3785-ed39-07d6-f8b4" name="Young Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d6b7-3868-7a4e-648e" name="Young Dragon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="76f2-d172-f414-a55f" name="Young Dragon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="94ba-a4bb-f08d-7ce4" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="98ed-9055-af7d-ab3f" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="5eb5-7841-6bb3-c982" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="2c01-0fc5-1bed-5efb" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="9d0c-65e3-1344-e13b" name="Stomp Attacks" hidden="false" targetId="4810-6726-807b-e78e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="109f-0b5b-8191-532f" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="17f6-887c-55b0-d586" name="Dragon" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="04d9-f0ab-8c63-10f9" value="2">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fba8-1341-e08e-7a79" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f029-c192-1250-243c" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04d9-f0ab-8c63-10f9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fecf-f6e9-6a89-3fab" name="Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="db10-a838-f72f-3ed6" value="12&quot; (16&quot;)">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab72-199b-87f3-a94e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d35e-250b-09d0-8444" name="Dragon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab72-199b-87f3-a94e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dacb-f8d9-13a0-d879" name="Dragon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7a3e-1622-1e74-f3a2" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="5558-d593-963f-1d0e" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="9344-1b21-f1a3-c26a" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="ab72-199b-87f3-a94e" name="Ancient Dragon (High Prince only)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce6a-7e8c-8d38-2f2a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="292e-a62e-9869-72f7" name="Reaver Chariot" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f0d-804e-cb9a-c290" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb6-5604-c7ce-b0da" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8309-4ebc-766c-0e9a" name="Reaver Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e009-3b79-ab4e-560b" name="Reaver Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d5b9-57be-4d90-e92e" name="Reaver Chariot Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9c29-bc4b-e624-6a5b" name="Reaver Chariot Horse (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9569-2dde-6f87-1b26" name="Reaver Chariot Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f8bd-fe83-4d91-4c94" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="5c55-dba9-f8f4-96de" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="aa2b-6d59-f2f6-6089" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="f489-96a6-4371-ca3f" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="6c73-84af-e671-abee" name="Longbow (3+)" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+        <infoLink id="4d33-a292-b64a-18f7" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="4ae2-7ba5-4ca4-3d33" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="8c1a-14b1-ec41-b6e8" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e85b-912f-e4f6-f8ce" name="Lion Chariot" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c39d-bb0e-9343-f306" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f7f-4705-3918-34f0" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="868c-9496-c039-2baa" name="Lion Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="52f7-1e37-6857-6a7b" name="Lion Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="98af-3963-de3c-be40" name="Lion Chariot Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a935-0dc6-4f04-1255" name="Lion (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7dc4-6d1c-1849-c1fd" name="Lion Chariot Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4867-d218-521b-a731" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="e640-6410-caf3-ac49" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="a53d-91ff-9f66-9f3c" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="c07e-cafe-ba5b-703c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="d781-1e84-c41c-f40f" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="432e-6670-5f00-d1e1" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6 +1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8eea-b00a-e8c7-9356" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="6b80-f0ae-bad3-903d" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, against Large Beasts, Large Cavalry, Gigantic)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c38f-edee-96c0-2d37" name="Sky Sloop" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e87-c157-d352-b9a2" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0ed-bb9c-2051-b7e7" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b8d6-2250-fdd1-b136" name="Sky Sloop Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4274-6992-71fb-d8ab" name="Sky Sloop Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="faa9-6724-ab01-4e52" name="Sky Sloop Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="13a3-aa78-d8dd-ec5d" name="Hawk Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f247-aca6-c099-2724" name="Sky Sloop Crew (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2f03-a4d0-5d22-8504" name="Sky Reaper (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">4</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8214-068c-7309-57fc" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="e690-6285-b545-c1f2" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="a415-5eba-b630-e0d2" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="ee92-3de1-0ce3-9313" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="af73-614a-5ebb-d3fc" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="e7b8-1fc3-168b-4380" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="ab37-e63b-470a-6408" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0594-306e-6847-ad1c" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="404a-19ba-ad8d-747c" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ae5-c313-ade6-b084" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0041-0798-cb76-13ed" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2fc0-fd16-0ae5-a1f8" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ddbf-9800-2ae7-57df" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d7a-5e15-eb81-56a3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="404b-3c91-bd1d-6cf6" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8077-df52-fe05-58f0" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="aa7f-2c1a-a9af-1543" name="HBE Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed1-3495-04bc-dd95" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="e7fd-b0c1-8daf-fb2f" name="Nova Flare" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce55-847e-b321-9b33" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a466-f7a4-414b-e285" name="Nova Flare" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Lance Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Divine Attacks, Magical Attacks, Lethal Strike, and Devastating Charge (+1 Att).  One use only. May be activated at the start of any Round of Combat. The wielder counts as Charging for the purpose of Devastating Charge.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1da9-3514-afda-1fb4" name="Elu&apos;s Heartwood" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4b5-f4a4-b06d-06f8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="afb0-d104-1c60-4b5a" name="Elu&apos;s Heartwood" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Longbow Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">This weapon gains Shots 3, Str as user +1, AP as user +1, and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bac9-ac5d-7963-59bb" name="Sliver of the Blazing Dawn" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f72f-a2e9-b231-2970" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ce71-383b-949f-52b3" name="Sliver of the Blazing Dawn" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Spear Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain +1 Strength, +2 Armour Penetration, and Magical Attacks. Each successful to-hit roll with this weapon causes two hits instead of one.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6fe8-7e32-a5cf-f641" name="HBE Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="e0e3-9b64-3ee7-43e7" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0e3-9b64-3ee7-43e7" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="657e-459a-4835-7a0b" name="Gleaming Robe - Standard size Mages only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78b0-bb2c-1af7-f461" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="19a3-e534-045b-da39" name="Gleaming Robe - Standard size Mages only" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains Aegis (3+) and its Armour is set to 1, which cannot be improved. If the wearer Miscasts and rolls Witchfire or Magical Inferno, the number of hits is halved (rounding up).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="40fa-0ff3-1b15-dfc5" name="Protection of Dorac - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a37c-bc95-eca7-d6a5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3838-57e2-7982-c1a6" name="Protection of Dorac" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Heavy Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +2 Armour and +2 Defensive Skill.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2a39-27c0-7bc8-a752" name="Daemon&apos;s Bane" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1580-dc3b-5b34-21d1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="02b8-fae5-0dcd-515d" name="Daemon&apos;s Bane" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +2 Armour against Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9df2-f36b-2b2b-6759" name="Starmetal Alloy" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b0b-c36b-f716-5be7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c4ba-b2ed-1311-f962" name="Starmetal Alloy" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The first time the bearer’s model suffers an unsaved Wound from an attack with Multiple Wounds, the number of Wounds suffered is halved (rounding fractions up).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="14b1-d48f-c286-1e7a" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8bcf-f60e-eb31-1ec0" name="HBE Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd83-08b0-bbcb-0c2c" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b561-f6b4-e6fb-b1ce" name="Book of Meladys" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e83-f1f8-a0c1-a30a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4628-8c45-386f-b0a7" name="Book of Meladys" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact - Dominant</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Once per Magic Phase, the bearer may reroll a single Magic Dice when making a casting roll, provided the spell was not Miscast. When rerolling a natural &apos;1&apos;, the rerolled Magic Dice benefits from Fizzle (if the Casting Attempt fails) regardless of the rerolled value.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bdb5-21fa-d94e-f92a" name="Ring of the Pearl Throne - Cannot be taken by Gigantic" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf3c-aa5b-b930-f067" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eb41-fdc9-cf76-bccd" name="Ring of the Pearl Throne" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">After step 4 of the Round of Combat Sequence (after Issue and Accept Duels), choose a single piece of Special Equipment or a single Dwarven Rune on a model in base contact with the bearer. This piece of Special Equipment or the Dwarven Rune cannot be used for as long as its bearer remains in base contact with the bearer of the Ring of the Pearl Throne. Only a single piece of Special Equipment or a single Dwarven Rune can be affected at any time. In case the model has more than one instance of the chosen equipment, only one instance is affected. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b8c3-64ff-082a-a163" name="Diadem of Protection" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62f-ee6a-6cee-eabe" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3f2d-0313-f9aa-eb4f" name="Diadem of Protection" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (+2, max 4+).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1f43-2a17-5044-3a7d" name="Amethyst Crystal - Wizards only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57b9-0643-d669-faf7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9680-d4b7-7b83-ecba" name="Amythyst Crystal" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Dispel rolls made by the bearer’s Army gain a +1 modifier.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="21fe-9923-5e75-0a92" name="Glittering Lacquer - Cavalry models only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c81d-c5de-9682-f032" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2086-bfe4-a76a-69e0" name="Glittering Lacquer" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Hard Target.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="bc60-004f-88a6-231e" name="HBE Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="07f4-7a7c-a1dc-b248" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fb46-f16d-65d3-19c6" name="Navigator&apos;s Banner" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de31-1dee-c976-7777" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4e76-652f-e9b7-5a75" name="Navigator&apos;s Banner" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">R&amp;F models in the bearer&apos;s unit gain Distracting in the first Round of Combat against attacks from enemies Engaged in the bearer’s unit’s Front Facing.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c40b-c43e-81c8-d0e2" name="Banner of Becalming" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="primary-category" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4bcd-01c8-ce5e-7108" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14b1-4275-a976-5b4b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="36ec-c4e8-ddc6-f254" name="Banner of Becalming" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">In the opponent&apos;s Magic Phase, during Siphon the Veil before converting Veil Tokens into Magic Dice, remove one Veil Token from the opponent’s Veil Token pool and add one Veil Token to your Veil Token pool.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0a1f-5ee3-7029-6f98" name="War Banner of Ryma" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e94a-e46a-cb2d-7748" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f89-8243-a8de-6f21" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5099-d44f-e716-6147" name="War Banner of Ryma" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">R&amp;F models in a unit with one or more War Banners of Ryma gains Devastating Charge (+1 Str). Model parts with Harnessed are not affected. In addition, all infantry models in the unit gain Devastating Charge (+1 Adv).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="3104-5801-50e1-a9c6" name="Martial Discipline" hidden="false">
+      <description>If more than half of a unit’s models have Martial Discipline, their Discipline Tests, other than Panic or Break Tests are subject to Minimised Roll.</description>
+    </rule>
+    <rule id="5ee0-1156-d7b5-5997" name="Master of Spellcrafting" hidden="false">
+      <description>Spells cast by the Wizard have their Casting Value reduced by 1. When rolling casting rolls with a single Magic Dice, a natural roll of 1 or 2 on the Magic Dice is always a failed Casting Attempt, regardless of any modifiers.</description>
+    </rule>
+    <rule id="8147-757d-433f-6fe7" name="Valiant" hidden="false">
+      <description>The model is immune to the effects of Fear. If more than half of a unit&apos;s models have Valiant, the unit automatically passes Panic Tests caused by Terror. </description>
+    </rule>
+    <rule id="ab0f-f771-45ad-7c68" name="Moonlight Arrows" hidden="false">
+      <description>This Attack Attribute can only be used with Bow or Longbow without a Weapon Enchantment. The attack gains Magical Attacks and Flaming Attacks, and has its Strength set to 4 and its Armour Penetration set to 1.</description>
+    </rule>
+    <rule id="eb07-a267-aa2c-5bf6" name="Fae Miasma" hidden="false">
+      <description>This Attack Attribute can only be used with Longbow and Paired Weapons.
+When a unit is hit by attacks with Fae Miasma, it must take a Resilience Test for each hit, using the Resilience that the largest fraction of models in the unit has (use the higher value in case of a tie). If one or more Resilience Tests are failed, all models in the unit are affected by Fae Miasma until the start of the Active Player&apos;s next Player Turn. A model that is affected by (one or more instances of) Fae Miasma suffers a -1 to-hit modifier (both for Shooting Attacks and Close Combat Attacks).</description>
+    </rule>
+    <rule id="bbf3-feb9-2c88-f0c8" name="Sword Sworn" hidden="false">
+      <description>The model part gains a +1 to-hit modifier when attacking with a Great Weapon.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="0605-22a2-3f43-283b" name="Dragonforged Armour" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Heavy Armour</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">5+</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">Aegis (6+, 2+ against Flaming Attacks), The wearer cannot benefit from Fortitude.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9ecf-68c3-07c3-ae0a" name="Lion&apos;s Fur" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1"/>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056"/>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">If on foot, the wearer gains +1 Armour, which is improved to +2 Armour against Shooting Attacks. </characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/highbornElves.cat
+++ b/highbornElves.cat
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="66f6-8610-3962-63fa" name="Highborn Elves 2.0" revision="24" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="66f6-8610-3962-63fa" name="Highborn Elves 2.0" revision="25" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="7eaf-eaa2-9211-8018" name="Ancient Allies (local)" hidden="false"/>
-    <categoryEntry id="3eec-2473-17c3-c831" name="Naval Ordnance (local)" hidden="false"/>
-    <categoryEntry id="0bd4-287b-6755-4532" name="Queen&apos;s Bows (local)" hidden="false"/>
+    <categoryEntry id="7eaf-eaa2-9211-8018" name="Ancient Allies" hidden="false"/>
+    <categoryEntry id="3eec-2473-17c3-c831" name="Naval Ordnance" hidden="false"/>
+    <categoryEntry id="0bd4-287b-6755-4532" name="Queen&apos;s Bows" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="e28c-c4d0-2f7b-2de3" name="Highborn Elves (local)" hidden="false">
+    <forceEntry id="e28c-c4d0-2f7b-2de3" name="Highborn Elves" hidden="false">
       <categoryLinks>
         <categoryLink id="c39e-d4ff-c08d-e33a" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -36,7 +36,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="903c-ad61-5d7b-1be7" name="Highborn Elves - Queen&apos;s Cavalier (local)" hidden="false">
+    <forceEntry id="903c-ad61-5d7b-1be7" name="Queen&apos;s Cavalier on Large/Gigantic Mount" hidden="false">
       <categoryLinks>
         <categoryLink id="d41a-302c-9d94-99fb" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -233,7 +233,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -242,7 +242,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -252,7 +252,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -261,7 +261,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -398,7 +398,7 @@
             </modifier>
             <modifier type="set" field="a65d-f119-56bb-4c89" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -416,7 +416,7 @@
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
@@ -444,7 +444,7 @@
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -544,11 +544,6 @@
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
                     <condition field="selections" scope="3979-e311-2b38-8142" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1046-7ee6-1763-0b9c" type="equalTo"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -735,7 +730,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -744,7 +739,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -754,7 +749,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -763,7 +758,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -900,7 +895,7 @@
             </modifier>
             <modifier type="set" field="6f30-9c60-12d7-6ff6" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -918,7 +913,7 @@
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="20">
@@ -941,7 +936,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
@@ -1050,7 +1045,7 @@
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -1389,7 +1384,7 @@
           <modifiers>
             <modifier type="set" field="7b3c-f0f7-321a-f1f0" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1407,7 +1402,7 @@
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
                 <modifier type="set" field="24fd-8af8-0c78-001c" value="70">
@@ -1435,7 +1430,7 @@
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
                   </conditions>
                 </modifier>
                 <modifier type="set" field="hidden" value="true">
@@ -3212,7 +3207,7 @@ The Grind Attacks and Sweeping Attacks are resolved with Strength 4, Armour Pene
       <modifiers>
         <modifier type="set" field="f6a9-725c-a68b-4a86" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3543,7 +3538,7 @@ The first time in each Magic Phase that the bearer successfully casts a Learned 
       <modifiers>
         <modifier type="set" field="04d9-f0ab-8c63-10f9" value="2">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97df-c72b-cebf-5e0f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="903c-ad61-5d7b-1be7" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/infernalDwarves.cat
+++ b/infernalDwarves.cat
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dfd2-0d74-3072-b274" name="Infernal Dwarves 2.0" revision="15" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dfd2-0d74-3072-b274" name="Infernal Dwarves 2.0" revision="16" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="12f7-9967-08bc-2ab6" name="Barrage (local)" hidden="false"/>
-    <categoryEntry id="1464-f43f-9e7c-296c" name="Bound and Binders (local)" hidden="false"/>
-    <categoryEntry id="b519-5f8b-0ed3-9b5b" name="Hail of the Gods (local)" hidden="false"/>
+    <categoryEntry id="12f7-9967-08bc-2ab6" name="Barrage" hidden="false"/>
+    <categoryEntry id="1464-f43f-9e7c-296c" name="Bound and Binders" hidden="false"/>
+    <categoryEntry id="b519-5f8b-0ed3-9b5b" name="Hail of the Gods" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="16c2-5494-f676-e931" name="Infernal Dwarves (local)" hidden="false">
+    <forceEntry id="16c2-5494-f676-e931" name="Infernal Dwarves" hidden="false">
       <categoryLinks>
         <categoryLink id="7d1c-7635-8495-2d3f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -800,9 +800,6 @@
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="7e28-6eac-bf57-b398" name="New CategoryLink" hidden="false" targetId="07b9-8bdd-9b0d-6119" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
               </costs>
@@ -2898,9 +2895,6 @@ At the start of a friendly Player Turn, if there aren’t any friendly units wit
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="422f-40d8-d7b0-a760" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
           </costs>
@@ -3090,9 +3084,6 @@ At the start of a friendly Player Turn, if there aren’t any friendly units wit
                   </modifiers>
                 </infoLink>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="650f-72a7-60ac-83e3" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
               </costs>
@@ -3628,9 +3619,6 @@ At the start of a friendly Player Turn, if there aren’t any friendly units wit
                   </characteristics>
                 </profile>
               </profiles>
-              <categoryLinks>
-                <categoryLink id="ba29-0342-b33b-edbb" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="305.0"/>
               </costs>
@@ -4012,7 +4000,6 @@ The roll for the number of hits from its Stomp Attacks is subject to Maximised R
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="2dc9-0093-bc5e-0fa0" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-                <categoryLink id="19e9-37f4-ab1a-5906" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
               </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>

--- a/infernalDwarves.cat
+++ b/infernalDwarves.cat
@@ -1,0 +1,4425 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="dfd2-0d74-3072-b274" name="Infernal Dwarves 2.0" revision="15" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="12f7-9967-08bc-2ab6" name="Barrage (local)" hidden="false"/>
+    <categoryEntry id="1464-f43f-9e7c-296c" name="Bound and Binders (local)" hidden="false"/>
+    <categoryEntry id="b519-5f8b-0ed3-9b5b" name="Hail of the Gods (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="16c2-5494-f676-e931" name="Infernal Dwarves (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="7d1c-7635-8495-2d3f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="a91d-c7b9-52f1-2f3f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8377-e22a-8dae-27ce" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="7381-70db-e5a9-cb29" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="023e-327f-9910-4404" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="e30a-ef8b-c1b6-13c2" name="Hail of the Gods (local)" hidden="false" targetId="b519-5f8b-0ed3-9b5b" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="e75c-0396-38cb-092a" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4a46-7ab8-0eae-d5cd" name="Barrage (local)" hidden="false" targetId="12f7-9967-08bc-2ab6" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="ebeb-500c-ecb6-7587" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0547-2af2-cfcb-47f3" name="Bound and Binders (local)" hidden="false" targetId="1464-f43f-9e7c-296c" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="d567-9c87-e46b-aabd" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="4dba-df4a-f909-fd57" name="Overlord" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="4813-35c6-6113-4573" name="Overlord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ed89-d834-d391-cae2" name="Overlord Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6269-9737-500a-e4ef" name="Overlord Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="4822-71c9-174d-dbf2" name="Fan the Flames" hidden="false">
+          <description>The Overlord and all model parts in the same unit, except model parts with Harnessed, gain Hatred.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="abba-d7ef-e34b-8926" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="9df6-ef5b-a1bd-afd0" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="70dd-8c91-c733-ed24" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7b31-08c8-0878-4be9" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cda9-2834-d063-67e0" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="500e-757a-0218-1542" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9384-8e97-452d-963d" name="Blunderbuss (3+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab75-ec08-6100-b43d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2404-adec-8129-0258" name="Blunderbuss" hidden="false" targetId="7afe-6f22-2b97-27ac" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3a77-b6bb-2882-f35d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456e-19d1-f061-cf69" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="59ce-ac32-5ffa-04b5" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80da-ae72-183c-27fd" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="cd06-4c7c-bde7-a487" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b74d-84b7-88e3-3636" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="809c-a972-50b4-d3dc" name="ID Weapon Enchantments" hidden="false" collective="false" targetId="f88d-d700-fcb7-41c0" type="selectionEntryGroup"/>
+                    <entryLink id="24c2-6c3a-c1c4-0905" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="83c4-3552-f3ab-6c15" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="1a7c-4ca5-6a52-de6e" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a7c-4ca5-6a52-de6e" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0734-1ad2-2bb7-b8be" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="fd48-e593-8c2c-ae6d" name="ID Armour Enchantments" hidden="false" collective="false" targetId="5045-4d35-a53e-8c35" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="7e47-7ee5-dcee-5626" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9efc-3a89-7bf4-0357" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9fa1-2934-3790-1616" name="ID Artefacts" hidden="false" collective="false" targetId="8db9-ba71-c526-438b" type="selectionEntryGroup"/>
+                    <entryLink id="fda8-47cf-b172-82d5" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eb7c-d1d2-c56b-3bac" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dea-3d76-db96-0cbe" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4fb9-ca8b-740d-5792" name="Flintlock Axe (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e78-3454-56bd-6567" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ae34-6e8e-0997-b1f4" name="Flintlock Axe Melee" hidden="false" targetId="06dd-1877-81f7-f93d" type="profile"/>
+                <infoLink id="4cbe-11a2-4790-9b62" name="Flintlock Axe" hidden="false" targetId="1338-63b0-76a0-355b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fc1b-18fe-bde6-694f" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3055-9c5c-db75-3511" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b569-c732-cb32-f10f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4d3f-4907-06b6-7aa5" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbe2-ef7e-de4f-142c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4379-21d0-3867-d8a0" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9564-503e-6579-24cf" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1207-c908-e975-dc7d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c5b0-284a-16b3-ca2f" name="Bull of Shamut" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c1d-2235-6b6d-a5ea" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="8eef-9bab-bde8-d115" name="Bound and Binders (local)" hidden="false" targetId="1464-f43f-9e7c-296c" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="cd96-1004-bcbc-a3be" name="Bull of Shamut" hidden="false" collective="false" targetId="b469-c799-e70a-8802" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="230.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5a71-e54a-66eb-c7fc" name="Great Bull of Shamut" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1089-e6fc-d121-4769" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="08fb-1e9e-1b78-bc0f" name="Bound and Binders (local)" hidden="false" targetId="1464-f43f-9e7c-296c" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="023d-0ee1-fcba-c852" name="Great Bull of Shamut" hidden="false" collective="false" targetId="c6f9-e247-8344-f709" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="410.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="44ed-5151-1754-f537" name="Army General" hidden="false" collective="false" targetId="94c0-164b-ef92-f4e7" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="270.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f9c-c720-af8d-b84d" name="Vizier" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="f2d7-ddf4-d326-1c0f" name="Vizier Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="21fd-4da2-407a-a3e7" name="Vizier Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d1ed-7c10-f8e4-dc4d" name="Vizier Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="798d-2e46-9374-39a1" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="2c06-3ccf-505f-6b50" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5a38-8a63-8155-d058" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3cea-77f1-f6e3-5145" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e981-20e5-d7dc-a18c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c3ee-d00c-8275-1c37" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fd5e-a6f5-9070-f63f" name="Blunderbuss (3+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0454-423d-dbff-268d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0687-4c69-2259-2cf2" name="Blunderbuss" hidden="false" targetId="7afe-6f22-2b97-27ac" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f702-654f-643c-822f" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd55-4af4-ba84-1d46" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c2e9-76fd-f879-4560" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="82eb-a44c-53d8-0d16" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="4377-0816-91c7-3efd" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60f5-908c-2b6b-a7f2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2e74-b164-d4d1-b405" name="ID Weapon Enchantments" hidden="false" collective="false" targetId="f88d-d700-fcb7-41c0" type="selectionEntryGroup"/>
+                    <entryLink id="8b03-d136-6dc5-363c" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="2f4f-7a10-2734-95e5" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="6111-05ba-6f87-378c" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6111-05ba-6f87-378c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7890-085a-9b9c-dd9f" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="2513-f489-b109-5085" name="ID Armour Enchantments" hidden="false" collective="false" targetId="5045-4d35-a53e-8c35" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="66c4-b852-351e-2a3b" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a149-4d1a-6312-1cb2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="a6bd-b102-ee41-749c" name="ID Artefacts" hidden="false" collective="false" targetId="8db9-ba71-c526-438b" type="selectionEntryGroup"/>
+                    <entryLink id="691a-1e5d-8af2-3aa5" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="22e1-36a1-54ad-638b" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="0f9c-c720-af8d-b84d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="829e-4217-277d-fb7d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cba0-25c6-21f4-e301" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2f01-f3c5-53f9-6c63" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="5b5b-d1dd-f39f-f240" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d5a7-bbfe-7c5d-87f4" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9b7-513b-57e0-2e7d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="acb8-eea3-765b-f138" name="Flintlock Axe (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a0-79c0-7341-6a09" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4a91-6135-a7e2-82ec" name="Flintlock Axe Melee" hidden="false" targetId="06dd-1877-81f7-f93d" type="profile"/>
+                <infoLink id="6780-3fc9-a123-c7bd" name="Flintlock Axe" hidden="false" targetId="1338-63b0-76a0-355b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3396-ef9e-4afe-267c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b2b-77fc-81a7-79ad" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e45d-a795-d7cd-9594" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="230a-eca0-e351-0fac" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d709-c429-267b-f132" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9ca8-ef47-008a-d01e" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f970-cc0e-f0eb-078e" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11df-cdfb-1f92-9d92" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8539-e184-e9ab-9fad" name="Bull of Shamut" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="110c-c1b1-9edb-e989" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="2780-6c32-660d-d878" name="Bound and Binders (local)" hidden="false" targetId="1464-f43f-9e7c-296c" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="e066-6757-7b7f-ea4f" name="Bull of Shamut" hidden="false" collective="false" targetId="b469-c799-e70a-8802" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="240.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3ba8-d7b6-0b78-4c2c" name="Army General" hidden="false" collective="false" targetId="94c0-164b-ef92-f4e7" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0f9c-c720-af8d-b84d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="829e-4217-277d-fb7d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="f606-2b55-ce4b-73e1" name="Battle Standard Bearer" hidden="false" collective="false" targetId="829e-4217-277d-fb7d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0f9c-c720-af8d-b84d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94c0-164b-ef92-f4e7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7930-d759-161c-00ca" name="Chosen of Lugar" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2abb-b049-6411-6c95" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ad7a-8cbe-31d4-146b" name="Chosen of Lugar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="742c-a9e6-a462-217f" name="Chosen of Lugar Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="85f3-94f0-d5d2-9b90" name="Chosen of Lugar Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f99b-2bd0-462d-319c" name="Lugar&apos;s Court" hidden="false">
+          <description>The model can only join units of Disciples of Lugar, and when joined to Disciples of Lugar, it gains Scoring. If playing Capture the Flags, the model gains Scoring (no matter if joined to a unit of Disciples of Lugar or not).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1e43-c1dd-4c07-ebff" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="518e-ff3e-022c-d14a" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="dc1f-8b85-f851-824e" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="0f8d-a501-2c94-1fab" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+, 2+ against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="dcff-9f0c-536c-f8ae" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+        <infoLink id="e315-1c9d-3bbc-279e" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="96ae-50f0-290e-c2d7" name="Volcanic Embrace" hidden="false" targetId="02ab-566d-7f51-fee2" type="rule"/>
+        <infoLink id="f6ae-f1f3-8e7b-87d3" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e35f-2411-d43f-dd4c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9ce4-d761-610b-0313" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9777-3e70-e061-2780" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a42f-cbfe-e0be-0292" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06c4-9ccf-d152-fa84" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8d43-930d-eee4-0b92" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="a56c-f799-e9cb-853c" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a56c-f799-e9cb-853c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9b2a-bf6f-d842-db92" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="29dd-ebcb-bed6-ea9f" name="ID Armour Enchantments" hidden="false" collective="false" targetId="5045-4d35-a53e-8c35" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3407-0e36-5166-a4c6" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebb7-2c5a-ef82-df7f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="caf1-daaf-6be2-a5bd" name="ID Artefacts" hidden="false" collective="false" targetId="8db9-ba71-c526-438b" type="selectionEntryGroup"/>
+                    <entryLink id="8d5e-b172-557f-d9b9" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8967-57ea-cc08-070f" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0b5-87e3-8fe4-00bd" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="1cd2-d4d5-8d81-7639" name="ID Weapon Enchantments" hidden="false" collective="false" targetId="f88d-d700-fcb7-41c0" type="selectionEntryGroup"/>
+                    <entryLink id="53ed-a73e-a3e1-0dfe" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5ebc-406c-efbd-253b" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="7930-d759-161c-00ca" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="829e-4217-277d-fb7d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f035-bdd7-df2a-2592" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2b26-59d6-8612-a865" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="51fc-6fd9-044f-f00d" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4f89-8115-3b51-7e8b" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a22f-a414-2382-cb19" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2749-2e99-6c46-1255" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf15-e10b-d24a-3d28" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="fc5e-bd4d-14e8-b679" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7914-d168-0bde-7d2d" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d42-d3cf-eef5-110a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d982-93a5-2eac-8484" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c82f-d912-bffa-c802" name="Army General" hidden="false" collective="false" targetId="94c0-164b-ef92-f4e7" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="7930-d759-161c-00ca" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="829e-4217-277d-fb7d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="b29b-f63c-802e-9015" name="Battle Standard Bearer" hidden="false" collective="false" targetId="829e-4217-277d-fb7d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="7930-d759-161c-00ca" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94c0-164b-ef92-f4e7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="220.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b21b-8218-7a32-6542" name="Prophet" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="eccf-6d71-6ca4-939b" name="Prophet Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f0a9-18d1-9e27-4a94" name="Prophet Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="63d3-112f-dd00-75ca" name="Prophet Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8216-3e46-3189-a7f7" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="b580-787c-c6f4-5443" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dc3b-88b8-9233-65dd" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bf6e-7235-874c-db33" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe19-3c28-18e1-c2ba" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6ea2-f829-7c56-8702" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="66cd-ddf1-f1e6-b032" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7707-326e-7298-9e53" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="350c-fa50-b37f-1f6b" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="3207-e788-6bb1-457b" value="200">
+                  <conditions>
+                    <condition field="selections" scope="b21b-8218-7a32-6542" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0059-29ea-5c32-c940" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3207-e788-6bb1-457b" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1b4c-aec6-2431-5bca" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="7ba2-e56b-04a4-3584" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ba2-e56b-04a4-3584" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="faf8-bd41-b279-4f3f" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="c0cb-db19-e7b4-a495" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="8a37-630f-c6be-21e1" name="ID Armour Enchantments" hidden="false" collective="false" targetId="5045-4d35-a53e-8c35" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="e904-2dd1-0df9-aa9c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3941-7480-1a94-ae81" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c9c-6f5f-c1f9-f9b7" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="079b-f82d-85f5-b2f4" name="ID Artefacts" hidden="false" collective="false" targetId="8db9-ba71-c526-438b" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="6b50-41e1-c586-db12" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="9bee-a1f1-cb00-ead7" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="3158-57eb-eabc-0206" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c79a-47c9-b488-59dd" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55e5-5f3a-e4c7-e8f8" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6baa-e9b6-aefe-e411" name="ID Weapon Enchantments" hidden="false" collective="false" targetId="f88d-d700-fcb7-41c0" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="2ef3-dbfc-c8a9-4c05" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="4b2d-fbfd-b40d-8a94" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="19b5-7dd0-db1e-bd09" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="460c-62af-712a-d922" name="Blunderbuss (3+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d48-a8f5-7dd2-4235" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8989-8167-f18d-8943" name="Blunderbuss" hidden="false" targetId="7afe-6f22-2b97-27ac" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a2de-afde-7d87-7974" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5ad-953f-1acb-b99d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7a5-35ca-ee1c-7e5f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f081-86dd-b659-ed88" name="Wizard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e9b-9fc9-974e-4fc5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f91a-9074-5cae-289e" name="Engineer" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e571-074e-f9b6-871a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="454d-c97a-0786-ee90" name="Engineer" hidden="false" targetId="c16c-8e9f-3d9c-7a2a" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="7e28-6eac-bf57-b398" name="New CategoryLink" hidden="false" targetId="07b9-8bdd-9b0d-6119" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b133-b758-1215-a35e" name="Wizard Level" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="21c1-43b6-ea15-08c7" value="0.0">
+              <conditions>
+                <condition field="selections" scope="b21b-8218-7a32-6542" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f081-86dd-b659-ed88" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c1-43b6-ea15-08c7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d20-841f-1786-a790" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9a08-5add-bcfc-9511" name="Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfc5-a4f8-81ea-6abd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="080f-6514-318e-49bc" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="96da-8a8a-247e-51bd" name="Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="064e-02fb-a83c-16c9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="14fe-95f3-99b7-c186" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0059-29ea-5c32-c940" name="Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01bf-aadf-5eb3-9553" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="66b5-cc47-5f36-a2fd" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="265.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6dc0-87e0-54be-735a" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="9878-2805-4dd8-550a" value="1">
+              <conditions>
+                <condition field="selections" scope="b21b-8218-7a32-6542" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f081-86dd-b659-ed88" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b21b-8218-7a32-6542" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b133-b758-1215-a35e" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="172a-cdfb-d8cb-98a5" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9878-2805-4dd8-550a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="172a-cdfb-d8cb-98a5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="34e6-b491-8b8b-9a5d" name="Alchemy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06a3-6f92-4de0-5786" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="32c2-96c1-e3d5-ff63" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf2-9b6d-d8d9-3651" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ce92-6db5-ff33-36e6" name="Occultism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bc2-eb2d-059b-6d6e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2ebd-ac7b-d75f-930e" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e289-59dd-7178-6fb5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="92b6-7de9-a3ca-59f6" name="Flintlock Axe (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbba-fa8c-2e45-fd92" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="300a-89d3-6084-f86a" name="Flintlock Axe Melee" hidden="false" targetId="06dd-1877-81f7-f93d" type="profile"/>
+                <infoLink id="c85a-97a3-b91a-3844" name="Flintlock Axe" hidden="false" targetId="1338-63b0-76a0-355b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d283-8202-5546-91c6" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4937-683e-41c2-92db" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b7a3-b307-3bad-ea2a" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7c24-b33b-752a-95f6" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1872-c52b-f42c-9093" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9629-646e-de61-1eca" name="Bull of Shamut" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="b21b-8218-7a32-6542" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0059-29ea-5c32-c940" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f709-df75-fc4e-e092" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="2822-eed3-ed68-7203" name="Bound and Binders (local)" hidden="false" targetId="1464-f43f-9e7c-296c" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="c42b-296e-309f-e3a5" name="Bull of Shamut" hidden="false" collective="false" targetId="b469-c799-e70a-8802" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="67ff-2967-3874-1714" name="Temple Lamassu" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dcb-243e-f62a-905e" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0936-508b-ccbe-bc5c" name="Bound and Binders (local)" hidden="false" targetId="1464-f43f-9e7c-296c" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="ff37-64f8-aaab-6e62" name="Temple Lamassu" hidden="false" collective="false" targetId="9488-8e9a-afb8-2ef3" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d659-5312-7be2-bc39" name="Army General" hidden="false" collective="false" targetId="94c0-164b-ef92-f4e7" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9a1a-ef26-b226-0b1f" name="Taurukh Subjugator" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="b284-f020-66b0-0670" name="Taurukh Subjugator Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bf2a-8b90-d932-9b07" name="Taurukh Subjugator Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="34ef-f0ff-50a7-b371" name="Taurukh Subjugator Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="05cc-7000-e03a-b4fb" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="39d4-135e-f274-4b9a" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+        <infoLink id="49d5-b227-712b-1c2b" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Ruins)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ebd3-1f04-96d0-f0a9" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Armour)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4a12-dc1a-41f3-6d51" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7afa-14eb-d07b-e3c0" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="767f-c721-6755-00fd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="03b3-2837-f70a-bacc" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7d1a-91f5-d89e-59ca" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18db-5904-6da1-7e21" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2c19-5710-f650-1985" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d8e-263f-ab56-1691" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b77d-10c4-909a-c667" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f4b-aafc-4c0b-40c4" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c634-abad-c48f-a673" name="ID Weapon Enchantments" hidden="false" collective="false" targetId="f88d-d700-fcb7-41c0" type="selectionEntryGroup"/>
+                    <entryLink id="3386-56cf-17f6-7cb6" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c78a-74f7-4102-749e" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="fa4e-6cb0-6d84-8990" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa4e-6cb0-6d84-8990" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e03d-5125-beb4-e1d0" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="30fb-cf81-4e8c-0a5a" name="ID Armour Enchantments" hidden="false" collective="false" targetId="5045-4d35-a53e-8c35" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="0c62-6b84-e276-1581" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ad-f36b-d9b7-6615" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="05c4-9c37-d1f6-6c5c" name="ID Artefacts" hidden="false" collective="false" targetId="8db9-ba71-c526-438b" type="selectionEntryGroup"/>
+                    <entryLink id="0dcb-56c1-6a5b-14bf" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="563c-e1a1-1309-ef3d" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="9a1a-ef26-b226-0b1f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="829e-4217-277d-fb7d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46ad-6bf7-e653-0ee3" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0e7f-133d-7ec1-4b17" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="8c8b-ea17-63cb-1810" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f713-adb0-7749-e4c6" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a49b-37bf-9a33-338d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="00ba-5d26-b575-e1ad" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc86-8da0-edfa-b1cd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f5cf-e5ac-84de-782a" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f53f-114d-f512-e9ec" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="279b-db09-62d9-71a3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c996-ed34-c900-88f9" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="02a8-1ba5-28b8-85bd" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f25-1c1b-e4f9-46f8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7633-7618-abf1-1ed1" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="75ea-671b-f51d-0ec3" name="Army General" hidden="false" collective="false" targetId="94c0-164b-ef92-f4e7" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="829e-4217-277d-fb7d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="90db-b6f8-c663-fe48" name="Battle Standard Bearer" hidden="false" collective="false" targetId="829e-4217-277d-fb7d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94c0-164b-ef92-f4e7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="305.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5d83-5442-114a-2281" name="Hobgoblin Chieftain" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f58e-6bad-6838-d856" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0e13-f3b3-f15c-9b7e" name="Hobgoblin Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b028-3d4b-80f5-6be0" name="Hobgoblin Chieftain Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="276e-40a9-7853-c954" name="Hobgoblin Chieftain Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5eb4-048f-4fa6-2ee9" name="Opportunist" hidden="false" targetId="2a22-a7a4-da35-4e5b" type="rule"/>
+        <infoLink id="99c0-da7b-e519-959a" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c58f-5fb4-c36d-915a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="796e-24de-90da-b940" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8da2-a2ec-e0e3-b032" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c531-0a08-9acd-b7b3" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5ec1-d671-c4a3-a118" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f070-bc40-2464-7dac" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="dbc1-a56b-3165-dbaf" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="be19-b2c8-9230-db46" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0484-59b6-7506-30f7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="751e-4ac7-91a5-7e8c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11a1-c62b-b07b-3298" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="44b2-b233-5220-f145" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="c97c-ba39-3f5a-b1a2" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c97c-ba39-3f5a-b1a2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4964-7bed-6b1c-5a10" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="3f6e-fc7f-86e9-b442" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="e320-24ed-6e11-544f" name="ID Armour Enchantments" hidden="false" collective="false" targetId="5045-4d35-a53e-8c35" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="7e8a-2a6c-6b23-a66c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="321e-7699-f2b7-11ef" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3341-ca70-3ce2-f092" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5bfd-09ff-668c-94cb" name="ID Artefacts" hidden="false" collective="false" targetId="8db9-ba71-c526-438b" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="295c-6514-591b-3378" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="81c4-9fe5-fa08-f864" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="619f-8891-d4fe-e54c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c2a0-ae6d-f214-bc5d" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc5e-414d-14a9-b0d2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6c4d-607c-d558-dd27" name="ID Weapon Enchantments" hidden="false" collective="false" targetId="f88d-d700-fcb7-41c0" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="eed2-876c-4fe2-9105" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                    <entryLink id="3f71-8588-8e74-6746" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup">
+                      <categoryLinks>
+                        <categoryLink id="a08e-c6c4-4290-e1f8" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                      </categoryLinks>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5e0c-e2bb-897d-12f6" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6741-f66e-d6cc-b421" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9d9d-afd8-afe7-597f" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cbb-6f59-2a0f-86ee" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2d96-91a7-1d49-a029" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4242-5914-7909-85df" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77e5-084a-f268-bc9a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c873-4dc9-dcb7-3694" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="77a0-46b6-8b99-0689" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13c7-9098-5114-a7c9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e1b5-0c01-1e38-ba44" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8bb2-a718-83c2-cb23" name="Ranged Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25ad-3c34-5738-97f2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="37cd-3dba-60b8-860c" name="Bow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9338-48ae-4d5d-36f4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f9e1-cc76-e9cf-ec76" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6e93-b2f3-7a84-9e87" name="Throwing Weapons (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcd7-1668-a4ce-2aad" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="600d-4b84-dee2-2b56" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9ca6-7146-e094-2d73" name="May Take:" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d798-8ac0-626c-9f96" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8074-cb8c-77aa-58fd" name="Wolf" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee34-d6cb-3507-859f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="65bc-8568-e3a4-7e12" name="Wolf" hidden="false" collective="false" targetId="2f95-a932-5607-afc6" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a307-94d9-977d-4e6a" name="Backstabber Boss" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a0c-e6fe-a626-02cd" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="d97d-0d14-6819-d522" name="Backstabber Boss" hidden="false">
+                  <description>The model gains Backstabbers (see Hobgoblins). As long as the General is on the Battlefield and not Fleeing, a model with Backstabber Boss may borrow the General’s Discipline.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7f38-d686-4651-a747" name="Infernal Warriors" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="2c39-934a-3766-e7fc" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="653f-1dd7-39a8-260c" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3aa8-a500-f2ca-8af6" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8118-1a3f-8b39-2759" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0116-6eef-c4ba-9a6a" name="Infernal Warrior" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6908-24ea-089f-0d47" type="max"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ba6-257f-9401-6777" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="a6ad-7b0d-294a-7c56" name="Infernal Warrior Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="542d-7715-6b6f-5b05" name="Infernal Warrior Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="46a9-819e-f376-5bfb" name="Infernal Warrior Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5834-f2d7-1750-04e3" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="7f38-d686-4651-a747" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0116-6eef-c4ba-9a6a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bcf-b097-03d1-cf5d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7e59-bcee-5414-120b" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f6fd-f096-54ca-3e8f" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="7f38-d686-4651-a747" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0116-6eef-c4ba-9a6a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baf8-5327-995b-e32c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a491-ecf4-64a0-70b1" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ac61-93e0-c83e-1170" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b412-1936-ebed-34db" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f3ac-c1d9-3603-b58b" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="0fd9-933d-0c6e-2ef8" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8b7f-a7e4-67a5-45d9" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="56ba-ec22-c921-3129" name="Infernal Warriors with Blunderbuss" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="614d-7c19-5cfb-a6c6" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="9e5e-6861-03df-a212" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="06e6-c128-1961-fb27" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="d92a-705a-d438-601f" name="Blunderbuss" hidden="false" targetId="7afe-6f22-2b97-27ac" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="546a-1b18-33fa-6cd9" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="89c0-b5d8-0695-4a8a" name="Hail of the Gods (local)" hidden="false" targetId="b519-5f8b-0ed3-9b5b" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="80a3-aa88-a083-d71f" name="Infernal Warrior" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce82-14d8-cf35-36b3" type="max"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="574b-714c-5f51-d234" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="aa81-73c9-4390-361e" name="Infernal Warrior Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="663e-c990-7e96-03ba" name="Infernal Warrior Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="04c3-6afc-ddc2-f44b" name="Infernal Warrior Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5611-4cc7-1a2c-5cd6" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="56ba-ec22-c921-3129" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a3-aa88-a083-d71f" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="170b-9cef-acfa-c3b4" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="47d3-403e-79e3-0ff7" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2e92-a115-7215-a87c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="56ba-ec22-c921-3129" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a3-aa88-a083-d71f" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6b-e7f2-538f-1801" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2676-fcd4-9932-0c03" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="98b2-9ce5-2b1f-a78a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="080f-10af-c5fc-3956" name="Citadel Guard" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="cf5e-fa1e-cc1e-5608" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="89d6-0f31-8912-60b3" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="9830-f778-fc02-a1c5" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+        <infoLink id="037c-2869-bea9-ac5c" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="398c-58fd-5221-c0f3" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5f1e-961c-ac99-ea0d" name="Citadel Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e33d-f77b-5162-5f17" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5416-097f-c496-6f62" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="42d4-fe8b-ae94-50de" name="Citadel Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7ffe-0403-9750-e611" name="Citadel Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="09de-21e8-525d-353c" name="Citadel Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="22.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="14fd-9dfe-e98a-08a4" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b3-21bd-7bc4-72d5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0720-c5b0-affd-338d" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="94b8-1104-3206-0dc2" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6354-a407-560c-ce2f" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c42-c860-2cf8-69b8" name="Citadel Guard with Flintlock Axe" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="f3dc-1dd1-b2e2-0db9" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="7f6c-877a-f176-b383" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="d97e-5e4a-3978-73f7" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+        <infoLink id="4d0f-fa22-c57e-eb28" name="Flintlock Axe" hidden="false" targetId="1338-63b0-76a0-355b" type="profile"/>
+        <infoLink id="0feb-dc7d-5b87-9d91" name="Flintlock Axe Melee" hidden="false" targetId="06dd-1877-81f7-f93d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4439-f66b-3783-51c6" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="c083-d691-475f-45f7" name="Hail of the Gods (local)" hidden="false" targetId="b519-5f8b-0ed3-9b5b" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b616-e5e4-7481-1250" name="Citadel Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7f2-5c5a-2ac4-b32e" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7b9-49e7-4ea2-b4fd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0508-38cb-f712-dd81" name="Citadel Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4a44-098b-9721-ba3e" name="Citadel Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f6ac-82f3-c843-3123" name="Citadel Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c6af-2e57-fe00-6327" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="5c42-c860-2cf8-69b8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b616-e5e4-7481-1250" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8933-024e-72a6-7ee8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1f12-88e8-b193-e18e" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9590-be2a-64ad-77f0" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3772-20f6-6b04-6cff" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cef6-d229-695d-553c" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="0a65-9db2-ff94-6b23" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fd13-66c3-d8ed-11c1" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7cc5-429b-699b-1f0f" name="Hobgoblins" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="c04c-fa9a-df43-af28" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2c28-394b-5e0b-f1bd" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="e9fc-6862-653b-59dc" name="Opportunist" hidden="false" targetId="2a22-a7a4-da35-4e5b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0de3-6f88-c87d-acff" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ef2e-dae0-f658-0e79" name="Hobgoblin" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9353-4aa9-f990-315c" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d00-dcb3-b6e5-77a5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e886-4186-9748-d738" name="Hobgoblin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c90e-bebc-3ca1-e2e2" name="Hobgoblin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b44d-9cf6-4ae0-6626" name="Hobgoblin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="7.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="38ca-ac84-0b86-b78c" name="Options" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b127-4ac1-761d-dc2c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8b2-6e6a-966b-85cd" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fc81-77a3-c2a7-d498" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="7cc5-429b-699b-1f0f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef2e-dae0-f658-0e79" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df02-b341-4664-7fcb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3211-bbe1-152b-d247" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6c24-9061-5b94-8ee5" name="Spear &amp; Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="7cc5-429b-699b-1f0f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef2e-dae0-f658-0e79" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9eb4-fdec-9fa0-5621" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7564-f554-c653-7c5d" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+                <infoLink id="5dee-2fa4-4f59-8428" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5f78-111f-ee86-a16f" name="Backstabbers" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="7cc5-429b-699b-1f0f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef2e-dae0-f658-0e79" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fab6-6b61-c1c4-0711" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="9188-9f6a-85be-bcc1" name="Backstabbers" hidden="false">
+                  <description>The model loses all of its Weapons and Armour, and gains Paired Weapons and Poison Attacks. In addition, the model gains +2 Advance Rate when charging an enemy unit’s Flank and +4 Advance Rate when charging an enemy unit’s Rear Facing.
+</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="b0ab-b7eb-19b9-a072" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+                <infoLink id="b487-28d8-4a6e-efad" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d55b-a8ae-3010-3f03" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a9f0-9d4c-90f1-8db2" name="Hobgoblins with Bows" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d189-eaed-79ef-7185" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b595-049f-2e9d-acb8" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="4824-d6cb-b551-26e4" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="66f1-9c07-e6e2-dbbd" name="Opportunist" hidden="false" targetId="2a22-a7a4-da35-4e5b" type="rule"/>
+        <infoLink id="ccc1-a8db-2bd5-23a2" name="Bow (4+)" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="82e5-6265-84ce-4e79" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="ef76-2cec-030c-4b60" name="Hail of the Gods (local)" hidden="false" targetId="b519-5f8b-0ed3-9b5b" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="edcb-7f0a-cc2b-add3" name="Hobgoblin" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cbd-d072-cbf4-ff1e" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c02-649b-f3b5-e0a9" type="max"/>
+            <constraint field="24fd-8af8-0c78-001c" scope="roster" value="540.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec1c-ba15-b607-849d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d00c-35fb-a7eb-ac33" name="Hobgoblin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="06ff-5e5e-ef9c-23bf" name="Hobgoblin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4a2a-792f-0862-86bc" name="Hobgoblin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="9.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a71c-95d8-882d-c238" name="Options" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caa8-4f1e-1e5a-fdad" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1129-48b4-32a8-a798" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="a9f0-9d4c-90f1-8db2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edcb-7f0a-cc2b-add3" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="976b-7e4d-133b-56ab" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7685-5da9-4ca6-1b61" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1d17-a857-4cb7-6afa" name="Spear &amp; Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="a9f0-9d4c-90f1-8db2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edcb-7f0a-cc2b-add3" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7259-f31e-fc05-1cfd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="321c-06d5-d456-296a" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+                <infoLink id="1b44-4c11-94e3-43bc" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c81b-517f-9eea-87ea" name="Backstabbers" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="a9f0-9d4c-90f1-8db2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edcb-7f0a-cc2b-add3" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa63-8da4-17a8-130d" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="ad61-773c-0940-9662" name="Backstabbers" hidden="false">
+                  <description>The model loses all of its Weapons and Armour, and gains Paired Weapons and Poison Attacks. In addition, the model gains +2 Advance Rate when charging an enemy unit’s Flank and +4 Advance Rate when charging an enemy unit’s Rear Facing.
+</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="10bd-8af5-b42c-cf7d" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+                <infoLink id="d8f8-22a7-c877-926f" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5c28-3849-7100-9cc3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67b9-e5d1-42b1-e2eb" name="Orc Slaves" hidden="false" collective="false" type="unit">
+      <rules>
+        <rule id="f2de-bfee-6bf4-47b7" name="Slaves" hidden="false">
+          <description>At the end of a phase, if there are no friendly models with Chosen of Ashuruk or Opportunist on the Battlefield, immediately remove all your Orc Slaves models as casualties.
+
+At the start of a friendly Player Turn, if there aren’t any friendly units with Chosen of Ashuruk or Opportunist within 6” of an unengaged non-Fleeing Orc Slave unit, roll a D6: 
+	1-2: The Orc Slave unit immediately flees directly towards the nearest table edge.
+	3-4: The Orc Slave unit is Shaken until the end of the Player Turn. 
+	5-6: No effect. The Orc Slave unit behaves normally.
+</description>
+        </rule>
+        <rule id="1a01-0588-a4b4-7e68" name="Born to Fight" hidden="false">
+          <description>The model part’s Close Combat Attacks gain +1 Strength and +1 Armour Penetration during a Round of Combat
+● If it is the first Round of Combat.
+● Or if the model part’s unit is Steadfast at the start of the Round of Combat.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f6ec-b475-eafa-815c" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="1ccb-e66c-cf19-a826" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6670-ac1a-dc7c-233a" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3e34-d1be-145c-aacd" name="Orc Slave" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a802-4e6c-649b-a708" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16f4-5bf3-a316-e9ab" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9a55-557b-7674-fcd1" name="Orc Slave Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d73f-0330-020a-f73c" name="Orc Slave Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e3e3-9aef-25c2-a05e" name="Orc Slave Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f6ec-d34a-6d5a-2578" name="Musician" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e297-0d59-955b-7ed2" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0d67-1daa-0f26-1ba7" name="Option" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b2b-8e7e-a002-13e2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="17fc-6cbf-8629-b506" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="67b9-e5d1-42b1-e2eb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e34-d1be-145c-aacd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e71c-74cc-9004-b883" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9bc1-3319-9ffb-ef4f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7e61-c625-b214-6997" name="Shields" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="67b9-e5d1-42b1-e2eb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e34-d1be-145c-aacd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d04a-adcd-29af-9690" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d9de-7c31-dc1c-29f3" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c301-2026-2b57-1832" name="Immortals" hidden="false" collective="false" type="unit">
+      <rules>
+        <rule id="1200-46c6-d942-ce91" name="Blessing of Nezibkesh" hidden="false">
+          <description>All Melee Attacks from Special Attacks against models with Blessing of Nezibkesh have their Strength halved (rounding fractions up). and their Armour Penetration reduced by 2.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c62c-b9b7-5093-1dbe" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="219a-326c-5341-ea6f" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule"/>
+        <infoLink id="6e50-5813-30b3-3501" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="6f72-e8e1-9715-1bda" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2c0d-ecfe-879e-31fc" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="51b0-5703-1c9b-63cc" name="Immortal" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d36e-770e-5e1f-a0c8" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61c6-c25b-2b20-fbec" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e37d-a61d-9ed4-98ff" name="Immortal Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d61b-6c65-3575-f91e" name="Immortal Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9635-0039-7c58-d235" name="Immortal Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="28.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="84e9-a45b-0bbf-c8d2" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="c301-2026-2b57-1832" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="51b0-5703-1c9b-63cc" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d16a-b320-9314-d382" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="dd24-fea0-3dcf-55c6" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6129-6613-cf95-0f04" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c301-2026-2b57-1832" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8ea-8cc1-9648-cff9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="17d6-34d7-30c1-e04b" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="d1e4-3044-0ecb-be96" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4d12-1071-5f95-8e45" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="3133-f22c-ea7e-d0d0">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="212e-ccef-efb9-e0a6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c10-38cc-64d2-dd6b" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3133-f22c-ea7e-d0d0" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7be5-67d4-6e3e-7b57" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="62d4-3f2b-f826-997b" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5129-613e-e03c-d46b" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="c301-2026-2b57-1832" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="51b0-5703-1c9b-63cc" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="914b-1717-c200-3d04" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c24c-a5f4-d8c6-6562" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e802-b4ad-2176-2e94" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0444-c987-7b8b-91c3" name="Taurukh" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa0d-0ee0-a1d2-f38d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8288-4f14-ad0a-4449" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="b900-5ee4-f9fa-964d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="9102-66a5-2b25-0446" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Ruins)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4e23-9f94-9f14-39ab" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+        <infoLink id="3a90-1d29-895c-5e15" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Armour)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2fcb-8595-bd2b-d890" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ee5c-a45f-02c8-1c64" name="Taurukh" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc3-d6e1-734c-b3ae" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6574-b4eb-391d-2be3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5ad2-a06e-3ffd-0215" name="Taurukh Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9167-f1a4-823a-62ed" name="Taurukh Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="862b-5bfb-7ef6-7e4e" name="Taurukh Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="24.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="951d-f234-1f9c-ee11" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="0444-c987-7b8b-91c3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ee5c-a45f-02c8-1c64" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9731-d6f9-4092-890c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a5b6-631d-2803-2eec" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="20be-677a-adfc-2655" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="822b-e855-d03f-000e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f948-f2ba-f51f-2e10" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="56f2-279f-9682-d448" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="76a3-ef5c-9fa9-044b" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a87e-7c39-2ce5-b566" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e825-33fc-60ec-0975" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="0444-c987-7b8b-91c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee5c-a45f-02c8-1c64" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e8c-65d4-928e-40a7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7acc-188d-97a5-7994" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ca97-5e97-651c-f7d1" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0444-c987-7b8b-91c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee5c-a45f-02c8-1c64" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7e3-26a1-585f-96b5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f123-a0e1-9db7-2037" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6e0d-3dd4-ca09-ff7e" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="0444-c987-7b8b-91c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee5c-a45f-02c8-1c64" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28a7-46c5-7eb9-a7ed" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="89d4-deef-fc9f-403f" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3196-45b4-10c0-e565" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7124-5fad-9ef7-6b45" name="Taurukh Anointed" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af86-2727-ca99-be7c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a9c4-8738-a465-5add" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="88fa-2405-d2f4-74cc" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="8edb-f874-62cd-f0bf" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Ruins)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="eb59-4e66-d294-00f5" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+        <infoLink id="3706-f69d-fa1f-367e" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Armour)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="019e-f480-b8e3-7a26" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4be2-f56e-2f14-ffb0" name="Taurukh Anointed" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad71-bbb0-5f91-8456" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad4-5b16-53a7-14d9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0a26-d756-af7d-36fd" name="Taurukh Anointed Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e2f5-8371-8692-a399" name="Taurukh Anointed Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1954-7730-9339-8361" name="Taurukh Anointed Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0c62-3763-7929-1cb4" name="Shields" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+              <repeats>
+                <repeat field="selections" scope="7124-5fad-9ef7-6b45" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4be2-f56e-2f14-ffb0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00bc-2147-be3c-e5f3" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b226-7cb6-e5d7-910e" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a336-1a22-20e8-227e" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec3-0b76-af04-a3aa" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="05be-2e9d-458b-08ee" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="ed6f-0dd7-ef67-41fb" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5785-e088-8204-4ed3" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce49-ba0d-b9c7-afde" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f8ca-7293-f36d-adbb" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="7124-5fad-9ef7-6b45" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4be2-f56e-2f14-ffb0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bab-029f-68b5-4370" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a595-a256-faa0-f7ab" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7ba0-cbf4-e8bf-9f44" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="7124-5fad-9ef7-6b45" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4be2-f56e-2f14-ffb0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3160-c57e-aab7-ede0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6f7a-c959-91b9-8a17" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="91c1-38dc-1ade-2666" name="Infernal Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="18">
+                  <repeats>
+                    <repeat field="selections" scope="7124-5fad-9ef7-6b45" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4be2-f56e-2f14-ffb0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85eb-cf12-b911-7dbb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7178-8321-f6ac-9a30" name="Infernal Weapon" hidden="false" targetId="3ce9-1282-2e80-84d5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f087-1adf-e046-f107" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5bb1-5cbd-02d8-8a7e" name="Hobgoblin Wolf Riders" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b2c-4a3f-74bc-ce7b" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b97c-727a-6ae0-8146" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="7864-474c-e1e5-40e6" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="ccf9-92b3-4b20-a5f2" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="0797-ad17-9bfe-7d16" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="67b1-b2c2-b2bb-a631" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ae49-ab17-6aad-42da" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7cab-f523-50b9-5118" name="Hobgoblin Wolf Rider" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ce5-819e-21e4-3f3a" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fef6-3305-e718-2b00" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5e01-f352-e6d2-45ad" name="Hobgoblin Wolf Rider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9dcc-c636-6095-6b8e" name="Hobgoblin Wolf Rider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d60b-c6aa-0ef1-4bc0" name="Hobgoblin Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5cfa-095a-e1b5-15bd" name="Wolf Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="14.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0360-5490-eeb0-b6bd" name="May take any of the following:" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="fb9e-3f4b-2a71-77e1" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="5bb1-5cbd-02d8-8a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cab-f523-50b9-5118" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c81-d20a-9ba9-d0f4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8925-2f23-cb5b-06dd" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2a36-4e17-3239-19b0" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="5bb1-5cbd-02d8-8a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cab-f523-50b9-5118" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6904-6c48-f68b-61cb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="301a-be00-d98a-b2a4" name="Bow (4+)" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5ffb-8347-af51-877b" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="5bb1-5cbd-02d8-8a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cab-f523-50b9-5118" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17d2-c6ba-1e78-6612" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="40dd-db16-b0a3-4c40" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7b1d-bc5d-7f2a-81f7" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3a89-1122-e033-0489" name="Infernal Artillery" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="7037-4590-c8cc-4e76" name="Infernal Artillery Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="964b-b109-090f-6028" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">3&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6662-93fd-2937-5af1" name="Infernal Artillery Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="964b-b109-090f-6028" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9bb7-f45a-3b9c-748e" name="Infernal Artillery Crew Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="964b-b109-090f-6028" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3170-6e26-c7a3-0458" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="964b-b109-090f-6028" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b94c-5fb3-0af1-c312" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="7745-965b-7884-a7f3" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="964b-b109-090f-6028" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9407-a408-5d30-a838" name="New CategoryLink" hidden="false" targetId="12f7-9967-08bc-2ab6" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="964b-b109-090f-6028" name="Bound Daemon" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="200">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1871-797a-785c-a45b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d89c-9def-6e96-f9cd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3ea9-8bcc-117d-725e" name="Bound Daemon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8a50-3428-708e-0b1f" name="Bound Daemon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4016-b2e6-5d59-d973" name="Bound Daemon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e0d6-2cd8-c3f5-4aed" name="Daemonic Fury" hidden="false">
+              <description>At the start of each friendly Player Turn, the Bound Daemon must take a Discipline Test. If the test is failed the Bound Daemon gains Random Movement (3D6) until the end of the Player Turn. It cannot freely choose which direction to rotate towards but must move directly towards the closest enemy unit in the Movement Phase (in case the initial Pivot is impeded, the model Pivots as far as possible towards the closest enemy unit and then moves no further).</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="bc85-9297-3b98-4e39" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+            <infoLink id="04af-6e1f-60e0-674a" name="Daemonic Infusion" hidden="false" targetId="5eca-08ce-8a5d-7a6f" type="rule"/>
+            <infoLink id="7478-abc5-7894-4d65" name="Move or Fire" hidden="false" targetId="6475-e063-0070-f6cc" type="rule"/>
+            <infoLink id="111e-9355-0569-ead4" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="422f-40d8-d7b0-a760" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a5ed-14d9-b6b2-3feb" name="Artillery Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="556a-0ed9-c470-fd13" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a668-813e-f211-1549" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4cbe-01d7-dd52-2204" name="Rocket Battery (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d36-6a3d-1dc8-5f12" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0a3-cb7d-862a-2538" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="49e8-218f-c074-a601" name="Rocket Battery (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">7</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="285.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1871-797a-785c-a45b" name="Volcano Cannon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c93-60f4-91ae-ff23" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34e1-5f3f-f600-e57b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a269-6a6b-0c98-c4ba" name="Volcano Cannon" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4 (5)</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">1 (2)</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">(Multiple Wounds [D3]), Flaming Attacks. Flamethrower Artillery Weapon. If used by a Bound Daemon, ignore the -1 modifier on the Misfire Table.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d936-4b2b-0e54-cce0" name="Titan Mortar" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5cc-d776-aa20-9aa2" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f747-666a-f7ca-0922" name="Titan Mortar (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">6-48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">4 [7]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">1 [4]</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3, Clipped Wings)]</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e275-bafe-a277-d64b" name="Ogre Slave" hidden="false">
+          <description>The model treats all rolls of Jammed (3-4) on the Misfire Table as Malfunction (5+).</description>
+        </rule>
+        <rule id="328f-3f86-eada-b5f2" name="Titan Mortar" hidden="false">
+          <description>Any unit that loses one or more Health Points due to an attack from weapon will count all Terrain (including Open Terrain) as Dangerous Terrain (1) and must reroll all natural to-hit rolls of &apos;6&apos;. A War Machine within 8&quot; of a unit that is hit by this weapon must roll a D6 just before shooting; on a roll of 4+ it cannot shoot. These effects last until the end of the next Player Turn.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="babd-35b2-4f03-979e" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="4d5e-70da-7de4-0989" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="7871-0a1a-c641-01bc" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1e17-e2bf-f81c-8714" name="New CategoryLink" hidden="false" targetId="12f7-9967-08bc-2ab6" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b3b1-fe0d-553b-65aa" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="b6ff-28c0-1af8-a0b6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46c2-eb3f-8322-6467" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59f0-bb88-6e38-f8d7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b6ff-28c0-1af8-a0b6" name="Ogre Slave Crew" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b28-523e-f3f8-4806" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="9437-2774-9670-d601" name="Titan Mortar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+                  <characteristics>
+                    <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+                    <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">3&quot;</characteristic>
+                    <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                    <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                    <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="5c47-2547-f86b-ff3f" name="Titan Mortar Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+                  <characteristics>
+                    <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+                    <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+                    <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                    <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="c631-3d70-bd2c-b98c" name="Titan Mortar Crew Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="50c4-b317-8758-da8d" name="Titan Mortar Ogre Slave Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b3b8-177c-05e6-6fa5" name="Bound Daemon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7f6-334d-36e3-bba9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="e4ca-89fa-a1c8-ff5f" name="Bound Daemon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+                  <characteristics>
+                    <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                    <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                    <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                    <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+                    <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="acaf-2131-d99e-f46e" name="Bound Daemon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+                  <characteristics>
+                    <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                    <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                    <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+                    <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="a346-d0c7-1af1-6d92" name="Bound Daemon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="65dd-8afa-ae18-b375" name="Daemonic Fury" hidden="false">
+                  <description>At the start of each friendly Player Turn, the Bound Daemon must take a Discipline Test. If the test is failed the Bound Daemon gains Random Movement (3D6) until the end of the Player Turn. It cannot freely choose which direction to rotate towards but must move directly towards the closest enemy unit in the Movement Phase (in case the initial Pivot is impeded, the model Pivots as far as possible towards the closest enemy unit and then moves no further).</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="21a1-af6b-b570-5e1b" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+                <infoLink id="9a4e-f0d5-7c15-d418" name="Daemonic Infusion" hidden="false" targetId="5eca-08ce-8a5d-7a6f" type="rule"/>
+                <infoLink id="1fd2-8270-f6f1-a78f" name="Move or Fire" hidden="false" targetId="6475-e063-0070-f6cc" type="rule"/>
+                <infoLink id="f088-2c6c-1081-7963" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="650f-72a7-60ac-83e3" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="200b-103a-6e70-f546" name="Gunnery Team" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8adc-98b2-abed-b3d0" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f7f5-007c-1e7d-5646" name="Gunnery Team Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">6&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Contrast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="615b-ec5b-e3ed-9846" name="Gunnery Team Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="74b8-939e-8bc7-e79e" name="Gunnery Team Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="51ba-ba52-5d11-c6e7" name="Steam Powered Chassis" hidden="false">
+          <description>March Moving does not prevent the model from using Shooting Attacks. The model cannot voluntarily choose Flee as a Charge Reaction.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="2d8d-e1a8-dcf3-4031" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="28fa-54d3-f275-26ab" name="Infernal Armour" hidden="false" targetId="3c9e-ab86-99bb-7595" type="profile"/>
+        <infoLink id="335e-9ced-1869-c975" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="ff69-5426-b531-bb17" name="Quick to Fire" hidden="false" targetId="5a08-d3bf-06f9-3034" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="275c-711f-0e65-3031" name="New CategoryLink" hidden="false" targetId="12f7-9967-08bc-2ab6" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d21c-9ec2-d98d-d450" name="Artillery Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="076a-adbc-3846-c894" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cc4-7bdc-859e-9311" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a171-1b72-0db0-2380" name="Gunnery Volley Gun (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7500-990a-152d-3306" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a97b-dc69-9679-0385" name="Gunnery Volley Gun (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6, 2D6 or 3D6</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="205e-4ab0-ff06-3662" name="Grenade Launcher (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aef-d45f-d7c7-6483" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="156b-6239-7366-5253" name="Grenade Launcher (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6+1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">6</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Gun Artillery Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cd0b-34af-2c9d-0cee" name="Flamethrower" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e501-982b-66c3-9f9f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="9113-9ed0-dc78-78a6" name="Flamethrower 1" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4 [5]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">1 [2]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3)], Flaming Attacks</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="72c3-fa3e-7526-672d" name="Flamethrower 2" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">0</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">All models in a unit hit by this weapon gain Flammable until the end of the next Player Turn, or until being wounded (including rerolling to wound) by an attack with Flaming Attacks (whichever comes first).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="79dd-c344-6eb2-db80" name="Hobgoblin Bolt Thrower" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c76-96e2-ef04-cfe8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fb29-e6c2-acad-f551" name="Hobgoblin Bolt Thrower Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ca6a-4c43-59d7-a4bc" name="Hobgoblin Bolt Thrower Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7ed2-bac9-5361-31a9" name="Hobgoblin Bolt Thrower Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="269b-9dfe-0316-cd7a" name="Hobgoblin Bolt Thrower (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [6]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3)]</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4713-62f9-3b5a-200e" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e1c9-5cbc-f293-f834" name="New CategoryLink" hidden="false" targetId="12f7-9967-08bc-2ab6" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="36ff-8e24-d516-6769" name="Disciples of Lugar" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a31b-cfe4-b9d5-521e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b17a-891a-8fba-2b36" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+        <infoLink id="2943-c86e-3fdf-7af6" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="742c-7504-f1b6-8857" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="3854-4a45-6f30-ecde" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+, 2+ Against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="edf4-8108-ddbe-8f42" name="Volcanic Embrace" hidden="false" targetId="02ab-566d-7f51-fee2" type="rule"/>
+        <infoLink id="4abc-3e5b-1657-c9ca" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f2b5-ffc8-b30b-4ffa" name="New CategoryLink" hidden="false" targetId="1464-f43f-9e7c-296c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="67e7-affd-10fb-36be" name="Disciple of Lugar" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b98-39d1-b026-3f38" type="min"/>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1afa-a703-7dbc-9b72" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9345-69cd-7569-7099" name="Disciple of Lugar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f30d-2634-a58f-149d" name="Disciple of Lugar Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="99fd-dea3-485e-9f8d" name="Disciple of Lugar Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c5b4-f9e6-2d7f-f406" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="83b6-b2b1-09d8-1b5c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed99-6d36-7c11-7b65" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a7-cb5e-2ccc-0e9b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="83b6-b2b1-09d8-1b5c" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e1-9368-fa48-a1e7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="44d7-6d91-b502-b85f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="eddb-c5f8-db3f-e02b" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="36ff-8e24-d516-6769" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="67e7-affd-10fb-36be" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed8-5d52-c570-d3af" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c773-74ef-31dd-8d49" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b70a-a420-65e3-80ec" name="Banner Enchantment" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2882-8550-0993-d75b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fcf3-5f36-e651-00a0" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+            <entryLink id="843c-9967-b0b2-adad" name="ID Banner Enchantments" hidden="false" collective="false" targetId="213b-cce6-215f-9453" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="990b-d5b5-2641-a04e" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="65c2-2b63-a60b-9606" name="Kadim Titan" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0763-2ba4-c33b-3689" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="524b-906e-5e66-ddd5" name="Kadim Titan Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3c76-d6d3-2b9f-1183" name="Kadim Titan Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1b93-521a-3a69-37f4" name="Kadim Titan Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">6</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5ffa-b45e-bbfc-1da4" name="Searing Rage" hidden="false">
+          <description>The model&apos;s Close Combat Attacks gain Divine Attacks when allocated against models with Aegis (2+, Against Flaming Attacks). Each time the model fails a Frenzy test it gains +1 Attack Value for rest of the game. </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f6b4-f03c-167b-a41a" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
+        <infoLink id="e319-af0a-1c6f-4c4a" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="2734-be4a-f995-81a7" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+, 2+ Against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a2d4-038f-8bf7-f0e2" name="Volcanic Embrace" hidden="false" targetId="02ab-566d-7f51-fee2" type="rule"/>
+        <infoLink id="2421-d889-8ad1-f120" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c36b-5eb0-8270-f952" name="New CategoryLink" hidden="false" targetId="1464-f43f-9e7c-296c" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="575.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc59-5dda-19cb-7244" name="Kadim Incarnates" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd8c-2f4a-6acc-60b7" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6169-3798-c140-bf7b" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
+        <infoLink id="97b2-7807-6905-0eaf" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="4a25-9963-08a8-895d" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="5553-f326-995b-56b0" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="5e83-2c64-c587-0249" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+, 2+ Against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2d10-9e4c-f727-8627" name="Volcanic Embrace" hidden="false" targetId="02ab-566d-7f51-fee2" type="rule"/>
+        <infoLink id="ec29-62cc-bb8b-c759" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="22d0-c1d5-a390-79e3" name="New CategoryLink" hidden="false" targetId="1464-f43f-9e7c-296c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6950-bbf2-40d0-c85e" name="Kadim Incarnate" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8505-44d9-2a30-50b5" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df95-f1ed-d23e-0fd5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c756-877d-b3bd-b8d5" name="Kadim Incarnate Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot; (6&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot; (12&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b161-1a25-df13-8a18" name="Kadim Incarnate Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1c46-3e02-2809-54cd" name="Kadim Incarnate Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d54f-f33a-0d76-9442" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51dc-3c64-5b6f-9a00" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="88da-eaae-7c7c-491f" name="Infernal Engine" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da8f-6dfb-f024-81f0" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b4f8-3916-15ec-b0fd" name="Infernal Engine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">6&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b3f1-74b7-acbe-dfb5" name="Infernal Engine Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">7</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f814-c6f0-4016-da2b" name="Infernal Engine Crew Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a49b-2302-8022-5817" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="50f2-824e-c447-0518" name="Full Steam Ahead!" hidden="false">
+          <description>At the end of step 2 of the the Movement Phase Sequence (directly after Rallying Fleeing units), the Infernal Engine may engage its boiler. If so, until the end of this Player Turn, the unit may not shoot and gains Random Movement (3D6), with the following exception: it cannot move into base contact with an enemy unit that was not within the Infernal Engine’s Front Arc before the initial pivot. </description>
+        </rule>
+        <rule id="a69d-705a-15a9-92d3" name="Ponderous" hidden="false">
+          <description>The Infernal Engine may not Declare Charges, Pursue, or Overrun.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="66ef-e593-4a60-d557" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="cc71-55b8-ac9f-3f1a" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="0a82-d9e0-bf80-a85b" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="67d9-b1b7-c219-b1a9" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="d291-f762-9f4d-619c" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="efbd-a70b-4e7a-908c" name="Daemonic Infusion" hidden="false" targetId="5eca-08ce-8a5d-7a6f" type="rule"/>
+        <infoLink id="1a75-b2fd-30d6-d618" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8c67-ab28-e0f2-2b49" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b113-1025-e987-c836" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (3D3)">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b113-1025-e987-c836" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="371b-e525-816b-5a06" name="New CategoryLink" hidden="false" targetId="1464-f43f-9e7c-296c" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="30ce-00d3-ff5d-d226" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1614-0b39-36d8-5f53" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e93-0ae4-917e-6bd7" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0261-44b8-4976-d3e9" name="Shrapnel Guns" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33cc-1246-8c2f-0c02" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2444-1cf1-734e-78ec" name="Shrapnel Guns (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6+2</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">6</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Multiple Wounds (D3), Daemonic Infusion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <categoryLinks>
+                <categoryLink id="ba29-0342-b33b-edbb" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="305.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b113-1025-e987-c836" name="Steam Hammers" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="572d-25ac-dc43-32b5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="305.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="145.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f04-adf4-8e79-d1ab" name="Armoured Giant" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="699d-f212-254b-8681" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5158-6036-6c1b-adb8" name="Armoured Giant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c802-bbdc-4536-9a83" name="Armoured Giant Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <conditions>
+                <condition field="selections" scope="2f04-adf4-8e79-d1ab" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f001-5206-a99b-a94a" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f72e-bcb8-0441-b294" name="Armoured Giant Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8147-00b0-9c37-ecbb" name="Rage" hidden="false">
+          <description>Whenever the model loses a Health Point, it gains +1 Attack Value. Whenever it gains a Health Point, it suffers -1 Attack Value.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="032a-4992-845c-0ce8" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="33b3-d476-ba1e-1835" name="Chosen of Ashuruk" hidden="false" targetId="bd7a-2f3c-f580-7678" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d521-d6ec-3ba8-58cb" name="New CategoryLink" hidden="false" targetId="1464-f43f-9e7c-296c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f001-5206-a99b-a94a" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0666-5cc9-e760-ea20" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="0f6e-495a-bd3e-fb62" name="Big Brother" hidden="false">
+              <description>The model&apos;s Health Points are set to 8, and its base size is changed to 75x100mm.
+The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2f10-f316-1b9e-993e" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfca-d715-3afa-4dc1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a44e-c80d-935d-3cd0" name="Giant Club" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53f8-3073-00c9-d291" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="53c9-e6f3-bc4c-fbde" name="Giant Club" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="61f5-dbd4-9207-69d3" name="Slavemaster&apos;s Whip" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ee5-9478-2b08-74b0" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0cdc-0a2d-c543-9bf5" name="Slavemaster&apos;s Whip" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">-</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">-</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains +2 Agility and Commanding Presence which always has range 12”. However, only Hobgoblins, Hobgoblin Wolf Riders, Orc Slaves, and Hobgoblin Chieftains may benefit from this instance of Commanding Presence. Friendly Hobgoblins, Orc Slaves, and Hobgoblin Chieftains on foot in units within 12&quot; of the wielder gain +2 March Rate.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="93ca-a4a1-f8a7-d3fd" name="Mining Pick" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b372-fe66-ace3-acd4" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5c1c-8b2e-9bf8-e38f" name="Mining Pick" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">-</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">-</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains Crush Attack. If the wielder has an Attack Value of 8 or higher, it can perform two Crush Attacks instead of one.  The Giant gains +1 to hit with Close Combat Attacks when attacking a unit Garrisoning a Building, and ignores Distracting granted to enemy units by Defending a Wall.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="b469-c799-e70a-8802" name="Bull of Shamut" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c794-6d02-1b0e-8b6d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e774-73e0-b236-3572" type="min"/>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce9-3f55-1f54-e4b7" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="1558-a3d4-9300-6c6d" name="Bull of Shamut Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2887-935a-1039-1eb8" name="Bull of Shamut Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0427-0fe0-1875-9e3e" name="Bull of Shamut Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3d2d-d494-681f-f2e0" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="d1d9-4e9a-31f5-b7b8" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="8cd4-c832-8544-a1b5" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="b8c9-1ef3-717d-5939" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="e63c-ce45-0ccc-0f93" name="Volcanic Embrace" hidden="false" targetId="02ab-566d-7f51-fee2" type="rule"/>
+        <infoLink id="3cef-d1a4-355e-ad20" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e7ca-7ce1-2407-6122" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2+ against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c6f9-e247-8344-f709" name="Great Bull of Shamut" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0e6-7538-52b5-45f7" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7298-965f-58ed-4cd7" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01d-e57c-e40e-3fa7" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bde8-a6d5-84c7-c71f" name="Great Bull of Shamut Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f9c7-27d2-1e9f-b65b" name="Great Bull of Shamut Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="28ea-755b-2e36-5e29" name="Great Bull of Shamut Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7705-6c45-cacc-342f" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="d645-350b-db4a-6d7e" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="0f54-c9e5-512e-7fa0" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="332e-264f-a53c-d374" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="261f-4dbe-bbce-5db2" name="Volcanic Embrace" hidden="false" targetId="02ab-566d-7f51-fee2" type="rule"/>
+        <infoLink id="314e-2ebc-e049-bf31" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0031-8926-31c0-5dd6" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fa98-4bb7-2d97-13ae" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+, 2+ against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="94c0-164b-ef92-f4e7" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7841-e2ff-cb23-6ac8" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f75c-4f15-fd0f-9ce4" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd40-e067-ab48-bd0e" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="03f0-7822-9f2b-be33" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="829e-4217-277d-fb7d" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="894b-e075-a747-ee47" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a2c-44d5-746f-de0f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bd3f-7386-99aa-05b4" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9488-8e9a-afb8-2ef3" name="Temple Lamassu" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d96-ed24-8ac8-bd93" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f94-db8a-056e-15ad" type="max"/>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="637c-8d76-2982-2c17" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="94fe-52f3-eaed-6826" name="Temple Lamassu Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="55dc-3ee6-80e2-dc4c" name="Temple Lamassu Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4d42-32bf-015f-edaa" name="Temple Lamassu Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="ab40-4cf7-49f1-5193" name="Aura of Unbinding" hidden="false">
+          <description>Weapon Enchantments carried by models (friend or enemy) in base contact with a Lammasu cannot be used. A Character riding a Lamassu is unaffected.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f4c2-136c-688b-5a53" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="7519-0067-7933-a126" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="7241-5778-7cf2-f4ca" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="8567-15ef-a4e5-b6e9" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5b0a-b065-934e-f1d8" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9739-3ba3-339c-41d0" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b91e-a4ea-d415-cf3a" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="b478-7c2b-68b6-b953" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP 1, Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9830-dfd7-a0d6-3fca" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="0d9c-8d5f-26bf-8e8d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2558-ee18-7ae2-30d5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab33-fb7b-9d09-d290" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0d9c-8d5f-26bf-8e8d" name="Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b47-bf16-c129-8b28" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4f3b-4216-2490-5672" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4638-8f2c-8fa1-a471" name="Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba3-01ff-6fa6-5a88" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b48e-ef08-4755-5f62" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="2dc9-0093-bc5e-0fa0" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                <categoryLink id="19e9-37f4-ab1a-5906" name="New CategoryLink" hidden="false" targetId="13a8-55e3-9886-acd2" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f95-a932-5607-afc6" name="Wolf" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="485c-ad37-21fe-8ef0" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ab5-db0e-a3c9-0b7d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7157-9cdd-fc84-4500" name="Wolf Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1070-b278-524e-82ac" name="Wolf Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="98a8-466a-d4ea-bc46" name="Wolf Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d790-cdbe-b174-c576" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="1893-b459-001c-ad6c" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="24bc-eb8a-26a9-9a1f" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="86d4-1ee5-95ac-fd6d" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="f88d-d700-fcb7-41c0" name="ID Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5304-94db-4e1d-25a6" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b65b-c386-74c4-33e3" name="Onyx Core" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3992-5c83-c7ec-33b4" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="97d6-cf46-721b-429f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="abaf-5ee0-cc59-ea60" name="Onyx Core" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain +2 Strength, + 2 Armour Penetration, Magical Attacks, and Multiple Wounds (D3, against Flammable). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="98ef-e31d-b466-799f" name="Burning Steel" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb28-0240-6e1c-e3f0" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="116e-7071-c3e7-3baa" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1c2e-0ff5-e991-c3d5" name="Burning Steel" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder gains +1 Attack Value. Attacks made with this weapon gain Flaming Attacks, Magical Attacks, and have their Armour Penetration set to 10, and always wound on a roll equal to or greater than 7 - the target&apos;s Armour. A natural &apos;6&apos; always wounds and a natural &apos;1&apos; always fails to wound.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="5045-4d35-a53e-8c35" name="ID Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="73df-2778-043f-1d26" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73df-2778-043f-1d26" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="4367-127a-b642-b98c" name="Steel Skin" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8ce-48e3-33e4-325b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a972-2a3d-5b50-bdc5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0d7e-31fa-a81e-3638" name="Steel Skin" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247"> Cannot be taken by models with Towering Presence. The wearer gains +3 Armour. Attacks against the wearer with Lethal Strike and/or Poison Attacks lose these Attack Attributes. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="09bb-5dd9-fc2d-fe89" name="Kadim Bindings" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a062-46eb-757d-a077" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4cf9-3320-b539-d723" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="32ab-5e03-e602-54ea" name="Kadim Bindings" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, the bearer gains Aegis (5+, 2+ against Flaming Attacks), and Volcanic Embrace. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="f359-897b-29ff-f3c1" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="33e0-e54d-f83c-6071" name="Secrets of Mithril" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77a2-263d-1c87-b494" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a5ba-4c74-f33e-b7d2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="aaf9-8f48-6ed0-ce2e" name="Secrets of Mithril" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (4+, against Armour Penetration 3 or more)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="71bc-39f9-46c0-a303" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8db9-ba71-c526-438b" name="ID Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d13-0a35-1930-1a79" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="a9fe-e3f9-fb6e-1e43" name="Gauntlets of Madzhab" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="112c-581e-7d62-ed38" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="468c-54f9-cde4-67fe" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="451d-4a49-54df-0b22" name="Gauntlets of Madzhab" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +1 Strength and +1 Armour Penetration. Each natural to-hit roll of ‘1’ by the bearer’s Close Combat Attacks hits its own unit (attacker distributes the hits). These hits can never hit the bearer itself, unless the bearer is mounted and not part of a combined unit. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aed8-ec9d-5235-6fca" name="Ring of Desiccation" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="453c-8af8-5b86-4167" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2183-7438-484b-2795" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="77dd-6947-17da-53d9" name="Ring of Desiccation" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models on foot only. All enemy units in base contact with the bearer’s model gain Flammable. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ca47-cfbd-840d-d56d" name="Mask of the Furnace" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd69-cee8-de7f-0018" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f7e-6112-293b-8ac9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="938f-e9bd-32a3-a06f" name="Mask of the Furnace" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Cannot be taken by models with Towering Presence. The bearer gains +1 Armour and Breath Attack (Toxic Attacks). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="61fa-b1df-c1e2-2fdc" name="Lugar&apos;s Dice" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3255-4690-b2ad-aff9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdca-4456-b903-ec40" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6d20-4594-c0af-8aa9" name="Lugar&apos;s Dice" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Natural to-hit and to-wound rolls of &apos;6&apos; with Close Combat Attacks against the bearer must be re-rolled. The bearer must re-roll natural to-hit and to-wound rolls of &apos;1&apos; with its Close Combat Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8fe0-22c5-b24a-ea38" name="Heat Haze" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cb0-b1ae-60ee-a310" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c56-2bef-698c-5f7a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a54d-1e08-5e68-980c" name="Heat Haze" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (4+, against Shooting Attacks) and its unit gains Hard Target. The effects last until the end of the Player Turn in which the bearer&apos;s unit suffers the first Health Point loss.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eb8d-5d2c-37dc-98ab" name="Besheluk&apos;s Mechanism - Wizards only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b60-0776-047d-c282" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="401f-2f7e-69a3-e4da" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="542f-3605-a5c6-d81f" name="Besheluk&apos;s Mechanism" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Dominant.  The bearer can cast a Bound Spell with Power Level (4/8), Range 24&quot;, Type: Augment, Duration: Instant. The target Raises a number of Health Points as given below (units not on the list are unaffected by the spell): Disciples of Lugar: 4 Health Points. Kadim Incarnates: 2 Health Points. Kadim Titan: 1 Health Point.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c370-3501-b6e7-ac93" name="Tablet of Ashuruk - Wizards only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2df3-99e1-88c1-0e62" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a16-3932-da65-ff0c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dcbe-0e44-3c84-dd86" name="Tablet of Ashuruk" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">In the opponent&apos;s Magic Phase, during Siphon the Veil before converting Veil Tokens into Magic Dice, remove one Veil Token from the opponent’s Veil Token pool and add one Veil Token to your Veil Token pool.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3ec2-3903-7b94-cb42" name="Bullhorn of Nezibkesh" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c54-e6ec-2ffe-fea2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b90-e7ca-77d0-a6ba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f15c-f816-2500-6eef" name="Bullhorn of Nezibkesh" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Charm</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The range of the bearer&apos;s Engineer Universal Rule (if it has it) is extended to 12&quot;. When a War Machine is selected by the bearer&apos;s Engineer Universal Rule, its Shooting Weapons gain +1 Armour Penetration for the duration of this phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="213b-cce6-215f-9453" name="ID Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1266-b3e3-42bf-8cd2" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c4c5-7cce-63e2-320a" name="Banner of Shamut" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6134-3ed0-c575-d99b" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="298e-40dd-1d03-e48e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0fca-f060-4391-a904" name="Banner of Shamut" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A unit containing one or more Banners of Shamut gains +1 Offensive Skill and adds +1 to its side’s Combat Score.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4917-9624-1101-1851" name="Icon of the Inferno - Cannot be Taken by Core" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43aa-2b9f-c9c2-e26b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bd76-1a0a-1050-41cb" name="Icon of the Inferno" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When a non-Attribute non-Bound Spell is successfully cast by a friendly Wizard within 12&quot; of the bearer (and after the corresponding Path Attribute Spell has been resolved if applicable), the bearer may automatically cast Blaze from Pyromancy, which cannot be dispelled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="bd7a-2f3c-f580-7678" name="Chosen of Ashuruk" hidden="false">
+      <description>The model automatically passes all Fear Tests (but still suffers -1 Discipline from Fear) and considers all units without Chosen of Ashuruk as Insignificant. Furthermore, the model gains Battle Focus, which cannot be used during the first Round of Combat, and model parts with Harnessed cannot use it. R&amp;F models with this rule cannot be joined by Characters without it.</description>
+    </rule>
+    <rule id="5eca-08ce-8a5d-7a6f" name="Daemonic Infusion" hidden="false">
+      <description>The model part gains Magical Attacks, and any Panic Tests they cause to enemy units through 25% casualties suffer -1 Discipline. </description>
+    </rule>
+    <rule id="2a22-a7a4-da35-4e5b" name="Opportunist" hidden="false">
+      <description>When fighting an enemy unit in the enemy&apos;s Flank or Rear facing while only being engaged in the Front Facing, a model part with this rule must re-roll failed To-Hit Rolls.</description>
+    </rule>
+    <rule id="02ab-566d-7f51-fee2" name="Volcanic Embrace" hidden="false">
+      <description>All Melee Attacks (including Special Attacks) made by model parts with Volcanic Embrace gain Flaming Attacks. In addition, at Initiative Step 0, all enemy models in base contact with one or more model parts with Volcanic Embrace suffer a hit with Strength 4, Armour Penetration 0, and Flaming Attacks. Models with Volcanic Embrace cannot benefir from Fortitude.
+</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="3c9e-ab86-99bb-7595" name="Infernal Armour" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Plate Armour</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">4+</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">Aegis (5+) against Flaming Attacks.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3ce9-1282-2e80-84d5" name="Infernal Weapon" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Magical Attacks. This weapon cannot be enchanted with Weapon Enchantments unless noted otherwise.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1338-63b0-76a0-355b" name="Flintlock Axe" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Attacks made with this weapon do not suffer any negative to-hit modifiers from a Stand and Shoot Charge Reaction.  This weapon can also be used as a Melee Weapon.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="06dd-1877-81f7-f93d" name="Flintlock Axe Melee" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">0</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">A model using this weapon cannot simultaneously use a Shield against Melee Attacks. </characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7afe-6f22-2b97-27ac" name="Blunderbuss" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">10&quot; </characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire. Attacks with this weapon do not suffer negative to-hit modifiers from a Stand and Shoot Charge reaction. March Moving does not prevent from shooting this weapon. When shooting with a unit that has more than half of its models equipped with a Blunderbuss and ● exactly 3 Full Ranks, each natural successful to-hit roll of &apos;6&apos; with a Blunderbuss causes two hits instead of one. ● 4 or more Full Ranks, each successful to-hit roll with a Blunderbuss causes two hits instead of one.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/kingdomOfEquitaine.cat
+++ b/kingdomOfEquitaine.cat
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a0dc-734f-ea5e-2f6f" name="Kingdom of Equitaine 2.0" revision="15" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a0dc-734f-ea5e-2f6f" name="Kingdom of Equitaine 2.0" revision="16" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="8733-41f5-7948-a83c" name="Airbourne Gallantry (local)" hidden="false"/>
+    <categoryEntry id="8733-41f5-7948-a83c" name="Airbourne Gallantry" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="71fe-1034-daf6-add2" name="Kingdom of Equitaine (local)" hidden="false">
+    <forceEntry id="71fe-1034-daf6-add2" name="Kingdom of Equitaine" hidden="false">
       <categoryLinks>
         <categoryLink id="1ddf-670e-737c-1db3" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -229,9 +229,6 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="228b-59fb-af2d-3dd5" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="8142-636e-ef12-0429" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
-              </categoryLinks>
               <entryLinks>
                 <entryLink id="0362-38c1-7a4e-fcff" name="Hippogriff" hidden="false" collective="false" targetId="a075-898a-6f5d-e0dd" type="selectionEntry"/>
               </entryLinks>
@@ -368,7 +365,6 @@
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="d9a0-52cb-89f2-b07f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-                <categoryLink id="b7e0-fc9a-5ce1-23c0" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="59f8-ba60-3d56-9ac3" name="Questing Oath" hidden="false" collective="false" targetId="62af-2ffe-340d-4bd8" type="selectionEntry"/>
@@ -383,7 +379,6 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="1316-9b5a-c202-2e44" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-                <categoryLink id="0f46-9a90-67d5-3e12" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="895c-7256-97b1-1ca6" name="Grail Oath" hidden="false" collective="false" targetId="6b02-0dc0-9533-4770" type="selectionEntry"/>
@@ -448,7 +443,6 @@
         <entryLink id="34ea-1818-01f6-4c96" name="Virtues" hidden="false" collective="false" targetId="d39e-1d67-5d01-ebaa" type="selectionEntryGroup">
           <categoryLinks>
             <categoryLink id="ddd4-aa12-5f22-293a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-            <categoryLink id="5e68-5262-7975-6879" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
           </categoryLinks>
         </entryLink>
         <entryLink id="8fee-4885-a651-0570" name="Pegasus" hidden="false" collective="false" targetId="f5b1-b3eb-ae5e-3db6" type="selectionEntry"/>
@@ -551,9 +545,6 @@
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4640-476b-a964-5644" type="max"/>
                   </constraints>
-                  <categoryLinks>
-                    <categoryLink id="c89a-678c-c0b5-4436" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
-                  </categoryLinks>
                   <entryLinks>
                     <entryLink id="95bf-f56f-beb3-5eb5" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
                     <entryLink id="0747-6e4d-6b5a-dce7" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>

--- a/kingdomOfEquitaine.cat
+++ b/kingdomOfEquitaine.cat
@@ -1,0 +1,3716 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="a0dc-734f-ea5e-2f6f" name="Kingdom of Equitaine 2.0" revision="15" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="8733-41f5-7948-a83c" name="Airbourne Gallantry (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="71fe-1034-daf6-add2" name="Kingdom of Equitaine (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="1ddf-670e-737c-1db3" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="1d7f-2bf9-9dc3-aa74" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="1f51-34fe-5076-cdc0" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="f869-d2c4-d496-aab6" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e4cd-8df4-794a-dd67" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="073e-082b-4597-99c7" name="Airbourne Gallantry (local)" hidden="false" targetId="8733-41f5-7948-a83c" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="5404-a18f-c1c4-1693" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="79c9-6c50-8761-e161" name="Duke" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="493c-00f4-cda6-1aff" name="Duke Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dca0-7219-8bfe-602f" name="Duke Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="34ab-e56d-1322-8647" name="Duke Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4a44-26b0-a96a-df06" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+        <infoLink id="a5c0-8057-1be9-e5ee" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="ba6a-f96e-1c95-77c1" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="094f-0b9b-6c9f-bd43" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="cdcd-a6e7-de8c-e473" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bfc8-97d5-d16e-72fd" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd48-7c04-8eef-19dd" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ff02-16b9-2fda-24e6" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8139-a5ac-590f-592c" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="32dd-8f41-cf65-b70e" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c8e-9643-4b91-ffda" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9451-1a50-13d6-0ea7" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="941e-72a3-1c2b-6f88" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="7c43-6cae-7c68-61d4" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="5494-97af-2d08-657c" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5494-97af-2d08-657c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8a35-fc0f-8e03-5833" name="KoE Armour Enchantments" hidden="false" collective="false" targetId="9cc7-7c08-5df1-35cf" type="selectionEntryGroup"/>
+                    <entryLink id="0299-2925-7651-97eb" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="11e9-a71c-e274-ed33" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c563-6fb6-33fc-a1f5" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e41f-f1c4-9058-e2bd" name="KoE Artefacts" hidden="false" collective="false" targetId="e28f-aa60-832d-0a57" type="selectionEntryGroup"/>
+                    <entryLink id="0f51-a744-7d98-0a73" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6a1b-ffd5-3d5c-45e1" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="635f-aabe-dc2e-5bd1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c2b6-3b9a-7999-5703" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="de76-e13f-2bf9-01a5" name="Oath" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd25-1981-7f27-4106" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="05ea-11a8-d338-3995" name="Questing Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5c-400c-5d03-9892" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9967-c917-9785-94d4" name="Bastard Sword" hidden="false" targetId="96e0-c067-bd1d-eeaf" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="26df-ecef-3641-0f04" name="Questing Oath" hidden="false" collective="false" targetId="62af-2ffe-340d-4bd8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b877-3933-93aa-4986" name="Grail Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6ef-697c-8c5b-4def" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1638-090e-cb1e-a36a" name="Grail Oath" hidden="false" collective="false" targetId="6b02-0dc0-9533-4770" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e6b3-37e6-1330-9c22" name="Melee Weapons" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="0424-946d-a645-3a4f" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f695-1799-e47f-7cde" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0151-460b-2ab0-bb6f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7e91-1a25-ede4-f697" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc6a-0937-c9e7-01f5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="44e0-8124-0520-e804" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="06b0-35a7-457f-ef37" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f5f-1b44-5cc3-22fc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d88d-a450-ee9d-50ed" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bfb9-b26c-dd84-b4ca" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9e8-ccdd-af13-be2c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="385a-2fba-3ca6-0670" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="eaeb-f8d8-b8a6-2f56" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f29b-c42c-04e9-0a80" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3a5b-e800-5531-ea8f" name="Barded Warhorse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44ae-99c0-b2a8-5a6c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4b3e-d8f6-31d3-08f0" name="Barded Warhorse" hidden="false" collective="false" targetId="da96-1b71-21da-e286" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bee1-7042-90e4-eab9" name="Hippogriff" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="228b-59fb-af2d-3dd5" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="8142-636e-ef12-0429" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="0362-38c1-7a4e-fcff" name="Hippogriff" hidden="false" collective="false" targetId="a075-898a-6f5d-e0dd" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="215.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="61a4-5a8f-d6d4-d385" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry"/>
+        <entryLink id="1ae1-875a-c34f-5c3a" name="Virtues" hidden="false" collective="false" targetId="d39e-1d67-5d01-ebaa" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fdbe-e3d9-ff9b-0d1d" name="Duke on Pegasus" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="61aa-3de2-26ff-0182" name="Duke Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="406b-197b-ac85-d200" name="Duke Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="725e-6407-fdcb-a602" name="Duke Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fb79-1241-a5af-5302" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+        <infoLink id="0b64-609c-6650-4f53" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="5d9e-96be-8a3d-75db" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="a2dd-8fdf-8949-90a4" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1bfa-80e4-a286-2072" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="a90b-6eab-27f0-5707" name="Airbourne Gallantry (local)" hidden="false" targetId="8733-41f5-7948-a83c" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4952-06a6-ab65-d939" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6437-548a-8f57-5c5b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7f67-33f2-4792-c828" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64b0-225d-3fe8-c1e2" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3674-61ee-a19e-2e9d" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3af-f5a4-7afe-86fe" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f7e1-3310-b52a-7aff" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="ec20-83f4-d03c-8047" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="763f-bccc-9dd0-ac2a" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="f69c-1066-6c9b-a987" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f69c-1066-6c9b-a987" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="d6fe-c64c-e224-bf89" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="a522-f867-c315-484e" name="KoE Armour Enchantments" hidden="false" collective="false" targetId="9cc7-7c08-5df1-35cf" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="dcad-65ed-248c-fa67" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e05-ece9-8210-5e17" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6ce5-2a41-621e-4b44" name="KoE Artefacts" hidden="false" collective="false" targetId="e28f-aa60-832d-0a57" type="selectionEntryGroup"/>
+                    <entryLink id="d9d9-b0f0-0779-7fe3" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="685d-f5d4-f512-240c" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6eb3-b703-056b-9a71" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6767-94ba-2690-5141" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f2f3-2f94-efe4-4fce" name="Oath" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2579-2493-fca1-5f42" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f8f0-11ed-7050-9e4d" name="Questing Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eee3-d3fe-09ec-cd3a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="eb44-b2a0-494b-e038" name="Bastard Sword" hidden="false" targetId="96e0-c067-bd1d-eeaf" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d9a0-52cb-89f2-b07f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                <categoryLink id="b7e0-fc9a-5ce1-23c0" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="59f8-ba60-3d56-9ac3" name="Questing Oath" hidden="false" collective="false" targetId="62af-2ffe-340d-4bd8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9338-28b1-074b-248d" name="Grail Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77b5-c823-9936-3d84" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="1316-9b5a-c202-2e44" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                <categoryLink id="0f46-9a90-67d5-3e12" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="895c-7256-97b1-1ca6" name="Grail Oath" hidden="false" collective="false" targetId="6b02-0dc0-9533-4770" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e0ef-80ff-c48e-5f5c" name="Melee Weapons" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="39bf-3044-8847-e16a" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="712c-43e8-7ab7-3170" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c8c7-c287-cc9d-e8c9" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f64e-6024-3cf8-550e" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e43-24ab-0371-4981" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f2e0-9f3e-a52d-477b" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a943-c1b9-3ff5-42db" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac7e-77fc-813b-6de7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e918-5e03-6fe2-1c88" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="952d-134c-f1c5-d671" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e8-f127-327a-b2a7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1aa3-ad8c-a1a4-f4b0" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="000f-000f-0c42-dc48" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry"/>
+        <entryLink id="34ea-1818-01f6-4c96" name="Virtues" hidden="false" collective="false" targetId="d39e-1d67-5d01-ebaa" type="selectionEntryGroup">
+          <categoryLinks>
+            <categoryLink id="ddd4-aa12-5f22-293a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+            <categoryLink id="5e68-5262-7975-6879" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+        <entryLink id="8fee-4885-a651-0570" name="Pegasus" hidden="false" collective="false" targetId="f5b1-b3eb-ae5e-3db6" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="300.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a17b-d69e-22e7-a453" name="Paladin" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="20e1-39ec-73eb-d096" name="Paladin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e7b1-ea65-dcde-aa20" name="Paladin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f290-0725-7809-4af0" name="Paladin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1f92-79f6-8049-4134" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+        <infoLink id="b8cd-9d67-db6b-509a" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="cbf8-fc52-265f-0b68" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="ea90-981e-4d81-cbd4" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="017e-cf47-1677-5323" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a7ef-86b6-472d-ee8a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b017-2bd2-bcce-3982" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2569-4e38-befb-bdca" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2369-0463-f434-6cb2" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b3d9-c755-aaea-8978" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4baa-2be1-1a4f-a102" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="61cc-de2d-0273-29b8" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="63e4-2c04-7c88-6fa7" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5ea6-ff78-0f26-b1e4" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="6133-1318-807a-7e60" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6133-1318-807a-7e60" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7fc2-2dad-06bd-dd58" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="6123-83e4-8f58-35b1" name="KoE Armour Enchantments" hidden="false" collective="false" targetId="9cc7-7c08-5df1-35cf" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="27a5-cc07-e3e4-bbb3" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eff9-d1b7-931e-f48f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="eab8-478e-2037-6692" name="KoE Artefacts" hidden="false" collective="false" targetId="e28f-aa60-832d-0a57" type="selectionEntryGroup"/>
+                    <entryLink id="8eea-70da-15a0-f891" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c393-5d4e-5ccc-070c" name="Banner Enchantment" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="a17b-d69e-22e7-a453" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f6-b26a-6480-42e0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4640-476b-a964-5644" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="c89a-678c-c0b5-4436" name="New CategoryLink" hidden="false" targetId="51a9-e7aa-3ae6-1d94" primary="false"/>
+                  </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="95bf-f56f-beb3-5eb5" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="0747-6e4d-6b5a-dce7" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="902f-e87b-0726-16ef" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7906-409f-d6be-c490" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1986-09f6-3ae7-41f9" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="32f0-eeec-5a64-12ca" name="Barded Warhorse" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b266-8c90-2364-d8f1" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4e2a-22a5-1ddf-0bbc" name="Barded Warhorse" hidden="false" collective="false" targetId="da96-1b71-21da-e286" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0a44-ddb9-c895-9646" name="Oath" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ac4-b787-2b94-4b04" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="72e5-20cb-6a43-cddd" name="Questing Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="091d-5dd7-623c-8704" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1027-1d3a-992f-4372" name="Bastard Sword" hidden="false" targetId="96e0-c067-bd1d-eeaf" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="85d9-b1b1-daea-9483" name="Questing Oath" hidden="false" collective="false" targetId="62af-2ffe-340d-4bd8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c733-5c9c-4d26-c79d" name="Grail Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ae-4db7-5354-0395" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a994-5398-81c4-512f" name="Grail Oath" hidden="false" collective="false" targetId="6b02-0dc0-9533-4770" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0447-52cc-90eb-ed49" name="Melee Weapons" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="2125-bd93-4a26-298c" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b45-39c3-871c-9e57" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f216-9fff-49c5-f7b2" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3b53-5167-8a01-1c2b" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d462-af37-c355-0c67" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9605-c6bc-4823-417e" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bb0d-da41-fa47-fc72" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1e3-44d3-d75f-57f3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a0e7-7cf1-6c10-b203" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5485-2171-4b83-3fad" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40f1-09db-89be-cae5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c526-4a1e-de3d-c719" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2744-1dbe-7061-d6c7" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f6-b26a-6480-42e0" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="16c8-e32f-5b84-462f" name="Virtues" hidden="false" collective="false" targetId="d39e-1d67-5d01-ebaa" type="selectionEntryGroup"/>
+        <entryLink id="16d9-f128-4466-94be" name="Battle Standard Bearer" hidden="false" collective="false" targetId="12f6-b26a-6480-42e0" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="50"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c0a-db00-56fb-0063" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5cee-3019-c20c-4ac7" name="Paladin on Pegasus" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="0db7-268b-c189-977f" name="Paladin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2e82-33ba-1aef-d334" name="Paladin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="faf9-b0d8-f90a-c19b" name="Paladin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="775d-28a8-b27b-b70f" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+        <infoLink id="f550-a314-f09b-d117" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="9572-504e-83fd-a607" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="72ca-13b7-fa58-d852" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="689f-9591-8616-5248" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="2be2-f74b-0bd0-ea84" name="Airbourne Gallantry (local)" hidden="false" targetId="8733-41f5-7948-a83c" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0524-a833-c53d-3367" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4afd-3c04-6204-bed7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c2de-1791-604f-5325" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="929e-69b8-3060-6688" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="bb51-df9e-0e7f-54b2" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c60b-a2ab-7945-363d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9bfe-2bf5-ab34-085c" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="6ee2-e30b-ac50-6519" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="ef31-a897-7f1d-f123" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="6e22-2f17-861f-b0fc" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e22-2f17-861f-b0fc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7a73-5d25-5eaa-7098" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="2c79-8757-4701-0574" name="KoE Armour Enchantments" hidden="false" collective="false" targetId="9cc7-7c08-5df1-35cf" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="443c-a714-eb88-3098" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e4ed-10d6-8ac0-c1fc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="3a8f-0bf5-4af4-8aef" name="KoE Artefacts" hidden="false" collective="false" targetId="e28f-aa60-832d-0a57" type="selectionEntryGroup"/>
+                    <entryLink id="72d2-ee92-1d9d-b85d" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="de12-4785-ab86-743e" name="Banner Enchantment" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="5cee-3019-c20c-4ac7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f6-b26a-6480-42e0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a00b-78a8-e6aa-b97d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6f2d-c5d1-a638-b9f1" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="a438-fe11-e20c-89b0" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6b19-84b1-3e30-4674" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd59-9285-02ad-aaba" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4390-7a07-52d4-6b05" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fbda-d955-c588-74c6" name="Oath" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb5a-ff42-02b8-97b9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b9c8-bbfb-d3f6-1819" name="Questing Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec39-6e02-74a4-a238" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9cd8-6e61-bf7a-1ce7" name="Bastard Sword" hidden="false" targetId="96e0-c067-bd1d-eeaf" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="52a2-797f-2b87-9da3" name="Questing Oath" hidden="false" collective="false" targetId="62af-2ffe-340d-4bd8" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6c69-4614-4cde-8a4f" name="Grail Oath" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="007c-2e22-cf80-581b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a9f6-0f6e-bb74-4f90" name="Grail Oath" hidden="false" collective="false" targetId="6b02-0dc0-9533-4770" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="447b-41f7-71ff-c044" name="Melee Weapons" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="7a7c-ab67-2c27-c99e" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a31a-fe0b-6c1a-6757" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bf4f-98a9-d262-865c" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="edf0-8124-ee20-9a19" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f55-ca4c-8e86-2813" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dedb-f961-a946-f6db" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="974d-21e0-9bc5-befa" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b88-501b-4398-877e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6338-81ef-b795-41a5" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="640b-fa5e-8c05-d0fb" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f8-e208-cf64-3a94" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2004-4d98-ca0f-ac0e" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="967e-4ce9-9a63-07d2" name="Virtues" hidden="false" collective="false" targetId="d39e-1d67-5d01-ebaa" type="selectionEntryGroup"/>
+        <entryLink id="fc2c-9fff-dc03-88ed" name="Pegasus" hidden="false" collective="false" targetId="f5b1-b3eb-ae5e-3db6" type="selectionEntry"/>
+        <entryLink id="a7c1-c8b2-8803-31e2" name="Battle Standard Bearer" hidden="false" collective="false" targetId="12f6-b26a-6480-42e0" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="50"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c0a-db00-56fb-0063" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="f914-452a-3c30-caf4" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="12f6-b26a-6480-42e0" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="230.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aab7-e10a-759b-6236" name="Damsel" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="8d58-b3aa-62d6-7ab8" name="Damsel Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="eccc-d66d-d938-88bd" name="Damsel Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1580-c4e2-d93e-b8d1" name="Damsel Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="3ed8-7d0a-7cd7-c400" name="Beloved" hidden="false">
+          <description>When the model is joined to a unit with at least one Full Rank of models with Lance Formation, it gains Stand Behind and cannot be chosen by the enemy as the model that refuses a Duel.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="30fc-95f8-9840-a892" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="cf49-ec55-99ec-4f14" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="893b-5e0b-aefd-cf60" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="0fbb-028c-373d-05f6" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c6b9-a904-4f95-dda5" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="90f6-0b61-2fe6-9f3e" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de98-2c9f-81ed-690a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f0d4-c04a-d15e-ffc0" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="9f32-c9d6-1bb8-9938" value="200">
+                  <conditions>
+                    <condition field="selections" scope="aab7-e10a-759b-6236" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c246-b8fe-5540-7a79" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f32-c9d6-1bb8-9938" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="6a0c-931b-3a34-8350" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="481c-dbad-9f4f-89e3" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2b7f-ebac-c949-69ef" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="d5bd-b223-d4a7-cbec" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="87d1-9877-f10d-310a" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db4f-1f7a-93af-92af" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6c81-3415-3b6c-d689" name="KoE Artefacts" hidden="false" collective="false" targetId="e28f-aa60-832d-0a57" type="selectionEntryGroup"/>
+                    <entryLink id="d1a5-fc7c-4016-cc57" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1819-ebc5-7d17-9218" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="1312-ff33-1f6a-101b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d42d-26fe-fc67-8d38" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bd7-2b89-303d-dd8a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1312-ff33-1f6a-101b" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4697-c45e-2c76-dd0b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6c61-7fd4-1033-473c" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="143c-53ee-0ee5-f98d" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f45d-4781-e78a-b56c" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b838-d0d3-878f-4a58" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bc0d-8b92-ef0e-5a7d" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c246-b8fe-5540-7a79" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a909-dee7-6227-e8fb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="63c7-1d97-d0de-3d3d" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="49bc-044e-a785-bb79" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="fe37-b1dd-3619-22bf" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6dd-db3c-2dae-787c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe37-b1dd-3619-22bf" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="67d3-8fa3-1f4c-d15e" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1044-122a-b871-72a7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e1c0-b9ae-4def-dfdc" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfc8-fdcf-9433-f4f0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c87d-1b19-e0d8-3897" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b469-d4e5-4c25-6f49" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e795-1eb6-1944-d884" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a46-176f-b388-d534" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5d12-eab1-2ca3-2392" name="Barded Warhorse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf4f-b037-e5f3-1970" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a1e5-9728-0018-c623" name="Barded Warhorse" hidden="false" collective="false" targetId="da96-1b71-21da-e286" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c2fe-8459-6265-97be" name="Equitan Unicorn" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="aab7-e10a-759b-6236" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c246-b8fe-5540-7a79" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d969-6d65-0613-88b8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ddb1-ec15-2813-2824" name="Unicorn" hidden="false" collective="false" targetId="08ee-007f-0c03-a6e6" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8614-9d86-e3c5-8e3f" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="03af-b794-d8e9-d1a2" name="Castellan" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73cc-07c7-38a1-e1f4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a112-5976-695c-ab25" name="Castellan Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e1cc-6570-279f-e290" name="Castellan Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="15ca-99c2-32e6-f059" name="Castellan Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="8265-800f-bc87-d00a" value="3">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a4d-285b-1998-11e4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e3d1-e049-2a99-b17c" name="Lowborn" hidden="false">
+          <description>The model may only join units comprised entirely of models with Insignificant.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="766e-0f5a-a994-dba3" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="8164-edbe-16c0-432a" name="Serf" hidden="false" targetId="2637-2544-799e-6656" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c6e6-f1b3-4c2b-3634" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e1ef-3a8b-9648-6566" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dee6-23a4-be51-96fa" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0bdb-ff6d-1c20-ef64" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1723-d317-8f8c-acaa" name="Horse" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="178f-e405-ac5b-c9e9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="22d7-014b-a863-7c5a" name="Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4c5f-04f3-f08c-1113" name="Horse Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8680-4471-21a6-a6b1" name="Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="1153-7757-a11c-fd24" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+            <infoLink id="88cc-8a2e-154e-ca22" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+            <infoLink id="2a7b-49b0-5b13-7268" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3426-4d83-6a91-e675" name="Weapon Enchantment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9728-7a83-ad11-942b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="79df-ba6d-1ae7-cf82" name="Weapon Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eab-4db9-333a-85ab" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b77-fa94-0fcc-3df6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="87e9-53fd-86c5-80b5" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                <entryLink id="3c5d-0046-f885-7613" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8978-9c29-babd-9b35" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f81-55c4-471c-7aa8" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="373b-02dc-04fd-b17d" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab65-5479-1369-8173" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fe4-6602-0667-c47f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e8c2-9a44-002b-6001" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+                <entryLink id="2ecd-1aca-4488-b675" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e61d-9479-223f-29cf" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="cd80-4c0a-b856-799c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="914b-bd60-22ea-bce1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32c2-8fbc-88f3-92cb" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cd80-4c0a-b856-799c" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a42-4b81-77a8-ca18" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3bff-4850-a8c5-fd52" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3abb-63ed-4bc5-3306" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="03af-b794-d8e9-d1a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1723-d317-8f8c-acaa" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff03-a793-d93e-2a18" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="01d9-945c-64e8-7341" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7cab-1ae1-6693-beaf" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5530-f0b4-9076-b12e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8035-a5ee-c298-3100" name="Throwing Weapons (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb7f-5361-1815-4a0d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="51b6-ee91-8685-8683" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5e73-9821-2070-bad6" name="Longbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4add-7b6e-d095-e329" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e29e-3f3b-adc0-ff5c" name="Longbow" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f138-3854-c715-45fa" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="02bc-a2e9-f28f-fc64" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0c7f-90ce-1117-75b3" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b301-1355-5703-4f09" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="90cf-8eff-e6f3-af78" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0549-45b3-e735-f4f1" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fa1-623f-e224-e4ad" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ea39-d015-0637-1099" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="25bc-16db-00ba-a527" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b8c-7f6b-0adb-0913" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b4b1-746d-22a1-ac8f" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7159-678d-194f-b76f" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8493-b9c8-2b93-b278" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a103-ef6d-07d8-826f" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d9fc-e489-6f3c-e123" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2adb-05af-0e30-669b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="611b-e793-d3f4-33ab" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5a4d-285b-1998-11e4" name="Master-at-Arms" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e427-aecb-2c41-d7c8" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="a2c3-5972-289a-159d" name="Master-at-Arms" hidden="false">
+                  <description>The Castellan gains +1 Attack Value and its unit gains Weapon Master.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="f293-bf73-2907-a9b1" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8561-57cb-6453-4582" name="Bannerman" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="917f-0ef6-f26f-aaeb" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="5421-4377-78df-e1b0" name="Bannerman" hidden="false">
+                  <description>The Castellan gains Stand Behind and is a Standard Bearer.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="8ceb-b454-e563-b1d6" name="Stand Behind" hidden="false" targetId="ccc1-4db1-6ef8-8bc7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="47a9-dae0-9cb7-4683" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f7ae-00a0-2c11-9cc4" name="Knights Aspirant" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e1e-ecec-7bbe-733a" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7894-154d-88d6-bd06" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="43e2-e2d6-3e08-a9c1" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="9918-4a28-a7ad-7234" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="b87a-f2e7-3761-ac67" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="ca63-2367-0307-edf5" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="ca24-fb5e-cb2b-41d9" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="71cd-2cbb-61c5-08a0" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3827-e845-636b-593b" name="Impetuous" hidden="false" targetId="6190-c357-5cbe-fb08" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b59f-7fd2-3956-bddb" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5010-6ffe-128d-12d3" name="Knight Aspirant" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="188f-12ef-68ec-5320" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="386a-5eab-d550-3c5b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8f27-8f12-042f-0998" name="Knight Aspirant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3c44-8f36-c3f1-fcdd" name="Knight Aspirant Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="355c-faef-1f34-b6a9" name="Knight Aspirant Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="08e2-3d66-a476-2fa3" name="Warhorse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="38.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fbb8-a402-1b96-8eee" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d0a-10bb-0b4d-ebbe" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="68e6-4a57-77bb-8916" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d91-e3a6-04eb-8a93" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0608-c0cd-b34d-5c44" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="2ffa-34fd-67c8-92dd" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="cdf9-1bec-abe2-8c81" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84a4-2b85-eeaf-3f6e" name="Knights of the Realm" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcfa-4f7d-eafb-1c72" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e2a7-3aad-910f-cb93" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="0b7c-9b6a-0f0e-9357" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="5849-ca13-ad21-151b" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="fae7-3407-05b0-3a53" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="d5aa-0363-570e-cea0" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="4868-03bf-5d74-ac0c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b312-cd22-321f-cec3" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="08f3-4f36-7a80-6137" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="88f2-51a3-3401-f385" name="Knight of the Realm" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1953-a0ec-2adc-e5c5" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a17d-3d72-566f-e9ff" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1c10-7a9f-265b-5c1d" name="Knight of the Realm Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="59e5-0d29-3f97-9ca2" name="Knight of the Realm Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0125-6da2-0d33-3c4c" name="Knight of the Realm Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d279-9d8e-4fec-a5d1" name="Warhorse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="48.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c0d0-210f-3f64-0c3c" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f990-da65-ab2c-ac54" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="cad1-ba7e-8625-74b9" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b1-aeef-4b95-bd9b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ba44-9849-e81c-a2f6" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="78eb-c6d1-a744-1393" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="583f-2d81-8e07-29fe" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-28.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d675-3326-25fc-ca6b" name="Peasant Levy" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="edac-e92c-bd7e-9a07" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="c927-b063-6f13-5015" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="097d-3940-9a68-6737" name="Serf" hidden="false" targetId="2637-2544-799e-6656" type="rule"/>
+        <infoLink id="f58a-e9d1-068b-138f" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="f95a-3591-2887-862c" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="843b-8706-8cdc-1f47" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5ae8-e1ab-903e-d25b" name="Peasant Levy" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5919-925f-7750-bf24" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a003-c54b-243d-46af" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c64e-e756-4881-b3ef" name="Peasant Levy Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2946-068d-df27-c55b" name="Peasant Levy Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="df69-1ace-95dd-3ba2" name="Peasant Levy Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="7.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="62aa-b19f-bbb2-fa7b" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e03d-f20e-21ea-f4e4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3904-ce9e-3295-4005" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="d675-3326-25fc-ca6b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae8-e1ab-903e-d25b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e34-b6b9-3904-ec4a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="766a-5368-d30f-c941" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0f05-8e92-82e7-331b" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="d675-3326-25fc-ca6b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae8-e1ab-903e-d25b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b6-4e01-d555-c0dd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9503-6cc7-dc89-b0e8" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e031-8e4d-5292-f857" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="577c-ffde-b318-5cf5" name="Peasant Bowmen" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32ab-c80b-ad26-a8e4" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="8d82-6eab-41c6-21d9" name="Bowmen&apos;s Stakes" hidden="false">
+          <description>When deploying the unit, you may place a Wall Terrain Feature fully within 1” of the unit’s Front Facing but not in contact with any other Terrain Feature. This Wall is up to as wide as the unit, to a maximum of 12&quot; and up to 20mm deep. It follows the normal rules for Walls, with the exception that it contributes to Soft Cover instead of Hard Cover.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6187-ce5c-19b9-3894" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="0c78-4c77-3734-4401" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="f7a9-3df9-a21f-a19a" name="Serf" hidden="false" targetId="2637-2544-799e-6656" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0dc4-1990-6958-6aa9" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="47e9-e5b9-a5c9-e0dc" name="Peasant Bowman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4647-d9a7-539d-26b2" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d53e-485a-4ad8-94ea" type="max"/>
+            <constraint field="24fd-8af8-0c78-001c" scope="roster" value="1100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="858a-81b6-cf67-56d2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d19a-a05c-cfc9-ddaa" name="Peasant Bowman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3b3d-24e5-c4f7-5525" name="Peasant Bowman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2aee-5542-23df-7e62" name="Peasant Bowman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="55a0-ccbc-091f-7e89" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="2e83-8612-e2a8-d8e6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9765-4941-8b5e-5b43" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2e83-8612-e2a8-d8e6" name="Longbow (4+) &amp; Braziers" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d1a-625d-d759-ff84" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="5934-2bd4-721a-4179" name="Braziers" hidden="false">
+                  <description>Before shooting a Longbow, the model may choose to use Braziers to gain Flaming Attacks for its Shooting Attack. Effects last for the duration of the Phase.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="004d-048c-720b-2299" name="Longbow" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0351-cbad-3d51-73de" name="Crossbow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="577c-ffde-b318-5cf5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="47e9-e5b9-a5c9-e0dc" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57f0-a31d-ded5-986c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f2af-5705-90b6-a093" name="Crossbow (4+)" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ab6a-633a-3b44-a1ba" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2362-6ca3-41eb-95f9" name="Knights of the Quest" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8875-2116-38ab-c885" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a1ed-4a0f-3bcf-6327" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="9153-81dc-89b8-69fe" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="4dc1-7b0b-550f-a5f4" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="c69f-260d-98f5-8dd8" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="31d8-fcf2-758a-4fe8" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="6347-9160-30f4-13eb" name="Bastard Sword" hidden="false" targetId="96e0-c067-bd1d-eeaf" type="profile"/>
+        <infoLink id="3ef1-cf5f-e1cb-ee4b" name="Questing Oath" hidden="false" targetId="1a90-f274-9ad1-75d5" type="rule"/>
+        <infoLink id="258a-4a56-2fea-57d7" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="41e7-f70a-5755-7b44" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1e6e-1960-923d-6221" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6cbc-3c75-f61f-c45c" name="Knight of the Quest" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="953a-c0af-0a78-4096" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5dc1-8b7d-676e-09ea" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="86ec-c799-cebe-0dae" name="Knight of the Quest Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9813-5369-72cd-9998" name="Knight of the Quest Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="82cd-3634-1b2d-61e5" name="Knight of the Quest Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7f3d-a904-797b-9b7c" name="Warhorse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a7a3-246c-b5d3-926c" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6a2-1655-956f-38c5" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c83c-0fb1-85f9-7e37" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efba-fff4-75b0-1eb8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="cf79-67c1-f0e1-b5e7" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="8c00-92ee-da91-a190" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="9a07-f1f0-e2c0-5231" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="884d-ea09-0f82-1d02" name="Knights Forlorn" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8e2-3c3c-cb03-45cb" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="e3a4-d5ad-3477-d217" name="Forlorn Hope" hidden="false">
+          <description>Enemy models do not count as charging for the purpose of Devastating Charge when attacking models with Forlorn Hope.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0dc8-da21-ba1b-7652" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3489-edb6-087e-8498" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0f67-3019-77da-9a3c" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="b1c5-87d5-eb1f-a536" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="c080-918a-22d2-b86e" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="2aad-3d9e-1424-dd74" name="Bastard Sword" hidden="false" targetId="96e0-c067-bd1d-eeaf" type="profile"/>
+        <infoLink id="4999-e32f-3fc4-9e74" name="Questing Oath" hidden="false" targetId="1a90-f274-9ad1-75d5" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7367-c461-42f0-6498" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ae14-7703-a499-0a0a" name="Knight Forlorn" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2eec-f357-b330-d512" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e27-9494-dbb0-778e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0524-7b4b-e41c-92fd" name="Knight Forlorn Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9c7e-6f83-e894-fdfc" name="Knight Forlorn Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="eb34-a6af-5dc1-7c77" name="Knight Forlorn Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c971-2400-a846-e8b9" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ca7-e78d-7932-9627" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b0bf-ee9a-d5e2-acbf" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d072-7276-f1d9-37ad" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b69b-cb1c-593f-2d04" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="6207-ea07-1695-1ed6" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="3532-3096-7a9c-49c6" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1db3-be14-2942-7eb1" name="Knights of the Grail" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="bdf9-d45f-ca2d-a848" value="1">
+          <conditions>
+            <condition field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e34-9e27-d390-af4e" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdf9-d45f-ca2d-a848" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="c60f-6841-36c2-dd13" name="Pure of Heart" hidden="false">
+          <description>Only Damsels and Characters with Grail Oath may join a unit with this rule.</description>
+        </rule>
+        <rule id="1084-c974-431d-3964" name="Holy Might" hidden="false">
+          <description>The model part can make up to 2 Supporting Attacks when its unit has at least one Full Rank.
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a006-c416-fff7-bca6" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="93ef-90fe-a953-e479" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="a0a3-0117-ac30-67f3" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="a506-d6c2-da61-6691" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="2ebc-ee84-3a97-a8a4" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+        <infoLink id="7487-c173-fba7-b465" name="Grail Oath" hidden="false" targetId="026d-0672-d4a3-9b68" type="rule"/>
+        <infoLink id="b2d4-74da-dc3b-ba08" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="13fd-a27d-2ab3-4f19" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f712-04b6-566e-a028" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="60c0-32f6-8e58-b35f" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2e8d-2f5c-0d08-e85a" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b027-9246-075f-f7b3" name="Knight of the Grail" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd10-6c5e-9efd-f8ea" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eba8-452a-3387-b52a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5911-6ce2-75f7-b801" name="Knight of the Grail Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="188e-fea2-2587-44c8" name="Knight of the Grail Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6db6-a074-ada2-3bba" name="Knight of the Grail Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="eda4-36e0-4a8e-5920" name="Warhorse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="84.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e157-8886-02fc-9a52" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8578-4d4f-3942-7981" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a9e8-4371-442c-3d1e" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="767e-8f4a-4b5d-cc95" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="53ba-459e-d7ee-e1d7" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="6cb6-5450-f985-5e0a" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7139-2c0f-7f15-979d" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-32.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e34-9e27-d390-af4e" name="Siege War Machine" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a0b3-d19e-e085-a1e1" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="cee0-94e6-90db-944f" name="Siege War Machine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="2e17-9c12-bfb4-59b0" value="Large">
+              <conditions>
+                <condition field="selections" scope="1e34-9e27-d390-af4e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="899d-fa00-6593-aa09" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">0&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">0&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="814e-99b5-aa10-a97e" name="Siege War Machine Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a7eb-dc3d-a568-9aa1" name="Siege War Machine Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="19d5-9248-169c-b76d" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="7942-2aca-2667-e39e" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="faff-759f-ce7a-de5a" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5ea4-13aa-b514-2828" name="Artillery Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec07-8ee9-642f-885e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca76-a387-78e1-d8d9" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ee81-40b0-ca87-cf66" name="Scorpion (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8b6-61e0-83eb-99d0" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0a7e-09d6-a20b-0584" name="Scorpion (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [6]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Bolt Thrower Artillery Weapon, [Multiple Wounds (D3+1, Clipped Wings)]</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="899d-fa00-6593-aa09" name="Trebuchet (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="760e-b5fd-354a-1f3c" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8e71-188a-5ffa-933f" name="Trebuchet (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12-60&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4 [8]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">2 [6]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (4) Artillery Weapon, [Multiple Wounds (D3, Clipped Wings)]</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="280.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b4ba-d469-036f-a794" name="The Green Knight" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea4e-b787-9c21-84f5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7370-f5e3-1882-1427" name="The Green Knight Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b8ae-9b74-207d-26c7" name="The Green Knight Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="50ea-9678-5cd5-f9db" name="The Green Knight Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1f16-a4de-6803-c06c" name="Spectral Stallion Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b67c-0920-5d12-7fe9" name="Lambent Sword" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+          <characteristics>
+            <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+            <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+            <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Ignores Parry</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="58ad-cd9f-1b3d-db65" name="Eternal Champion" hidden="false">
+          <description>The Green Knight cannot be deployed during the Deployment Phase. Once per game, at the start of any of your Movement Phases, you may deploy The Green Knight within 6” of a friendly Damsel. The Green Knight cannot perform a March Move this Player Turn. If The Green Knight has not been deployed by the end of the game, it counts as destroyed.
+While The Green Knight is within 12” of a friendly Damsel, it gains Stubborn and may Issue and Accept Duels as if was a Champion.
+</description>
+        </rule>
+        <rule id="dd5b-2d6d-9042-2d44" name="Thrice Blessed" hidden="false">
+          <description>The Green Knight gains The​ ​Blessing​. If the Army Prayed, The Green Knight gains Aegis (+1).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6b6b-2344-99dc-5852" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="17d4-f8c5-f35c-5cba" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="55ee-9ff2-3723-9a64" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
+        <infoLink id="74e3-fbfe-3dc2-bde1" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="a701-375a-c0c8-75d4" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="59cc-a770-7acc-9ef9" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="2070-a83f-30de-5d5a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0707-3c22-c8eb-2fac" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="375.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e784-439f-80be-f121" name="Yeoman Outriders" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5357-145f-5de8-a7f6" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8807-9208-fb09-d58d" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="0da2-9879-acfc-649d" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="ba65-0a6d-0330-790d" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="47f7-859a-52be-e265" name="Serf" hidden="false" targetId="2637-2544-799e-6656" type="rule"/>
+        <infoLink id="64ce-a093-9693-fc88" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="287f-379d-35cb-dbd9" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="8836-1c9c-16bb-3741" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="38b2-a35c-3926-e0fc" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7988-f02b-547d-f35b" name="Yeoman Outrider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac94-ac55-a650-55ee" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4189-0f51-a7fd-34a2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3afe-616b-7a51-5ed9" name="Yeoman Outrider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="52a7-e401-3db3-dcf8" name="Yeoman Outrider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="13ce-d585-a725-751e" name="Yeoman Outrider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="bf9a-4575-48af-376c" name="Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3f4f-dc89-5577-c09b" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="e784-439f-80be-f121" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7988-f02b-547d-f35b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe4f-7d1e-0731-80a6" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="07b5-0de9-1de0-1219" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a1bf-2d2d-2d3b-be5a" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="e784-439f-80be-f121" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7988-f02b-547d-f35b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b085-3648-07dd-a7c7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8d59-7cab-4be4-f703" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2341-8ccf-9121-af60" name="Ranged Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3139-3d32-87b0-8107" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6123-a9c3-1e10-ef0e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="87bb-5651-ec7f-4630" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9563-05e8-223e-fde4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e145-3138-145d-f032" name="Bow (4+)" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6bce-cb89-0c81-d175" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="e784-439f-80be-f121" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7988-f02b-547d-f35b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfa3-8ffe-4d45-c290" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="94d9-ea47-1f41-22c4" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3c84-ff3d-0429-7c04" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e649-c8c7-5520-dece" name="Brigands" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a59-2f28-17ce-043c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="4702-e18b-4929-d467" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="c918-1142-9a04-04d5" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="0beb-5191-6a3c-ae85" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="46ac-c1fb-2cb8-0ba3" name="Serf" hidden="false" targetId="2637-2544-799e-6656" type="rule"/>
+        <infoLink id="5454-c495-a516-838a" name="Quick to Fire" hidden="false" targetId="5a08-d3bf-06f9-3034" type="rule"/>
+        <infoLink id="821d-2d3c-91be-e219" name="Longbow" hidden="false" targetId="245b-baaf-f5ec-e168" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4fe9-d17c-076b-8abf" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8a71-4f1a-d60d-ba33" name="Brigand" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="26db-8c19-cee9-1af7" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0fc-a447-4512-42a6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e378-6b47-0133-d38c" name="Brigand Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6722-e6eb-dad7-ad3a" name="Brigand Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a8ea-aa43-f64c-fe43" name="Brigand Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="13.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0932-327c-2547-a70e" name="Peasant Crusaders" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="d85d-32f7-2afb-4bbb" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="6606-5986-c3f9-4603" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="dea7-a441-5d6c-8d9b" name="Serf" hidden="false" targetId="2637-2544-799e-6656" type="rule"/>
+        <infoLink id="7f1e-09fb-01e0-378e" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="4533-1cbb-23eb-7d38" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Sacred Reliquary)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b992-9dbb-f7a7-eb90" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="b540-b445-6edc-1946" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0932-327c-2547-a70e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42cf-0df1-cc18-b67b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4ecd-033c-2d54-4d88" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+        <infoLink id="d19e-d2db-72a4-28fd" name="Impetuous" hidden="false" targetId="6190-c357-5cbe-fb08" type="rule"/>
+        <infoLink id="7903-86a0-c5b8-16f8" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bc3b-3180-324f-f118" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="34a9-7ed5-fd87-4888" name="Peasant Crusader" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c6a7-b0d4-352d-ad48" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c119-5911-b12d-bf42" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7fd1-adbe-0ca0-97f0" name="Peasant Crusader Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cc99-8577-65bb-339d" name="Peasant Crusader Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1f3b-7524-3592-d915" name="Peasant Crusader Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="86a8-b78b-99e9-9e2f" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bb7-9559-e056-83bd" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ea5d-2843-3a34-82cc" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f0-49b1-95cc-2f3a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="622a-91fb-90ba-2eba" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="82db-570e-7841-a0fc" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="42cf-0df1-cc18-b67b" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6393-1c94-4e93-95da" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="266d-15c9-7e47-a68f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="15d1-a01a-5618-ea62" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b835-a0d2-4a96-646c" name="Sacred Reliquary" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9b6-a023-6304-8ac9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5215-7853-b0a4-e73f" name="Sacred Reliquary Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5339-8b33-95f7-fc99" name="Sacred Reliquary Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cd20-1f33-0d5e-ded1" name="Sacred Reliquary Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="65d9-6666-c931-ac1b" name="Holy Fervor" hidden="false">
+          <description>A unit joined by a Sacred Reliquary gains Fight in Extra Rank. If the Sacred Reliquary is in base contact with an enemy model, the Sacred Reliquary and all friendly units that are Engaged in the same Combat gain +1 Armour</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8d75-e402-687d-a5a9" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="8a89-4f23-7384-72fa" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="2b06-65e6-96a1-0145" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+        <infoLink id="41bd-23d2-4fb2-029c" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="75c0-94f1-8e38-6f11" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="cc24-14fe-85a4-7674" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="841a-b987-ba02-8466" name="Impetuous" hidden="false" targetId="6190-c357-5cbe-fb08" type="rule"/>
+        <infoLink id="cf87-169b-354c-38ea" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="959c-e36d-3ebf-d519" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="266b-72e2-1234-2994" name="Pegasus Knights" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfea-4b36-fc24-14f1" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="df0f-8c96-7028-3c93" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="5116-4b5e-b4e9-a0ba" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="729a-14f8-55ed-92cb" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="00cd-de00-9d76-3be0" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="2aef-ffc5-a927-d9a8" name="Oath of Fealty" hidden="false" targetId="9b72-e4ef-0883-424c" type="rule"/>
+        <infoLink id="ec70-94c9-426c-0e80" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="981f-5e41-5a0c-2c69" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ab40-aca6-3551-a933" name="New CategoryLink" hidden="false" targetId="8733-41f5-7948-a83c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3ebc-00da-763a-4b4a" name="Pegasus Knight" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86db-0284-e6fc-ce9a" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8af-4918-3a63-6a91" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="49c1-2fe7-da50-8255" name="Pegasus Knight Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot; (8&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot; (16&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="408a-a34b-24b9-5ef1" name="Pegasus Knight Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="10d4-886a-d432-1bf4" name="Pegasus Knight Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3df9-eb93-cb69-8a2b" name="Young Pegasus Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="77c2-1fc0-099d-b22b" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="7">
+              <repeats>
+                <repeat field="selections" scope="266b-72e2-1234-2994" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ebc-00da-763a-4b4a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83b6-92ca-81f6-2ee3" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7efc-ad10-9941-e7c6" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="65dd-cc85-2d18-6705" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e73-ddf8-d8b0-2e2a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f92b-1f6d-d0b7-f662" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11b3-8511-8f49-62ee" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9c14-25d6-864c-2eb3" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="e295-477d-544c-54b8" name="KoE Banner Enchantments" hidden="false" collective="false" targetId="0a34-b9d7-dd66-4516" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="11df-fdcd-3465-3f13" name="Skirmisher" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="266b-72e2-1234-2994" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ebc-00da-763a-4b4a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5558-19d5-8e04-906e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3ba8-c7fc-148e-0d05" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="aa5c-cb66-b4a1-ed65" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c3e-4796-f33a-458e" name="Damsel on Pegasus" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="c0fe-a050-ba9b-8cde" name="Damsel Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9912-f205-6094-349b" name="Damsel Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3448-7f4c-6b12-1791" name="Damsel Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="dae2-a5ac-228f-062b" name="Beloved" hidden="false">
+          <description>When the model is joined to a unit with at least one Full Rank of models with Lance Formation, it gains Stand Behind and cannot be chosen by the enemy as the model that refuses a Duel.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0e1a-706e-6646-74a6" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="7d3a-f293-0b0f-81a7" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7eea-e56d-99c4-8219" name="The Blessing" hidden="false" targetId="f4b8-68e0-86ef-c252" type="rule"/>
+        <infoLink id="2068-284c-60d4-77fe" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0a96-26e0-d6ec-238b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="779d-b8fb-9498-c6db" name="Airbourne Gallantry (local)" hidden="false" targetId="8733-41f5-7948-a83c" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1eb0-9306-1497-bef6" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ed9-eaae-6651-0637" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f96d-ceac-82a1-5a26" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="85bb-8ae6-0600-9b4f" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b534-5eb0-5b44-9965" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa23-0c55-f139-920b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f8fe-0360-1e4d-2c26" name="KoE Weapon Enchantments" hidden="false" collective="false" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="b71f-e14c-8c34-3a0a" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c5a8-ecec-f5ad-c078" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a32-ad13-fa69-461b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="122b-2c0f-19ca-876c" name="KoE Artefacts" hidden="false" collective="false" targetId="e28f-aa60-832d-0a57" type="selectionEntryGroup"/>
+                    <entryLink id="3b8b-5718-4aaf-622b" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cf26-d581-e62c-a3ef" name="Pegasus" hidden="false" collective="false" type="upgrade">
+          <entryLinks>
+            <entryLink id="8780-8355-8a31-48a7" name="Pegasus" hidden="false" collective="false" targetId="f5b1-b3eb-ae5e-3db6" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e5c4-5bf2-d132-8318" name="Wizard Level" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a42-c494-10d5-344c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e7a-01ad-7fd6-68d6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="16e4-f45e-77d9-5b47" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a891-5bc1-e9d3-e18f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a03d-8334-8342-58f2" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a175-3c0f-eca4-e6f5" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="3bc5-22fb-a7ad-e7c9" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4037-cadd-aa60-f2b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bc5-22fb-a7ad-e7c9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6b48-407e-b0af-a25f" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a8-b1a1-9f6f-650e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f127-c958-e6b9-b978" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d58-dbc2-d16e-ef01" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="47d4-08f6-2564-66a6" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6284-c54f-939d-aeed" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="78a2-aec0-0355-0508" name="Army General" hidden="false" collective="false" targetId="5c0a-db00-56fb-0063" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="6b02-0dc0-9533-4770" name="Grail Oath" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b55-85a6-0678-8de2" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="228f-cc78-0deb-6313" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c965-1ca5-31ad-8f91" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f180-23c0-52d7-f80d" name="Grail Oath" hidden="false" targetId="026d-0672-d4a3-9b68" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="62af-2ffe-340d-4bd8" name="Questing Oath" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96fc-1f9b-4a98-11a2" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bb4-d2f4-3869-5c4c" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="89db-4f6b-7e2f-5eb7" name="Questing Oath" hidden="false" targetId="1a90-f274-9ad1-75d5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c0a-db00-56fb-0063" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f3f2-39ae-c478-04cd" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1efd-2d0d-dc58-66fa" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed28-0fd5-2b71-d26d" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12f6-b26a-6480-42e0" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a5ef-031c-17a8-f866" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e5b-668f-e26b-235f" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="da96-1b71-21da-e286" name="Barded Warhorse" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6752-4ec2-8542-69a5" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b10-22b6-ffda-6f27" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="caa4-7c4e-793d-7c92" name="Barded Warhorse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f341-fead-db99-fd76" name="Barded Warhorse Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b50a-102f-e456-197a" name="Barded Warhorse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="60c6-4d2c-35ec-945f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="14e3-f6f8-288e-ac2b" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a075-898a-6f5d-e0dd" name="Hippogriff" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdab-ede0-1019-6cea" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ca-e41a-7df4-b3fa" type="max"/>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57e1-946e-5c33-12f1" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2d18-e659-27c9-6695" name="Hippogriff Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="df61-2c88-0a14-8a09" name="Hippogriff Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6fb0-80ac-7f98-64a1" name="Hippogriff Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5d02-e3ec-6c01-dc85" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="785e-5652-cb0f-0481" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="2655-d037-2b06-e68d" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="56be-c31d-bc6e-b950" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="227c-50cb-d9af-6b90" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f5b1-b3eb-ae5e-3db6" name="Pegasus" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="990e-760a-661e-d6de" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bbf-22b5-6369-931c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d338-a544-2b87-855e" name="Pegasus Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1b25-1cb3-898e-2822" name="Pegasus Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7de4-3b7c-8db9-e764" name="Pegasus Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a11b-931e-8dd9-35af" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="a859-0ae2-9267-c935" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="051d-d761-b2b1-5b1e" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="fbe8-7671-39ae-afaa" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="08ee-007f-0c03-a6e6" name="Equitan Unicorn" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b328-6009-8eb9-102b" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ce8-9eaf-a914-0220" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f3d8-4275-b9fe-6642" name="Equitan Unicorn Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">10&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">20&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3a3f-4aab-b408-e9c0" name="Equitan Unicorn Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="174b-d4d9-8612-6b6a" name="Equitan Unicorn Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8067-9902-fa2a-5861" name="Forest Guide" hidden="false">
+          <description>All models in the model&apos;s unit gain Strider (Forest) and Magical Attacks.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3a00-a539-87a6-6033" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="44c9-4ebd-c0e9-fc98" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="4216-0c60-6a65-c1b1" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="24d7-ba7b-8465-31f7" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="d39e-1d67-5d01-ebaa" name="Virtues" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2199-0bcf-2f43-a8df" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2e1a-84b6-c0d8-3e62" name="Might" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d62-7db2-0e73-1700" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86d4-2b88-cce0-5708" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="11f4-a628-807e-e38c" name="Might" hidden="false">
+              <description>When using a Lance, the bearer gains Devastating Charge (+1 Att, +1 Str, +1 AP), and when Charging, every unsaved wound caused by the bearer’s Close Combat Attacks using a Lance, before applying Multiple Wounds, generates another Close Combat Attack at the same Initiative Step. Resolve these attacks before removing any casualties. These new attacks do not generate any further attacks.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f8d1-2ebe-1f44-5f78" name="Valour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c7b-270e-a5a6-0d0c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0457-329a-c961-1cc5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a538-1d41-8a9b-317c" name="Valour" hidden="false">
+              <description>The bearer automatically issues a Duel whenever possible (this can not be prevented by issuing a Duel with another friendly model first), and this Duel must be accepted whenever possible. When Fighting a Duel, the bearer must reroll failed to-hit and to-wound rolls.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d97d-030e-5b45-55a6" name="Audacity" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faf2-48b8-5a74-0625" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ebd1-007e-4d3e-a11a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="d952-1420-aa4d-74e7" name="Audacity" hidden="false">
+              <description>Attacks made by the bearer that are allocated towards models of Large Size must reroll failed to-hit rolls. Attacks made by the bearer that are allocated towards models with Towering Presence must reroll both failed to-hit and failed to-wound rolls.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="987c-8f4d-7017-6ded" name="Renown" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce0d-9876-d8e7-733c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3430-5932-74e9-4060" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="ae53-6001-4c3b-48f4" name="Renown" hidden="false">
+              <description>The Bearer gains Lethal Strike. Close Combat Attacks made by the bearer that roll a natural 6 to wound gain Multiple Wounds (D3).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6b65-8e00-31ab-4c72" name="Piety" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b90-8fa9-ecba-ca98" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="258a-cc48-13fc-7875" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="5004-3874-b478-6228" name="Piety" hidden="false">
+              <description>The bearer and all R&amp;F models in the bearer’s unit gain Aegis (+1, max 5+). The bearer may only join Standard Size units.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="03fc-eaba-d055-99a8" name="Daring" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11d5-0b85-1ac7-1b8b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="813f-2a1a-c6ae-0efd" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="2cf5-aa2c-a867-0f04" name="Daring" hidden="false">
+              <description>Charge Range rolls of the bearer&apos;s unit and Charge Range rolls towards enemy units in base contact with the bearer are subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7bd5-76f0-ea52-8ab8" name="Humility" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ac-e09e-7051-e1e0" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d67-8dc6-b53f-e32f" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="561a-c926-a1bb-50a0" name="Humility" hidden="false">
+              <description>The bearer gains Insignificant, has its Commanding Presence range increased to 12&quot;, and gains Rally Around the Flag. However, only units with more than half of their models with Insignificant may benefit from this instance of Rally Around the Flag. </description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b1ad-c078-481f-9e34" name="KoE Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="375a-fab4-058d-a7dd" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="946d-a08e-03a8-d20c" name="Divine Judgement" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83c1-1787-49fb-009d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed75-baa2-a0aa-260f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ce0c-1869-8c8a-c010" name="Divine Judgement" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Lance Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Magical Attacks and Devastating Charge (Multiple Wounds (D3+1)).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5f3e-62c9-2320-5727" name="Tristan&apos;s Resolve" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e013-2afe-024d-77d1" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c26f-6cf1-4929-6032" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d908-387c-a6c8-3c05" name="Tristan&apos;s Resolve" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When using this weapon, the wielder gains +1 Strength, +1 Armour Penetration, +1 Attack Value, and Magical Attacks. After a successful to-hit roll, the attacker may discard one of the hits with this weapon and choose a Weapon Enchantment carried by the model the attack was allocated towards. The chosen Weapon Enchantment cannot be used for the rest of the battle.​</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a48f-a190-6f5e-bba3" name="Wyrmwood Core" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53d7-0ac0-bda8-dc13" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0911-cbc4-f903-4b97" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="91c3-b0c7-e750-e325" name="Wyrmwood Core" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Lance Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder gains Breath Attack (Str 5, AP 0, Flaming Attacks). Attacks made with this weapon gain Magical Attacks and Flaming Attacks. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9cc7-7c08-5df1-35cf" name="KoE Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="b98c-a11a-7cc1-4893" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b98c-a11a-7cc1-4893" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="22a4-4dcb-ef47-9644" name="Crusader&apos;s Salvation - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f130-44c4-8e39-fb29" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f24-ee79-e14d-5116" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d1c6-50a0-3017-3496" name="Crusader&apos;s Salvation" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Heavy Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and must reroll failed Armour Saves. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="46c7-c05e-051f-9daa" name="Fortress of Faith" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3d7-d1aa-330b-6d08" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cc3-8855-9804-8408" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c508-34b9-1de9-5820" name="Fortress of Faith" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, the bearer must reroll all natural to-hit and to-wound rolls of ‘1’ with its Close Combat Attacks, and must reroll all natural Armour Save rolls of ‘1’.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="2024-fdfd-c07a-bbcb" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1b90-ec66-dcdf-e0ad" name="Faith of Percival - Dominant. Cannot be taken by Towering Presence" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7849-b268-fd85-4b22" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea6d-a4b3-0f62-7e37" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="611b-b3b8-a0bf-e14c" name="Faith of Percival" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, the wearer gains Aegis (+1, max 4+). Attacks against the bearer with Divine Attacks lose this Attack Attribute.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="e2b1-4aa8-8a6d-4e91" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="228f-3776-5817-2b61" name="Uther&apos;s Conviction" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a9b-d22e-61c7-e460" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb50-bed2-7948-aad1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6768-a266-3297-e3d3" name="Uther&apos;s Conviction" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Heavy Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +1 Armour. Against attacks with Armour Penetration 6 or more, the bearer gains Aegis (+1, max 4+, Against Armour Penetration 6 or more). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e28f-aa60-832d-0a57" name="KoE Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f397-d726-be33-b07f" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="315a-e1ef-96d4-ff8b" name="Storm Clarion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf28-8de0-5fa2-30cc" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b542-1370-ac2c-42b5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f520-2c27-4204-f689" name="Storm Clarion" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any Player Turn. Enemy units cannot make Flying Movements during this Player Turn.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7463-4809-1f33-4155" name="Wafers of Penitence - Wizards only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98a5-7455-0666-b889" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="945c-6f55-1b05-aced" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="53d7-e204-3967-0755" name="Wafers of Penitence" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated after rolling for a Dispel Attempt. Add +2 to the rolled result. This is an exception to the Casting and Dispelling Modifiers rule.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9bff-0255-d1e8-af2f" name="Black Knight&apos;s Tabard - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="590c-eca0-b7e6-dc6b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="478d-7535-02b3-333c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="29da-d9a3-e562-81c7" name="Black Knight&apos;s Tabard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One Use Only. Activate when the bearer reaches 0 (or fewer) Health Points. Do not remove the bearer as a casualty. Instead, after resolving all simultaneous attacks (such as all Shooting Attacks from the same unit or all Melee Attacks at the same Initiative Step), the bearer&apos;s Health Points are set to 1, and it gains Aegis (3+) until the end of the Player Turn.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cb30-7564-33a5-dde9" name="Crystal of the Valiant Charge - Dominant - Wizards only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f2-91f2-6dba-f95a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7cdf-cf9c-ad0f-92fc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b327-320b-a68e-ff9f" name="Crystal of the Valiant Charge" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of the opponent&apos;s Magic Phase. In this phase, during Siphon the Veil, before converting Veil Tokens into Magic Dice, remove 1 Veil Token from the Active Player’s Veil Token pool for each friendly unit that is Engaged in Combat within 18” of the bearer. Add the tokens removed this way to your Veil Token pool.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0a34-b9d7-dd66-4516" name="KoE Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e186-547c-2f03-c979" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fb72-e6c9-d411-fbe1" name="Banner of Roland" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="363a-38e2-ed55-7031" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8961-009d-867d-6412" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fe58-e94e-33b7-0a7d" name="Banner of Roland" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Aegis (+1, max 4+, against Ranged Attacks). Furthermore, enemy units cannot choose Stand and Shoot as Charge Reaction when charged by the bearer’s unit. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3678-e0f3-8f29-8b81" name="Oriflamme - Cannot be taken by Core Units" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b51-a8ec-bf04-0687" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dfa-b54d-d973-e246" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="74bc-8785-bb15-4a41" name="Oriflamme" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Fear. Enemy units in base contact with the bearer’s unit cannot benefit from Rally Around the Flag.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="91a5-b0a1-9218-8f5d" name="Banner of the Last Charge" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd7e-bb5e-67fc-e2e9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc26-38e1-7dc1-ff1e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ae69-f252-fea3-0de0" name="Banner of the Last Charge" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">R&amp;F Cavalry models in the bearer&apos;s unit gain Impact Hits (X), where X is equal to the number of Full Ranks in the unit. These Impact Hits are resolved with Strength 4 and Armour Penetration 1. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="36e8-b926-f060-7729" name="Banner of the Green Knight" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d617-0c86-b5a2-b419" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2873-e1bd-b9e9-08d5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8f20-44ef-b13d-f96f" name="Banner of the Green Knight" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated during the owning player’s Movement Phase. The bearer&apos;s unit gains +2 March Rate, Ghost Step, and loses Scoring. All friendly units are treated as Impassable Terrain. Effects last until the start of the next Player Turn. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="2637-2544-799e-6656" name="Serf" hidden="false">
+      <description>A unit gains +2 March Rate until the end of the Movement Phase if:
+ - more than half of its models with type Infantry and/or Cavalry have Serf and
+ - the unit is under the effect of Commanding Presence from one or more models with Oath of fealty at the start of its March Move.</description>
+    </rule>
+    <rule id="f4b8-68e0-86ef-c252" name="The Blessing" hidden="false">
+      <description>The model gains Aegis (6+). Before rolling for first turn (at the beginning of step 7 of the Deployment Phase Sequence), decide if the Kingdom of Equitaine Army Prays or not. If it does, models with The Blessing gain Aegis (5+, against Strength 5 or more), and the Army cannot gain any bonus to the dice roll for first turn.</description>
+    </rule>
+    <rule id="b53e-e733-517e-8c2d" name="Lance Formation" hidden="false">
+      <description>The model gains Fight in Extra Rank. If more than half of a unit&apos;s models have Lance Formation, the unit only requires ranks to be 3 models wide in order to form Full Ranks, and when such unit charges (with ranks 3 models wide), models with Lance Formation in the unit gain an additional instance of Fight in Extra Rank.</description>
+    </rule>
+    <rule id="9b72-e4ef-0883-424c" name="Oath of Fealty" hidden="false">
+      <description>Universal Rule: The model gains Commanding Presence with the following restrictions: It has a range of 6&quot; and can only benefit units with more than half of their models with Serf.</description>
+    </rule>
+    <rule id="1a90-f274-9ad1-75d5" name="Questing Oath" hidden="false">
+      <description>Universal Rule: The model is immune to the effects of Fear of enemy models. Models with Questing Oath add +2” to their Charge Range rolls against enemy units with at least one model with Fear.
+Attack Attribute: The model part gains +1 to-hit with Close Combat Attacks against models with Fear. </description>
+    </rule>
+    <rule id="026d-0672-d4a3-9b68" name="Grail Oath" hidden="false">
+      <description>Universal Rule: The model gains Fearless.
+Personal Protection: The model gains Aegis (5+). Characters with Grail Oath gain +1 Defensive Skill.
+Attack Attribute: The model part gains Magical Attacks. Characters with Grail Oath gain +1 Offensive Skill.</description>
+    </rule>
+    <rule id="6190-c357-5cbe-fb08" name="Impetuous" hidden="false">
+      <description>A unit consisting entirely of models with this rule may reroll failed Charge Range rolls. The model gains Frenzy while Engaged in Combat.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="96e0-c067-bd1d-eeaf" name="Bastard Sword" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">This weapon follows the rules for Great Weapons, except the wielder can use it together with a Shield. In the first Round of Combat, the wielder may choose to use it as either Spear (if Infantry) or Light Lance (unless Infantry). In subsequent Rounds of Combat, it uses the Great Weapon rules as normal. </characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/ogreKhans.cat
+++ b/ogreKhans.cat
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b60b-8840-3461-ebf5" name="Ogre Khans 2.0" revision="18" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b60b-8840-3461-ebf5" name="Ogre Khans 2.0" revision="19" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="b0d2-524e-01c5-5893" name="Chained Beasts (local)" hidden="false"/>
-    <categoryEntry id="8848-ec3f-ef30-5842" name="Powder Keg (local)" hidden="false"/>
+    <categoryEntry id="b0d2-524e-01c5-5893" name="Chained Beasts" hidden="false"/>
+    <categoryEntry id="8848-ec3f-ef30-5842" name="Powder Keg" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="b4af-f743-dcfc-8c0b" name="Ogre Khans (local)" hidden="false">
+    <forceEntry id="b4af-f743-dcfc-8c0b" name="Ogre Khans" hidden="false">
       <categoryLinks>
         <categoryLink id="019f-6523-89ea-0db4" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -30,7 +30,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="65f1-e3a5-286c-670e" name="Ogre Khans - Wildheart (local)" hidden="false">
+    <forceEntry id="65f1-e3a5-286c-670e" name="Wildheart" hidden="false">
       <categoryLinks>
         <categoryLink id="873d-12a9-6b64-09bf" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -61,7 +61,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -265,7 +265,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1069,7 +1069,7 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="notInstanceOf"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
@@ -1083,7 +1083,7 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="notInstanceOf"/>
               </conditions>
             </modifier>
             <modifier type="set" field="hidden" value="true">
@@ -1226,7 +1226,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1523,7 +1523,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1813,7 +1813,7 @@
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2486,7 +2486,7 @@ If an enemy unit makes an Advance Move, March Move, Reform, Pivot, Charge Move, 
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2664,7 +2664,7 @@ If an enemy unit makes an Advance Move, March Move, Reform, Pivot, Charge Move, 
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3383,12 +3383,12 @@ The roll for the number of hits from its Stomp Attacks is subject to Maximised R
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="notInstanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="notInstanceOf"/>
               </conditions>
             </modifier>
             <modifier type="set" field="9fd1-c07a-c529-c510" value="1">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65f1-e3a5-286c-670e" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>

--- a/ogreKhans.cat
+++ b/ogreKhans.cat
@@ -1,0 +1,3729 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="b60b-8840-3461-ebf5" name="Ogre Khans 2.0" revision="18" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="b0d2-524e-01c5-5893" name="Chained Beasts (local)" hidden="false"/>
+    <categoryEntry id="8848-ec3f-ef30-5842" name="Powder Keg (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="b4af-f743-dcfc-8c0b" name="Ogre Khans (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="019f-6523-89ea-0db4" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="7eb7-4cba-35c3-c62c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5359-9d4f-dd22-a048" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="a157-c82e-f103-fee2" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7884-3aed-ac90-9991" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="60aa-e248-009a-d676" name="Powder Keg (local)" hidden="false" targetId="8848-ec3f-ef30-5842" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="fe6b-d4c8-8dc4-36e4" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="abd5-a831-736a-6f2c" name="Chained Beasts (local)" hidden="false" targetId="b0d2-524e-01c5-5893" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="0cac-67d8-376b-0858" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="65f1-e3a5-286c-670e" name="Ogre Khans - Wildheart (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="873d-12a9-6b64-09bf" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="6044-7077-5c30-1b90" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6cb6-ace3-2223-c5db" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="39bc-4996-d31a-3928" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b1ea-1b87-5bc3-4d91" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="23e0-4ee5-a8db-0238" name="Powder Keg (local)" hidden="false" targetId="8848-ec3f-ef30-5842" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c2a-edd4-6574-8a12" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a1a2-e45b-9bdf-09e0" name="Chained Beasts (local)" hidden="false" targetId="b0d2-524e-01c5-5893" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="33b7-a204-d417-962a" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="cd6f-3e17-f9cc-1bae" name="Great Khan" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="34ba-6a2b-f247-2f45" name="Great Khan Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="004d-a913-4785-13b5" name="Great Khan Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b3e7-a282-3e44-1cb3" name="Great Khan Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c1d9-78e9-f243-eed2" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="43bd-59f1-208e-3bb0" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ce8a-4e74-61ba-c5af" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89ef-a45f-cb54-d6ca" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6bd6-7248-c51b-db30" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1164-5d4a-e6f0-7396" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3fa6-0516-b23f-1404" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72f2-2e98-9e2e-e361" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="50bb-ef5c-ccea-9bcc" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="33b6-95b8-4f62-1b1c" name="OK Weapon Enchantments" hidden="false" collective="false" targetId="80ba-f84b-6b53-c0fc" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3862-3339-a877-a4fa" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="31cf-9f48-af43-784b" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31cf-9f48-af43-784b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e79f-08fb-7cfa-dba8" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="7400-a69c-4933-cf04" name="OK Armour Enchantments" hidden="false" collective="false" targetId="cd8f-8926-00ff-24f5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6c51-a86f-038f-6127" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bec-c82d-6fe1-1f5d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="b51b-4552-d2d8-e4fe" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="1438-a24b-76ce-eb6d" name="OK Artefacts" hidden="false" collective="false" targetId="58c1-2f86-ae48-0fe5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1faf-5a6e-0f8b-2fe4" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="558d-5390-8402-9962">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d19d-ad6b-1938-3cb4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ffa-0e66-cef7-161c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="558d-5390-8402-9962" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3818-b001-21b5-b734" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5c87-340b-37ca-8865" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e92d-9dea-e8a6-8aaf" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7144-923f-d9dc-c93f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c158-53ea-481b-1b56" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="34d4-001b-aa2c-912f" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1660-9d81-1fd2-ded8" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c94a-d2f5-7db9-1ada" name="Brace of Ogre Pistols (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2bb-07a3-b6d7-fcf9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bb57-026f-a6e8-19d5" name="Brace of Ogre Pistols (4+)" hidden="false" targetId="ab76-c5ad-a4a6-e148" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4229-f135-27a3-04b5" name="Ogre Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e504-5dfe-0018-f1a8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="00b9-27f2-6ea4-5913" name="Ogre Crossbow (3+)" hidden="false" targetId="6fed-96d4-3d46-a385" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e1d8-3b70-8f9d-7a44" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02cc-f7e2-f6bb-1330" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="914c-c9ac-163a-595b" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dd3-e9f2-6ef9-c9a4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c693-3a7e-16f5-f774" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="77d3-953d-522b-c088" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="770e-12c7-4b85-6d91" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a039-7c1f-af48-9f23" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="758e-1843-4558-0048" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b6c-97fa-b757-7a56" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4291-f01b-3e34-bd5f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c93f-930b-8d06-40a1" name="Big Names" hidden="false" collective="false" targetId="c7bf-d07e-1bd8-3232" type="selectionEntryGroup"/>
+        <entryLink id="1a4d-42e4-4ad6-321a" name="General" hidden="false" collective="false" targetId="de54-24fe-f876-65e6" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="310.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d22b-66e0-0dc6-614c" name="Khan" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="5b2d-4ef3-e367-18b1" name="Khan Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="806b-d081-1fca-1130" name="Khan Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f47f-f210-1946-7235" name="Khan Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="bd9b-456e-dc8f-648c" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+        <infoLink id="767c-d3f3-319d-05e4" name="Scrapling Lookout" hidden="false" targetId="acfe-1168-a223-c621" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bca1-71d4-d38e-5ee0" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="96f2-2a0e-710b-6487" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="42d6-ecfb-d313-487c" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0c79-869e-72c6-4c0c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="893d-b9b9-1fc5-62f0" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ffd8-3b62-8930-04ff" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e89e-d59a-a320-84fb" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8a1f-2db0-e4b9-ea0d" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="6322-61d5-7b00-c319" name="OK Weapon Enchantments" hidden="false" collective="false" targetId="80ba-f84b-6b53-c0fc" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="06b8-41bc-13da-c59e" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="0f34-660d-30f3-4797" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f34-660d-30f3-4797" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f937-052c-144a-5871" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="7e0f-6b04-22c6-feea" name="OK Armour Enchantments" hidden="false" collective="false" targetId="cd8f-8926-00ff-24f5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="99eb-ea98-d7e7-23c2" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc10-1438-3eb3-e2f1" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c336-91ea-1c58-220f" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="2a12-fabd-75f3-191c" name="OK Artefacts" hidden="false" collective="false" targetId="58c1-2f86-ae48-0fe5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="43fd-fdb2-84bf-49af" name="Banner Enchantment" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="d22b-66e0-0dc6-614c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="959f-40d4-b9ed-0ba5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f8d-3ca7-9c95-a507" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e1cc-6c0e-58a4-7a64" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="7c11-496b-f263-0ede" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2173-d391-8186-a637" name="Armour" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49c-824a-3e80-aad0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f75-6321-545a-a5f7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3bbe-b88f-7512-6e6e" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="185a-f207-b2e9-1445" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8726-3b8f-dcc3-13ed" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3450-c05f-07e8-bc61" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec7b-fd0e-47b7-d79c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="254c-c795-6b0e-5e23" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="967b-8d8c-f5ff-3bfe" name="Shooting Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4884-65b8-593b-9c88" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3d4f-d321-d7e3-06fd" name="Brace of Ogre Pistols (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1545-6351-7b9f-888a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ab3e-4116-b132-3ddc" name="Brace of Ogre Pistols (4+)" hidden="false" targetId="ab76-c5ad-a4a6-e148" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6d89-f0be-afc5-7878" name="Ogre Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e37c-480e-4088-01f6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="856d-aaab-f516-eb07" name="Ogre Crossbow (3+)" hidden="false" targetId="6fed-96d4-3d46-a385" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b09a-5d43-7cbb-fd2c" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="637d-288e-561b-49b3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="96b9-d032-c183-c38e" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1e5-c0dd-70fa-6778" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6ff3-7b0e-28f2-4a70" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f22f-46f9-453e-bc22" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6325-61dc-e698-8706" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="21dd-c0c4-3d27-2ad4" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="31e0-c090-08c8-6839" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75be-53e3-18a6-8362" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5b70-ee3d-d615-85d9" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="db50-3693-b091-b743" name="Big Names" hidden="false" collective="false" targetId="c7bf-d07e-1bd8-3232" type="selectionEntryGroup"/>
+        <entryLink id="5408-19ff-9f68-3e09" name="General" hidden="false" collective="false" targetId="de54-24fe-f876-65e6" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="d22b-66e0-0dc6-614c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="959f-40d4-b9ed-0ba5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="f8c5-ba9e-8282-425c" name="Battle Standard Bearer" hidden="false" collective="false" targetId="959f-40d4-b9ed-0ba5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="d22b-66e0-0dc6-614c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de54-24fe-f876-65e6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0354-83f8-6656-122f" name="Shaman" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="1881-4b87-b28c-7a37" name="Shaman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2494-6fb7-56f9-a368" name="Shaman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="25e3-27d3-c801-7403" name="Shaman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4bea-8ea3-9b6e-4deb" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="82e3-12e7-5688-91b7" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="785b-c5c6-73a9-5a66" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1874-0688-7d59-693a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="38d8-0aa2-d120-fb01" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e1ed-5882-6cc1-c1b0" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="929a-08f0-135b-bbe3" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5ee1-e41f-335e-b65b" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="c426-d152-54fc-475d" value="200">
+                  <conditions>
+                    <condition field="selections" scope="0354-83f8-6656-122f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c64-544e-131d-ab35" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c426-d152-54fc-475d" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1149-648c-2dce-c976" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2731-cea1-9958-7c70" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0ad2-9dad-7848-4e2a" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="47aa-c660-9b57-6810" name="OK Weapon Enchantments" hidden="false" collective="false" targetId="80ba-f84b-6b53-c0fc" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="46e6-5955-3f03-62b1" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="4fb9-3826-cc4a-4c7a" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fb9-3826-cc4a-4c7a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e1b9-ec86-217c-7986" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="0f95-f834-25fe-6d5b" name="OK Armour Enchantments" hidden="false" collective="false" targetId="cd8f-8926-00ff-24f5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5d58-8ee3-96f9-bf95" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1c8-8b23-648a-69b8" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="048f-bccd-6f99-b5f4" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="4237-c795-7ef1-9e85" name="OK Artefacts" hidden="false" collective="false" targetId="58c1-2f86-ae48-0fe5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0fbe-2ed3-884d-6f1e" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="5a3a-f8f6-3a10-186f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="986d-6f36-7061-8ef5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7182-289c-8db3-5158" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5a3a-f8f6-3a10-186f" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb4-849c-1370-a28e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a727-c6e5-a479-5796" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7639-507c-ae82-7ee6" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d807-79e7-ae73-d269" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="53c0-78b4-b7f5-700f" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0c64-544e-131d-ab35" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b084-7a90-b927-52b9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a5d5-1e8f-69ea-c3d8" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a328-5ad5-120a-a1ce" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="e69f-c0d5-c62a-65a2" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5609-a8d0-8c21-411b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e69f-c0d5-c62a-65a2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="940d-72eb-b2e5-c13f" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0d1-54d2-34bd-b7a9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="83c2-1037-17ce-3cc0" name="Thaumaturgy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f48-b004-c273-7f02" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="afa8-d439-50b5-c70b" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d853-593d-4d1c-ee04" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="dba5-9598-8a0e-ef7f" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98b7-c663-381a-bec1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6fd8-ee3b-f02b-d3c8" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f170-b986-dfc2-0449" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="31db-3043-6ac2-fa20" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fb50-1935-379a-40ad" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b87-ebed-cb06-d42e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8fd8-6018-f15e-d5a6" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a890-0f80-51cb-c192" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4995-485b-0e8d-c57b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d679-f26d-1f30-1a38" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f535-b846-1587-1522" name="Big Names" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="5b32-707f-2922-4dd8" name="Firebrand" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0354-83f8-6656-122f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="afa8-d439-50b5-c70b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5381-db94-5044-db17" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fe3-4bbb-5235-9f12" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="a740-78db-a314-47ee" name="Firebrand" hidden="false">
+                  <description>The bearer gains Flaming Attacks, Aegis (2+, against Flaming Attacks), Breath Attack (Str 4, AP 0, Flaming Attacks), and always knows Fireball (Pyromancy) in addition to its other spells.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="b69a-8f52-3834-7005" name="Big Names" hidden="false" collective="false" targetId="c7bf-d07e-1bd8-3232" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ab2f-9422-8a1e-5279" name="General" hidden="false" collective="false" targetId="de54-24fe-f876-65e6" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1f91-684b-5a72-e05d" name="Mammoth Hunter" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="4df0-19a0-e81a-ae75" name="Mammoth Hunter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ff8e-133f-89d6-a51c" name="Mammoth Hunter Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5b2f-2aaf-c44c-6a5a" name="Mammoth Hunter Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="9b26-e4bd-c327-2c83" name="Loner" hidden="false">
+          <description>A model on foot with Loner can only join units of Yetis and Sabretooth Tigers (ignore the Insignificant rule for joining units). If mounted, it cannot join any unit. A model with Loner cannot join a unit containing any other Characters, and Characters cannot join a unit containing a model with Loner.</description>
+        </rule>
+        <rule id="bf68-4ccc-be1e-0090" name="Animal Master" hidden="false">
+          <description>The model gains Commanding Presence, but only units of Sabretooth Tigers may benefit from it.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d695-849d-a2f4-0fb3" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0138-c481-641b-31f3" type="equalTo"/>
+                    <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2920-a556-7ce3-1ede" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="72dc-cbb1-e506-c36d" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="bd01-037f-5ee4-b7af" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="f59a-7039-a7ba-07fc" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="773a-79f9-4877-9691" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7fe4-aa58-7abd-398b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="de75-8e46-87e8-8914" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6ff-8664-3821-6fde" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0b8d-93de-3729-6f70" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="3516-4bcf-d076-2a48" value="150">
+                  <conditions>
+                    <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3cba-95d8-af26-79ee" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3516-4bcf-d076-2a48" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="6586-7c16-3be5-92c3" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d27-4bcd-b15b-7252" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="fc8c-2f52-da38-d29a" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="72da-c269-8a02-123a" name="OK Weapon Enchantments" hidden="false" collective="false" targetId="80ba-f84b-6b53-c0fc" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="45a3-f4f4-507c-0417" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="d7ad-c2d3-1731-cacb" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7ad-c2d3-1731-cacb" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="a473-6587-78e7-d050" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="11c2-eca8-0d67-f613" name="OK Armour Enchantments" hidden="false" collective="false" targetId="cd8f-8926-00ff-24f5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e2f8-8821-f355-01ad" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="284d-15e9-d37e-5904" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="fea0-405c-c78c-67fb" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="1b40-b2d1-b65b-a225" name="OK Artefacts" hidden="false" collective="false" targetId="58c1-2f86-ae48-0fe5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="f888-79ac-f656-fabb" name="Banner Enchantment" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="1f91-684b-5a72-e05d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="959f-40d4-b9ed-0ba5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d95-ec10-1bde-8bc8" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="cd01-0fe7-7f60-c35f" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="6ec0-c449-11ee-a1d7" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7e21-9cec-a871-0a33" name="Leader of the Pack" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91a6-fb1f-d68e-bcaa" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="f8b6-8354-adf4-8594" name="Leader of the Pack" hidden="false">
+              <description>The Mammoth Hunter changes its base size to 50x50mm. As long the model is part of a unit of Sabretooth Tigers, the unit loses Insignificant, gains Vanguard, and the Mammoth Hunter counts as being Standard Beast for the purposes of distributing hits.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c739-14e8-4186-01a1" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="e200-70ec-9323-c864">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed9-0a5b-39f6-4b87" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="748c-1373-a033-db55" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e200-70ec-9323-c864" name="Hunting Spear (2+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5001-519f-9085-fe67" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1008-2c9b-f29c-ffa0" name="Hunting Spear" hidden="false" targetId="d8e1-c144-925b-71db" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7626-1759-e3a9-a6b8" name="Ogre Crossbow (2+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf6d-bd67-3180-d4a5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e1d7-29a6-ab58-cbf7" name="Ogre Crossbow (2+)" hidden="false" targetId="6fed-96d4-3d46-a385" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1f04-250b-63a3-e6e9" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f79a-b757-fef3-5026" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b523-11cc-4a81-fb37" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b2d-1196-d188-00bd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="465c-b1ba-e8cf-e16f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ecef-acdb-7806-1d87" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0138-c481-641b-31f3" type="equalTo"/>
+                        <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2920-a556-7ce3-1ede" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0279-c046-a7df-ca8c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f465-43de-7e76-bc4e" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="36a4-1bd2-3524-18e9" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26da-9102-fcc3-e5e2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6832-d2e9-05da-ddcc" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="75c8-9bf9-8fee-8443" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b2-c985-3303-e1f4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="62fa-118f-9018-13e1" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0e73-7a42-b824-78d3" name="Options" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ee-cfda-4753-64a6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3a83-a978-e6c6-6a19" name="Vanguard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f576-ec58-32dc-fbf3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b096-e0c4-421c-4993" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b5d2-f4ae-7f79-510b" name="Scout" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b38-8047-89fb-9a1f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3cd1-182f-e65b-e99c" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0138-c481-641b-31f3" name="Tusker (lose Light Troops)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0646-13d6-1488-0c38" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="46a1-1306-cf96-c5ac" name="Chained Beasts (local)" hidden="false" targetId="b0d2-524e-01c5-5893" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="4164-b3c6-917d-807d" name="Tusker" hidden="false" collective="false" targetId="b1b3-b15a-0ed3-a02d" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2920-a556-7ce3-1ede" name="Rock Auroch (lose Light Troops)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbf7-0c72-4465-3793" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="577f-a7d7-8a8c-b96d" name="Chained Beasts (local)" hidden="false" targetId="b0d2-524e-01c5-5893" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="90f5-59d6-e416-61a0" name="Rock Auroch" hidden="false" collective="false" targetId="77f0-e914-b7e7-5940" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="360.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="640f-27a9-341a-7578" name="Big Names" hidden="false" collective="false" targetId="c7bf-d07e-1bd8-3232" type="selectionEntryGroup"/>
+        <entryLink id="3da5-8c8a-748e-2b19" name="General" hidden="false" collective="false" targetId="de54-24fe-f876-65e6" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="959f-40d4-b9ed-0ba5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="3e91-ac3a-bb05-a46e" name="Battle Standard Bearer" hidden="false" collective="false" targetId="959f-40d4-b9ed-0ba5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="1f91-684b-5a72-e05d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de54-24fe-f876-65e6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0185-d8bd-f5be-e60b" name="Tribesmen" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59cd-68bf-3969-edf0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="3c9f-d304-2c6a-657a" name="Scrapling Lookout" hidden="false" targetId="acfe-1168-a223-c621" type="rule"/>
+        <infoLink id="fb9e-875f-6bd6-3466" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="858d-d39f-4249-caaa" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="881a-566d-826a-62a2" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="448f-3641-ffd8-df46" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e6de-7cd8-d044-c848" name="Tribesman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5ab-2c06-a59a-e9e4" type="min"/>
+            <constraint field="selections" scope="parent" value="13.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b8e6-4dab-e6d0-fc55" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="89f5-1402-c802-cc4a" name="Tribesman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="40ce-ac85-64f5-22ab" name="Tribesman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9519-eee8-ad3a-7b26" name="Tribesman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="52.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fb09-62fb-5739-3177" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6acb-a83c-12b2-09b6" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e694-3b02-9e23-0e09" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e4d7-fc46-ad7d-9ec0" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="021a-10fd-aed2-dcd2" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                <entryLink id="7dc4-6693-55c2-d1dc" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9e6e-6cd5-571b-cab7" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="f3ed-d711-2e9f-aa61">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb66-a748-6877-5634" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="091d-ced8-a55d-191b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f3ed-d711-2e9f-aa61" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c551-1f68-39e7-c409" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7694-cea4-032f-27fb" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e886-f5dc-f9dc-a3a2" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="0185-d8bd-f5be-e60b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6de-7cd8-d044-c848" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d397-4c8d-597b-0426" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="70f6-7272-87ea-d6ee" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c337-7047-cb4f-093e" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="356a-88fa-db57-ea45" name="Bruisers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc48-26c7-a2fa-6380" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="01a0-4d69-cb3c-4954" name="Scrapling Lookout" hidden="false" targetId="acfe-1168-a223-c621" type="rule"/>
+        <infoLink id="bb8a-ad59-37dd-8c83" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="2e9f-22f0-d689-f74f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="5d60-4582-5f0e-072a" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+        <infoLink id="2536-e1b8-fffc-f617" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="06f3-7d98-0e57-3b81" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b76f-9130-9f9f-0761" name="Bruiser" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35c7-75c2-ad9c-6b19" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b90-ee5e-a929-71ee" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a9a6-5235-2b9e-b1f1" name="Bruiser Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c44e-bb74-d5cc-d132" name="Bruiser Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8116-b5ab-bb13-75f2" name="Bruiser Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="76.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fa35-4019-11d5-74bf" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef12-a3fa-7f43-0051" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="384b-8c84-dbac-cec2" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="94cb-b3ad-846e-5178" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6c59-391a-1284-80aa" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                <entryLink id="a021-798b-4600-6e92" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="76ab-ccc9-088d-af8d" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup">
+          <categoryLinks>
+            <categoryLink id="556d-1fb0-166d-eff4" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-43.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bcdc-e58a-0a46-7cd7" name="Scraplings" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="518e-e057-4ca4-70d0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6bb0-883d-5478-3b90" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="abf4-78bd-1af3-4748" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a246-c5ef-5cf8-a936" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="72a7-d1ab-76b0-2019" name="Scrapling" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a8c-e07c-3837-d17a" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb38-afa5-6544-61bf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f3d4-f48b-e192-7e44" name="Scrapling Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1c94-4529-f814-a6f9" name="Scrapling Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5b9a-9b86-ee7d-c3d3" name="Scrapling Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6476-ace2-66df-f1da" name="Command Group" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="2a06-6a64-c2ae-a797" name="Scrapling Foreman" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2be2-da12-860c-a84c" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="831f-1dab-04a1-f540" name="Back to Work" hidden="false">
+                  <description>The Scrapling Foreman is a Champion, except it does not benefit from First Among Equals. It gains Rally Around the Flag, but only Scraplings, Scratapults, and Scrapling Trappers may benefit from it.</description>
+                </rule>
+              </rules>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7ccb-eae3-3430-9331" name="Melee Weapon" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed33-7165-aef7-0219" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="71db-61d8-7737-a34a" name="Halberd" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f3d-6a40-90af-d4a2" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="5421-5765-a4d3-67dc" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+                      </infoLinks>
+                      <categoryLinks>
+                        <categoryLink id="579b-98b4-c4fb-f739" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                      </categoryLinks>
+                      <costs>
+                        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="4.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="80b4-fb3f-62c0-726a" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8252-f5db-83c6-4edf" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="29dc-c5c2-040c-9767" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+                      </infoLinks>
+                      <categoryLinks>
+                        <categoryLink id="a384-1b67-623d-0354" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+                      </categoryLinks>
+                      <costs>
+                        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="4.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7389-3d30-9f4b-b95c" name="Musician" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b81-84ad-6aa9-414c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="72ef-656b-88f9-bfde" name="Standard Bearer" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12dc-ca7e-c8c8-0dc3" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="015c-e67e-d9ad-434a" name="Options" hidden="false" collective="false" defaultSelectionEntryId="4327-dce7-c60c-5a91">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9fca-c3a8-099c-0c27" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3025-6983-1103-9f99" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4327-dce7-c60c-5a91" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fd4-8dd9-7fcc-3bdd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f41e-c547-068b-ee23" name="Throwing Weapons (5+)" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4cda-741a-0ac1-0a99" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="bcdc-e58a-0a46-7cd7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72a7-d1ab-76b0-2019" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afb4-69bc-3c0e-9232" type="max"/>
+                <constraint field="24fd-8af8-0c78-001c" scope="roster" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9009-9787-5209-9625" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cccd-85a3-da11-29d6" name="Bow (4+)" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9375-c824-2e35-8d0a" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="bcdc-e58a-0a46-7cd7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72a7-d1ab-76b0-2019" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8ae-f41d-2304-ce6b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="51f0-80ff-bc72-99b3" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b43c-5412-44ec-f971" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="bcdc-e58a-0a46-7cd7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72a7-d1ab-76b0-2019" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cc3-679a-0780-857b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ca79-c165-e884-3ead" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fb4-1aaa-370a-92d8" name="Mercenary Veterans" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="c6de-54b8-28fd-82b0" name="Scrapling Lookout" hidden="false" targetId="acfe-1168-a223-c621" type="rule"/>
+        <infoLink id="1c86-31e8-0f23-f35d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3a51-f019-a48d-e03b" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4fb4-1aaa-370a-92d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f97-767a-6108-bb33" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ad88-61f8-6d29-3b50" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d2b6-be32-6a48-d7c3" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="90c8-807c-33d1-f5f0" name="Mercenary Veteran" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cae8-3a2b-99cf-d578" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6317-5137-ad51-fc02" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6f03-58e0-6444-daa9" name="Mercenary Veteran Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4e3d-902c-9f4e-431f" name="Mercenary Veteran Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f3c8-7f9a-f049-af5c" name="Mercenary Veteran Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1f50-0556-5801-0431" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2395-eb59-ed09-cfcd" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3e87-011f-103c-8d39" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05bc-8706-12da-9cd3" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d830-2eba-db74-1fe2" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                <entryLink id="a83b-c0ca-d99d-a404" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="985c-0227-c243-b0a7" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bde-baaa-27c3-d448" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9068-a964-668b-fb36" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+                  <repeats>
+                    <repeat field="selections" scope="4fb4-1aaa-370a-92d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90c8-807c-33d1-f5f0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea77-162b-e411-4678" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="56a2-4926-db8a-abde" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="da4f-fddf-bf54-f728" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+                  <repeats>
+                    <repeat field="selections" scope="4fb4-1aaa-370a-92d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90c8-807c-33d1-f5f0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5425-ceb3-24b4-3349" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="aaa1-1f18-5c03-1066" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="74f3-3f8f-fbc2-68f0" name="Great Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+                  <repeats>
+                    <repeat field="selections" scope="4fb4-1aaa-370a-92d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90c8-807c-33d1-f5f0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1919-2cb2-9f77-473e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="190b-1e85-d303-0934" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="67d8-6fe3-3c53-bde9" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="13">
+                  <repeats>
+                    <repeat field="selections" scope="4fb4-1aaa-370a-92d8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90c8-807c-33d1-f5f0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c2-bd7c-3b6b-d2c6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6fb1-4259-579e-fe38" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0931-ea33-7b3d-6a43" name="Battle-Scarred" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="594a-568f-24d4-350d" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d445-80aa-f917-30c4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="75d6-1ed3-1a27-e2d7" name="Poison Attacks" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3fad-d1f5-6060-fdfe" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e2b-6bcc-d0c0-4e8f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="385a-dc5c-c3cd-9053" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f98b-4cf0-dd66-2931" name="Magic Resistance (2)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f504-d0d2-6ba6-7c34" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c65-253b-b4ad-b6ab" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b996-85f5-dedf-5687" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (2)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7c91-edb8-f1d5-17f9" name="Lethal Strike" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c074-b0e7-9d34-9c49" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b31-8d89-37e8-236c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e96d-43ee-a6a0-1263" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bc0d-7ec1-a1d4-21f0" name="Swiftstride" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a43a-802c-e5c2-4188" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7f3-1327-74ee-86ca" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5f82-f93c-7aaf-2c9f" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fd81-12d3-6c2b-4de9" name="Vanguard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b54-5c09-316c-220a" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b11c-ccf0-c695-09c9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="48e1-be41-d105-6451" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2dc5-cd04-a5e7-3694" name="Devastating Charge (+1 Str, +1 AP)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="85f5-82fb-7e07-bda6" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5583-4d92-a22d-5796" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="709c-9efa-7855-2d83" name="Devastating Charge (+1 Str, +1 AP)" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9f97-767a-6108-bb33" name="Plate Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="72a3-fab1-9c52-dc2f" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c17-7ad3-6af4-e4bc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="04a1-938f-82ae-f0d5" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="71f1-c508-2b93-31c8" name="Accurate" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a69-4835-3870-2d8d" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b3a-11da-1853-e2ba" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b60d-93b8-e01e-0ddb" name="Accurate" hidden="false" targetId="68aa-b60b-ae0b-158b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="91e0-5bec-3363-24ff" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e70-717b-ebff-d3b3" name="Mercenary Veterans with Ogre Pistols" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="cb08-6954-31d4-0f92" name="Scrapling Lookout" hidden="false" targetId="acfe-1168-a223-c621" type="rule"/>
+        <infoLink id="084d-228c-d249-1404" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="108a-e60d-8cd5-f468" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4e70-717b-ebff-d3b3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f86-40e9-6be4-1f1a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b898-5b69-b201-ccf9" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+        <infoLink id="0f4e-f5f9-9e13-afd5" name="Brace of Ogre Pistols (4+)" hidden="false" targetId="ab76-c5ad-a4a6-e148" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="18a0-c4d6-b98b-37b5" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="faaf-9f90-576b-2fd0" name="Powder Keg (local)" hidden="false" targetId="8848-ec3f-ef30-5842" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fdec-b291-fb51-d46d" name="Mercenary Veteran" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39b3-517c-c1db-ae8a" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34d1-3bb4-8a49-5f9a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e7d7-2390-5f1d-1099" name="Mercenary Veteran Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4323-6b1e-c91e-b763" name="Mercenary Veteran Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c8a7-ce22-4242-a03d" name="Mercenary Veteran Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="124.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c42a-10d5-09e8-41a0" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42c2-6e8f-85dc-c6b9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="aa73-eaa3-b22b-2700" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e4c-d6aa-7d2b-d369" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3cc2-c3f0-eaee-a0b3" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                <entryLink id="6b46-b0c1-05cc-103a" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="75c4-8dec-e282-7fcb" name="Battle-Scarred" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d32d-2532-1a88-cc75" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8b8-15d0-9864-d5d4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4d23-ea6e-d273-eb8a" name="Poison Attacks" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1396-42b4-3578-8fb4" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba0d-a1da-a181-07e1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dd7d-d0cc-df6d-8d2b" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="30ed-108a-2ab5-b39c" name="Magic Resistance (2)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03a9-1ae7-fc2b-6d44" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d5ea-635b-0c66-a78c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8588-3fa3-8e5c-70d0" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (2)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8299-8ad5-c682-ad92" name="Lethal Strike" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0056-1962-5621-7910" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a21a-2945-707c-a17f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="930f-df84-5266-2eda" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a048-392c-fc0d-5f5a" name="Swiftstride" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="039f-e613-f355-87b8" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ebb-43a5-abf1-0196" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1c8e-ca2e-b8f6-2e47" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="50f9-ccd9-860c-22d8" name="Vanguard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d98-2bb8-3f12-72ab" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="396d-938c-3b51-e9fe" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d931-285f-42dd-4fe6" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="eb6e-2445-1c35-e2cf" name="Devastating Charge (+1 Str, +1 AP)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6362-3610-e260-dd19" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2b1-ba00-f70c-c45d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="adfc-b0a6-cac1-e0d6" name="Devastating Charge (+1 Str, +1 AP)" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2f86-40e9-6be4-1f1a" name="Plate Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d2f-bcbe-071d-56b8" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e9b-0acc-77de-5a19" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="11b7-af9d-a9f2-75a3" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7b24-cc67-c1e6-b53a" name="Accurate" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c4d-6fe4-ccb7-f95b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29c3-2851-a315-c0ac" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="809a-dea1-fca4-faed" name="Accurate" hidden="false" targetId="68aa-b60b-ae0b-158b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="df62-1d71-fe70-6544" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bdba-ec58-78a8-10a5" name="Tusker Cavalry" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83a4-3bd4-29cb-0675" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d7d4-ef40-e76e-feb6" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="2f13-1054-a095-9103" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="98bf-20e4-f95a-03ff" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="994f-d03b-6015-08a9" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="d5b8-cbfe-327f-776e" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9f18-2fe6-b8b4-af39" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1588-6172-790e-f2c9" name="Tusker Cavalry" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a825-3e4b-26bb-e088" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39c4-3bc3-c1ac-ef3b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="31a7-6302-a7ce-70f0" name="Tusker Cavalry Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="770e-254d-5b64-a7b1" name="Tusker Cavalry Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4ec1-100d-fa69-bd43" name="Tusker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="22d9-43fa-83f0-6be2" name="Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5512-c932-c7b1-c9b7" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0bb-f5a2-7bcb-e6a5" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2239-83a4-b304-9ce7" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d14-3b05-6a28-f380" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fab6-96de-9a4d-4d4f" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                <entryLink id="abc8-52ee-6e7a-5060" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="439f-61dd-f65c-2a3d" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6e0-4e38-1ab2-e3a5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="78c4-8df4-a68a-88ae" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="bdba-ec58-78a8-10a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1588-6172-790e-f2c9" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b76-6d47-1fc7-470b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="622f-1b6c-9f89-de61" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fca6-1070-6bd6-72f0" name="Paired Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="bdba-ec58-78a8-10a5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1588-6172-790e-f2c9" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="017c-760b-63dd-08f7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b86c-e75e-f8db-c504" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="78b2-d974-d3e8-62f3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5b2f-cf3b-67ea-8c40" name="Yetis" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaf6-065e-932b-9c73" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="e605-b385-f6f6-0c96" name="Touch of Frost" hidden="false">
+          <description>Enemy units suffer -1 Agility for each unit of Yetis in base contact with them.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a7fc-6b59-9e68-2c44" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="1810-7998-48e6-9795" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="2c1b-016c-f907-a8ed" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="2e60-010b-fd60-ba93" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="5bdb-b10a-63bc-5e1f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="73fa-9cf7-27b4-978b" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a369-33a7-2e40-eba2" name="Yeti" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e59-fdb8-f5c9-5880" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f75f-ce60-7b80-79d6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2179-d323-c286-8245" name="Yeti Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="980c-8073-f1aa-98a0" name="Yeti Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7fd7-4188-e617-a4ef" name="Yeti Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2b8a-9e8f-b18f-5cc5" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5617-66cc-758f-71bc" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b1da-71fb-188e-d8bf" name="Scrapling Trappers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8df3-752e-fd46-3753" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="ab2c-5dfe-1739-44d0" name="It&apos;s a Trap" hidden="false">
+          <description>Each unit of Scrapling Trappers may place a Trap Counter:
+right before the battle (during step 7 of the Deployment Phase Sequence), on a single Terrain Feature that the unit was deployed in or was in base contact with at any point during its Vanguard move, and
+once during each friendly Movement Phase, on a single Terrain Feature that the unit was in base contact with at any point during this phase after an Advance Move, March Move, or a Reform.
+
+If an enemy unit makes an Advance Move, March Move, Reform, Pivot, Charge Move, Failed Charge Move, Pursuit Move, or Flee Move inside or into base contact with a Terrain Feature with one or more Trap Counters, remove all Trap Counters in that particular Terrain Feature. Each model in the unit must take a Dangerous Terrain (1) Test (these tests are not considered to be caused by the terrain feauture; any Dangerous Terrain tests that would normally be caused by the Terrain Feauture still need to be taken)
+
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f1f9-cea7-cb20-94c0" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="8100-bda1-050f-1e49" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="1e63-b0ca-9711-ca16" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="be8d-37e9-3ac0-dc46" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="be9e-8560-5874-f687" name="Throwing Weapons (5+)" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="44fd-8c9d-ecba-488c" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="53bf-a52c-3833-486c" name="Scrapling Trapper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ffd-69cc-4bc0-e9b7" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd66-9f2e-1773-0f49" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f268-0b93-fd4c-4f20" name="Scrapling Trapper Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8d15-e28b-f859-ae1f" name="Scrapling Trapper Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="efa4-fcd8-4fe9-fff2" name="Scrapling Trapper Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5b3d-ad1e-69ad-2639" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b342-5216-8c9b-77c6" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e9f7-1d3d-5a8a-5155" name="Sabretooth Tigers - Special" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="674f-7864-a23a-a893" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9a70-d2d0-0891-d010" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="674f-7864-a23a-a893" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="0940-e15d-5c11-61d2" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c7b0-907f-ef5d-f6c7" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="09f0-a006-f780-540e" name="Sabertooth Tiger" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92a2-ebed-0961-5cb1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1a0-de80-09af-9105" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="cd53-a395-0349-1788" name="Sabertooth Tiger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="eeb8-1992-52d4-be97" name="Sabertooth Tiger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cf46-c617-55db-fd59" name="Sabertooth Tiger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9a70-d2d0-0891-d010" name="Sabretooth Tigers - Core" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="2600-4532-81e9-cf43" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9f7-1d3d-5a8a-5155" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2600-4532-81e9-cf43" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="27bd-fa90-9692-c38e" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="696a-6eb7-7b85-8252" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="66dd-0981-8916-30b9" name="Sabertooth Tiger" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f5f-a7df-928e-eac1" type="max"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b51-01ea-d12b-0821" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="886a-c62a-2382-197d" name="Sabertooth Tiger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6013-a193-0a36-4235" name="Sabertooth Tiger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7460-dd66-fbd4-1f6b" name="Sabertooth Tiger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="130d-5dd5-58e6-d3ab" name="Kin-Eater" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8859-1298-941a-e8b4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="1dd6-e444-1138-3b36" name="Kin-Eater Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ad4a-b196-db57-55b6" name="Kin-Eater Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d0a7-ab88-2bf5-2774" name="Kin-Eater Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1742-4a5e-30f9-1434" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="bc5c-1bc7-b2de-9b71" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+        <infoLink id="99cc-a89c-f489-a246" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
+        <infoLink id="47d1-347d-3f4b-2f83" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="443a-6fe9-3427-07ba" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0558-6bc7-d48d-9e46" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="175.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7c4f-768e-7d01-74db" name="Thunder Cannon" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4b8-52e4-6d35-d472" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3b9f-8147-d10f-b710" name="Thunder Cannon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">6&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d670-a19b-f03d-2ec8" name="Thunder Cannon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6a76-7b63-c1c2-d9f2" name="Bombardier Crew Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d81f-95ed-6205-7f89" name="Scrapling Crew Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="629e-2b0a-ebf0-ab32" name="Woolly Rhino Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1184-2972-be9d-5866" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="271f-fcdd-0af1-7677" name="Thunder Cannon (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">5 [10]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">2 [10]</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3+1, Clipped Wings)]. A Thunder Cannon that only Pivots (and moves no further) during its owner’s Movement Phase ignores the to-hit modifier from Moving and Shooting in the next Shooting Phase.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="00c9-bb76-16c0-55d5" name="Thunder Cannon (4+) Volley Gun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">4</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">A Thunder Cannon that only Pivots (and moves no further) during its owner’s Movement Phase ignores the to-hit modifier from Moving and Shooting in the next Shooting Phase.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2ef5-0765-558a-5eb3" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+        <infoLink id="aa4d-96fa-8ba5-17a3" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="f3e3-699b-6984-c8d5" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5a4e-e206-8ca8-3728" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5ee5-9105-5946-a1a9" name="New CategoryLink" hidden="false" targetId="8848-ec3f-ef30-5842" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="320.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="edf3-1210-abdd-84a5" name="Scratapult" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d3f-402d-f5ce-4dda" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ff97-3cb0-0cf5-a322" name="Scratapult Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">6&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7818-e3f3-4cb3-9d0a" name="Scratapult Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b270-3688-2720-45f7" name="Scrapling Crew (7) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="28f4-0b4b-c08d-67ce" name="Woolley Rhino (Offence)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b296-b23a-fefa-09ae" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="eed7-87e2-3304-3cd1" name="Scratapult (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12-48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Lethal Strike. A Scratapult that only Pivots (and moves no further) during its owner’s Movement Phase ignores the to-hit modifier from Moving and Shooting in the next Shooting Phase.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="cd2c-6e24-4cb8-908e" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="c7da-0429-9dcb-f8b6" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="01b9-e4e1-3895-4993" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="fcea-6cc3-ddda-b4cc" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="15ec-5588-acb4-c3ab" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6e56-3e91-eea3-4658" name="New CategoryLink" hidden="false" targetId="8848-ec3f-ef30-5842" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="245.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="050d-0138-7654-3690" name="Bombardiers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86df-3ef4-a659-4274" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4dda-a300-1e26-720e" name="Hand Cannon" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b95e-0efa-a7f8-e215" name="Scrapling Lookout" hidden="false" targetId="acfe-1168-a223-c621" type="rule"/>
+        <infoLink id="ad79-df15-d1b3-c421" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="645a-c89b-4ec3-1dea" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="61db-b4ae-89e5-80cc" name="Sons of the Avalanche" hidden="false" targetId="caaa-36aa-3213-dd41" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="730f-3dde-700c-118a" name="New CategoryLink" hidden="false" targetId="8848-ec3f-ef30-5842" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="73b9-ce8e-e1bf-3e20" name="Bombardier" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9ad-a56a-5fe7-efaf" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89c1-e6f0-5c5f-e268" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c7f4-4776-9b6f-f7e7" name="Bombardier Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8989-3989-a2e9-efc4" name="Bombardier Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="93b2-e466-d1b2-ba0d" name="Bombardier Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="82.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e9de-19fb-4c14-20a4" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e01-4069-8cc7-cfe9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9224-1cf8-789a-e668" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b3a-92dd-47aa-70bc" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2cc1-8623-8fb3-c1f8" name="OK Banner Enchantments" hidden="false" collective="false" targetId="375e-b103-bb5e-7d2a" type="selectionEntryGroup"/>
+                <entryLink id="b54e-e5d3-1d7b-7494" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="61d1-d2c7-e6bc-06b2" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-61.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fa4c-41b5-30e0-beb7" name="Rock Aurochs" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="decrement" field="1948-2afe-bff6-1f7d" value="1">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="77f0-e914-b7e7-5940" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1948-2afe-bff6-1f7d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c9aa-5b3a-0733-0e88" name="Rock Auroch Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7a26-6286-0fc3-87f3" name="Rock Auroch Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ebb1-2bdf-988c-4351" name="Rock Auroch Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7021-43fb-b21f-b4c7" name="Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1418-a5f7-c5a3-3bc7" name="Living Avalanche" hidden="false">
+          <description>Impact Hits from the model gain +1 Strength and +1 Armour Penetration.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e92f-289e-bcc8-ba1a" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="5520-aa1c-f098-ea4a" name="Stone Skin" hidden="false" targetId="cbda-c7b7-5e59-8d0b" type="rule"/>
+        <infoLink id="b685-fda6-a917-da8a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="606a-2b7b-98b8-78d3" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="33f5-6128-65cf-779a" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="275a-f777-64a7-c554" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9d41-0b6c-2406-c633" name="New CategoryLink" hidden="false" targetId="b0d2-524e-01c5-5893" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0ceb-3247-e298-dc1b" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="e294-d22b-48b1-9e02">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8b0-9f4e-a78e-36b4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9493-94b4-e3b0-fdc4" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e294-d22b-48b1-9e02" name="Ogre Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c97e-e75e-0cee-44c6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="44d6-922c-603c-7801" name="Ogre Crossbow" hidden="false" targetId="6fed-96d4-3d46-a385" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="670c-78bc-cc2b-f1f4" name="Hunting Spear (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c3b-c278-689b-7e25" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="fbca-6393-9e78-5af7" name="Hunting Spear (3+)" hidden="false" targetId="d8e1-c144-925b-71db" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e671-85f7-45d2-00e2" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c98c-418d-969e-0b43" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0736-d120-8f69-85ff" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="475.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="04df-77d1-d29d-0582" name="Frost Mammoth" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b949-1f43-9615-045e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fc4a-7124-0827-c9a2" name="Frost Mammoth Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0e78-3089-6a2d-9bb9" name="Frost Mammoth Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="563e-3701-edcf-fc1b" name="Frost Mammoth Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c6fe-3a6a-862d-23fa" name="Rider (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="da42-015d-1888-669d" name="Living Avalanche" hidden="false">
+          <description>Impact Hits from the model gain +1 Strength and +1 Armour Penetration.</description>
+        </rule>
+        <rule id="62ce-80a5-c9ef-f7ab" name="Freezing Aura" hidden="false">
+          <description>The model can cast Chilling Howl from Shamanism as a Bound Spell with Power Level (4/8).
+Enemy units within 9” of one or more Frost Mammoths suffer -3 Agility. The roll for Flee Distance of enemy units that Break from combat while in base contact with a Frost Mammoth is subject to Minimised Roll.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="cf51-6089-4447-95e6" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="8a61-5bcd-321e-4930" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c21a-c342-625b-2345" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a9a2-7d74-c99b-8bbb" name="New CategoryLink" hidden="false" targetId="b0d2-524e-01c5-5893" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1bc8-be37-9639-92c5" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="44e6-8d3f-07b8-5267">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39cb-2628-fe7f-18e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a7fa-979f-bcf5-9009" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="44e6-8d3f-07b8-5267" name="Ogre Crossbow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ae8-4888-3a04-d5a3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4c69-d714-7c54-ca05" name="Ogre Crossbow" hidden="false" targetId="6fed-96d4-3d46-a385" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f184-61a8-8ebc-06ce" name="Hunting Spear (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35f-e01e-557a-5bd3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9325-2d11-2f06-d39b" name="Hunting Spear (3+)" hidden="false" targetId="d8e1-c144-925b-71db" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="405.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cc3-0dfb-c6c3-a7b8" name="Slave Giant" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b46-7db9-5a19-4457" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="95e1-5852-da1d-773d" name="Slave Giant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8076-5722-fc1c-daf6" name="Slave Giant Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <conditions>
+                <condition field="selections" scope="2cc3-0dfb-c6c3-a7b8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5e64-c970-158c-0c63" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4e62-7d66-540b-be14" name="Slave Giant Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="3424-e374-ee85-6331" name="Giant See, Giant Do" hidden="false">
+          <description>The model gains Sons of the Avalanche and counts as a Character for the purpose of Sons of the Avalanche. 
+The model is a Musician. The range of the Giant&apos;s March to the Beat, and to enemy units that are required to take a March Test due to the Slave Giant, are both extended to 18”.</description>
+        </rule>
+        <rule id="e951-c2e9-930b-a396" name="Rage" hidden="false">
+          <description>Whenever the model loases a Health Point, it gains +1 Attack Value. Whenever it gains a Health Point, it suffers -1 Attack Value.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="a672-5740-c122-94d6" name="New CategoryLink" hidden="false" targetId="b0d2-524e-01c5-5893" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5e64-c970-158c-0c63" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cfd-b705-2bf4-f4a8" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="eae7-6243-8859-343b" name="Big Brother" hidden="false">
+              <description>The model&apos;s Health Points are set to 8, and its base size is changed to 75x100mm.
+The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cef4-f608-2fc2-2ed7" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cbb-940d-9a15-7d97" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d751-47a6-946a-aad1" name="Giant Club" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a51-aad6-df56-10b0" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c61b-b383-22bc-a604" name="Giant Club" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="55ce-a079-aa98-087b" name="Iron Fist" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b834-a5e8-ff25-1b01" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0e74-fb9d-49af-1386" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0edd-87fb-ac80-9a93" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ae5-cce7-5820-6d8d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f1e1-1373-7ca3-ac7b" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="265.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="de54-24fe-f876-65e6" name="General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="865a-2216-efbc-b93a" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ed7-e723-1256-7ce2" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="21a0-7143-5229-6ec5" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="959f-40d4-b9ed-0ba5" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a53c-a23c-eb62-7d08" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="068f-f870-567d-6c35" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="8f8b-5851-f5bd-b811" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b1b3-b15a-0ed3-a02d" name="Tusker" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc4-989b-d46e-22e9" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b299-8476-b4d5-0018" type="min"/>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbe2-c626-447e-fddc" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ebaa-39a6-4569-4109" name="Tusker Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bc0b-589e-9674-1bc3" name="Tusker Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2f5c-46d2-a65a-27b2" name="Tusker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e692-552d-4aa2-6f66" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="f643-5d9c-8dc5-643b" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="1c98-deb2-cf52-0910" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="77f0-e914-b7e7-5940" name="Rock Auroch" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fafe-340f-adfe-bd44" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e89-654d-cdf4-9f7e" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f93a-2a1d-e39f-e219" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="500b-3ba4-756f-54bb" name="Rock Auroch Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="72e4-bc5d-22df-eb43" name="Rock Auroch Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="006a-6b67-e8ac-1e29" name="Rock Auroch Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="029c-d6f4-02d1-bab6" name="Living Avalanche" hidden="false">
+          <description>Impact Hits from the model gain +1 Strength and +1 Armour Penetration.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9a31-d8a4-3fde-caaa" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="93f0-dc0f-a56a-0fcd" name="Stone Skin" hidden="false" targetId="cbda-c7b7-5e59-8d0b" type="rule"/>
+        <infoLink id="278d-76bc-e203-5cd8" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="7093-80f0-2934-2f63" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9cf4-ff4d-2bda-706c" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="7e90-9648-2f19-820a" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3cba-95d8-af26-79ee" name="Wildheart" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d237-4a8c-570e-c611" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="025c-61d9-1711-61a9" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="c7bf-d07e-1bd8-3232" name="Big Names" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d0e-52ae-4535-5b92" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="9fa9-3840-439a-894e" name="Trolleater - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f436-8c46-8b4e-7c04" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cd8-d2af-64f8-ad9a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="002c-0e84-a0cb-c81e" name="Trolleater - Models on foot only" hidden="false">
+              <description>The bearer gains Fortitude (4+), Stupidity and Multiple Wounds (2, against Large Infantry).</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="5758-d0ca-7696-767b" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="84b7-2f5c-1e0a-2995" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (2, against Large Infantry)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7298-bba6-c0c5-5093" name="Hoardmaster - Khan/Great Khan only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43dd-d9fc-3287-fd85" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a662-8488-f69b-aa65" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="86ba-3d0e-c623-bacc" name="Hoardmaster" hidden="false">
+              <description>The bearer gains Weapon Master, Plate Armour, Iron Fist, Great Weapon, Paired Weapons, and Halberd. The bearer cannot take Weapon Enchantments.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="318e-23bd-cdfe-53c0" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+            <infoLink id="5b56-fb4f-f0c9-94e6" name="Iron Fist" hidden="false" targetId="8ad3-0e9d-3cdf-36b4" type="profile"/>
+            <infoLink id="4a59-47f2-80ce-991c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+            <infoLink id="c128-198c-a99c-bc0d" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+            <infoLink id="0cfe-dd4d-65e5-894f" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+            <infoLink id="2955-f47c-9d6f-628d" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a728-fc49-ea5a-bdff" name="Headhunter" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d5d-610d-602c-be2a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c7d-a6fb-300b-c2b3" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="e991-9585-2c33-ffb2" name="Headhunter" hidden="false">
+              <description>At the end of any Melee Phase in which the bearer has killed one or more models and is not fleeing, roll a D6. On a roll of 3+ it Recovers a single Health Point.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bcd5-396e-f7a5-a6cb" name="Cult Leader - General/BSB only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9aa-ce71-2939-0a6a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5db3-00db-cfc1-fa95" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="4209-3876-52ae-c66d" name="Cult Leader" hidden="false">
+              <description>The range of the bearer’s Commanding Presence or Rally Around the Flag is always 18”.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a336-10ec-ee76-e138" name="Gut Roarer - Shaman only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d252-bfeb-f9a1-382d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ee3-be5c-1e68-1c71" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="7b53-e0be-73c6-5e20" name="Gut Roarer" hidden="false">
+              <description>The bearer gains Fear and Channel (1).
+</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="57dc-c145-2667-faaa" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+            <infoLink id="036f-d8ca-f92a-3851" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3a3e-4c80-a66b-e692" name="Spinesplitter - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3731-5206-62ee-e45d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cab8-159b-0d9f-7f20" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="3e9c-438a-fd2b-2f61" name="Spinesplitter" hidden="false">
+              <description>The bearer gains Devastating Charge (+1 Att, +1 Str, +1 AP). The Strength and Armour Penetration bonuses from Devastating Charge also affect Impact Hits and Stomp Attacks.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="66c0-0034-fa32-9d47" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (+1 Att, +1 Str, +1 AP)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="49a0-e7d3-7c77-a8d4" name="Rottenjaw" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecf6-078f-1a8c-0544" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd7-b455-2225-dd75" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="6180-f476-8c33-204a" name="Rottenjaw" hidden="false">
+              <description>The bearer gains Poison Attacks, and a;; friendly Kin-Eater units may reroll Ambush rolls of 1 and 2 while the bearer is on the Battlefield. Unless the bearer is Gigantic, all attacks against the bearer with Poison Attacks lose this Attack Attribute.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="306e-8e28-32f7-61ff" name="Wildheart - Mammoth Hunters only" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="9fd1-c07a-c529-c510" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9bd2-5b60-0fea-cd3f" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e9d7-df12-9e7b-cfd2" type="max"/>
+            <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9fd1-c07a-c529-c510" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="dcaa-4827-a773-7eac" name="Wildheart" hidden="false">
+              <description>One of a Kind.
+The bearer loses Not a Leader and must be the General. Its Special Equipment allowance is increased to 150 pts. Another Mammoth Hunter in the Army may be the Battle Standard Bearer for 50pts; this Battle Standard Bearer gains Scrapling Lookout when joined
+to Yeti units. The Core limit is reduced to “at least 20%”. The Army may not include any Great Khans, Khans, Bruisers, Mercenary Veterans, Bombardiers, or Thunder Cannons.</description>
+            </rule>
+          </rules>
+          <entryLinks>
+            <entryLink id="0f70-0bba-01b5-f940" name="Wildheart" hidden="false" collective="false" targetId="3cba-95d8-af26-79ee" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="80ba-f84b-6b53-c0fc" name="OK Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1295-22f5-1934-9690" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="597d-4751-bb18-36ea" name="Khagadai&apos;s Legacy" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20f7-b29d-b72a-c34a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee4-cce1-d9ed-c95f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="374e-4e9e-c63c-8a06" name="Khagadai&apos;s Legacy" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Great Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Multiple Wounds (D3) and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d1a3-0966-766b-6c3b" name="Viper&apos;s Curse" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc6-bb5e-c263-99e9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0618-2989-d914-7cce" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="60a7-8762-06bf-0b1a" name="Viper&apos;s Curse" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Brace of Ogre Pistols or Ogre Crossbow enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">This weapon has Shots 4, Str 4, and AP 2 (Range is dependent on which weapon is enchanted). This weapon also gains Poison Attacks and Magical Attacks (in case of Brace of Ogre Pistols also for Close Combat Attacks made with it). An enchanted Ogre Crossbow loses Penetrating. Shooting Attacks made with this weapon always hit on 4+.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0f75-470a-2ea2-28b8" name="Heart-Ripper" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc1-84c2-da28-1591" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff5-3ad1-a21f-32e8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c9aa-de37-22dd-1cf5" name="Heart-Ripper" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Iron Fist or Paired Weapons enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gains Lethal Strike, Magical Attacks, +1 Armour Penetration, and can never hit on worse than 3+.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4f9d-1c15-4af5-8925" name="Ritual Bloodletter - Shamans only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="983a-584c-efc5-2cdf" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="551d-7668-91e1-41ac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0d1e-488b-4bf6-661a" name="Ritual Bloodletter" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon, Paired Weapon, Iron Fist enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder gains +1 Offensive Skill and +1 Attack Value while using this weapon. Attacks made with it gain Magical Attacks. For each unsaved wound inflicted with this weapon, the owner gains one Veil Token.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="375e-b103-bb5e-7d2a" name="OK Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4270-da94-0ddc-99bc" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6371-17e7-e334-26e3" name="Banner of the Gyengget" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81ae-a232-22c0-ab5d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325e-7acf-6c92-a607" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b39e-9100-93a9-3c6b" name="Banner of the Gyengget" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment. Cannot be taken by Core units</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">All model parts in the bearer’s unit must reroll natural to-hit, to-wound, and Armour Save rolls of ‘1’ in the first Round of Combat (this includes Special Attacks).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0a7f-cfbb-bc9b-4bea" name="Pennant of the Great Grass Sky" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c28-6e76-d0b8-8b8f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c6c-c085-09b8-2609" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6c97-71df-1e56-eaf6" name="Pennant of the Great Grass Sky" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Swiftstride.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d8f9-c510-174f-7d6d" name="Skull of Qenghet" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a18e-d05a-bac1-a33a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a73-2730-8f57-f301" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8a5d-591a-5a04-4062" name="Skull of Qenghet" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models in the bearer’s unit gain Fear and automatically pass Panic Tests caused by Terror.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="cd8f-8926-00ff-24f5" name="OK Armour Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ca2-cdd2-041e-ce6f" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="84c5-c092-d4f5-1f67" name="Wrestler&apos;s Belt - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cf3-c653-5ad6-98fc" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eebd-5467-6d56-83eb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f737-5a11-495d-04b7" name="Wrestler&apos;s Belt " hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +2 Armour and +1 Strength.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="daf1-3d5a-043c-8030" name="Mammoth-Hide Cloak - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38b4-26d1-4292-c3cf" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d49-f1be-20d9-7f58" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="28f6-41ce-0259-c398" name="Mammoth-Hide Cloak" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suits of Armour enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour. Attacks against the wearer can never have a Strength above 5.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8912-401d-4e85-9b78" name="Karkadan&apos;s Resilience" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff4-513a-5975-5da0" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff8-c3e8-e252-02d8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6567-1e50-7f12-35ce" name="Karkadan&apos;s Resilience" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suits of Armour enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Resilience but automatically fails all Special Saves.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d4a-7f8b-df24-70e3" name="Yeti Furs" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f221-9924-8510-4888" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="770e-e91e-2ce6-83b6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e874-421a-cf87-b131" name="Yeti Furs" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suits of Armour enchantment. </characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour. Enemy units in base contact with the wearer suffer -1 Agility</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="58c1-2f86-ae48-0fe5" name="OK Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3108-ae86-8e9d-88fd" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="024f-44fc-651f-6183" name="Lygur&apos;s Tongue" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="186a-9c70-2d9e-733e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f8e-d1eb-3188-534a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="216c-f4be-90e7-5ef0" name="Lygur&apos;s Tongue" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">All enemy models in units in base contact with the bearer suffer -1 Attack Value. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="75b6-f1bc-d006-5511" name="Rampager&apos;s Chain" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e384-194b-827e-db4f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0024-7689-c557-02e3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4321-f010-e2d1-2aa1" name="Rampager&apos;s Chain" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Stomp Attacks (D3+1), and all models in the bearer’s unit must reroll failed to-wound rolls with Stomp Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a5e8-52ee-e14f-93e8" name="Auroch Charm" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf06-1e81-a87a-ef30" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3fd-c449-d638-ae29" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b356-2e97-3956-8d55" name="Auroch Charm" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Stone Skin.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="acfe-1168-a223-c621" name="Scrapling Lookout" hidden="false">
+      <description>If a unit includes a Standard Bearer or a Battle Standard Bearer with Scrapling Lookout, R&amp;F models must be fewer than 3 before hits can be distributed onto Characters with the same Type and Size as the unit.</description>
+    </rule>
+    <rule id="cbda-c7b7-5e59-8d0b" name="Stone Skin" hidden="false">
+      <description>When a model with Stone Skin suffers a wound from an attack with Multiple Wounds, the number of wounds that it is multiplied into (due to Multiple Wounds) is halved, rounding up.</description>
+    </rule>
+    <rule id="caaa-36aa-3213-dd41" name="Sons of the Avalanche" hidden="false">
+      <description>The model part gains Impact Hits (1). If its unit has 2 or more Full Ranks, the model part gains Impact Hits (2). A Character with Sons of the Avalanche instead gains Impact Hits (D3), or Impact Hits (D3+1) if its unit has 2 or more Full Ranks.​ In addition, the model is immune to the effects of Fear of enemy models.​</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="8ad3-0e9d-3cdf-36b4" name="Iron Fist" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">As User</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">As User</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains +1 Armour and +1 Attack Value unless using another weapon. If the wielder is on foot it also gains Parry. This weapon cannot be enchanted with Weapon Enchantments from the Common Special Equipment section.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ab76-c5ad-a4a6-e148" name="Brace of Ogre Pistols" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire. Counts as Paired Weapons in Combat.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6fed-96d4-3d46-a385" name="Ogre Crossbow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">30&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">2 [5]</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1 [3]</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Penetrating</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d8e1-c144-925b-71db" name="Hunting Spear" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">As User</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">+1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Multiple Wounds (D3, against Gigantic)</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/orcsAndGoblins.cat
+++ b/orcsAndGoblins.cat
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="fb15-9166-d400-2894" name="Orcs and Goblins 2.0" revision="15" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="fb15-9166-d400-2894" name="Orcs and Goblins 2.0" revision="16" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="82d5-126d-e31a-aa94" name="Big &apos;n Nasty (local)" hidden="false"/>
-    <categoryEntry id="213d-78ab-6a2f-1664" name="Death from Above (local)" hidden="false"/>
+    <categoryEntry id="82d5-126d-e31a-aa94" name="Big &apos;n Nasty" hidden="false"/>
+    <categoryEntry id="213d-78ab-6a2f-1664" name="Death from Above" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="966b-c87a-698b-6453" name="Orcs and Goblins (local)" hidden="false">
+    <forceEntry id="966b-c87a-698b-6453" name="Orcs and Goblins" hidden="false">
       <categoryLinks>
         <categoryLink id="7159-9d70-ba2e-1fe0" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>

--- a/orcsAndGoblins.cat
+++ b/orcsAndGoblins.cat
@@ -1,0 +1,6224 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="fb15-9166-d400-2894" name="Orcs and Goblins 2.0" revision="15" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="82d5-126d-e31a-aa94" name="Big &apos;n Nasty (local)" hidden="false"/>
+    <categoryEntry id="213d-78ab-6a2f-1664" name="Death from Above (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="966b-c87a-698b-6453" name="Orcs and Goblins (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="7159-9d70-ba2e-1fe0" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="2b0c-a029-a670-ef61" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="283c-33ed-159d-b074" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="6342-ec2a-55f9-0615" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6a73-1da8-2007-c375" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="2b39-2b40-e671-78d7" name="Big &apos;n Nasty (local)" hidden="false" targetId="82d5-126d-e31a-aa94" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="025e-ac0a-f440-f3e8" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d00a-f833-726b-0cb8" name="Death from Above (local)" hidden="false" targetId="213d-78ab-6a2f-1664" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="15.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="a0cc-52bd-1c9a-a006" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="b201-da67-ffac-9943" name="Orc Warlord" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="1894-25d2-4542-db1e" name="Orc Warlord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cac9-3799-283f-70ff" name="Common Orc Warlord Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5459-5776-310d-8f67" name="Feral Orc Warlord Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-ae1f-eff0-98d9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3fd4-6870-0820-78f2" name="Iron Orc Warlord Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b544-653e-8306-27a4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2df7-2393-fc59-e1c1" name="Common Orc Warlord Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8052-3137-cd97-e218" name="Feral Orc Warlord Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-ae1f-eff0-98d9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="43a1-d55f-74fe-bffe" name="Iron Orc Warlord Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b544-653e-8306-27a4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4695-5953-303f-0a07" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d331-ab96-b047-90c3" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b544-653e-8306-27a4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2da6-90f8-771c-08ea" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b201-da67-ffac-9943" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-ae1f-eff0-98d9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6cfe-ec71-2919-e8a4" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="eb98-e263-095c-0ca0" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4899-a1a2-a2eb-0e3b" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe3-fa27-1982-4c5a" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2714-8a15-359e-4f9d" name="War​ ​Cry!" hidden="false" targetId="6084-6161-b449-356a" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="9c39-43a3-38f1-b1d3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="b870-9f7e-769a-0e3c" name="Army General" hidden="false" collective="false" targetId="2d2f-6b4d-ec4d-ef53" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e6d0-0dfa-9baf-0274" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6132-8e66-c76d-24da" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="47fd-73e8-85bf-6c8e" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9878-d851-cd19-32a5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c8f1-eff1-8f36-ca88" name="Armour Enchantments" hidden="false" collective="false" targetId="62b9-ee82-d70a-3430" type="selectionEntryGroup"/>
+                <entryLink id="898e-182a-3147-823b" name="Weapon Enchantments" hidden="false" collective="false" targetId="fa05-24e8-b27c-98f3" type="selectionEntryGroup"/>
+                <entryLink id="dac1-3749-782a-bda1" name="Artefacts" hidden="false" collective="false" targetId="a10c-1edf-196a-3870" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6f55-7ee0-ac51-d59f" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="716f-e826-35cc-d5cc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9432-3b2c-2132-c10d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="92a6-ae1f-eff0-98d9" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="260"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ab-11fc-02a3-5b4b" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2649-ad6e-fdae-95da" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="220"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ebe-65ba-a296-62c0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b544-653e-8306-27a4" name="Iron Orc" hidden="false" collective="false" targetId="989b-3f4f-b070-0b7a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="285"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f8b-3359-3762-a270" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0e62-1f8e-ab78-13aa" name="Mounts" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d0b-0a97-e5b4-3309" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6bd1-e6bc-8f5f-d49d" name="War Boar" hidden="false" collective="false" targetId="9588-734d-c644-79eb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="40">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-ae1f-eff0-98d9" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="50">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b544-653e-8306-27a4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c52e-f520-bfaa-471f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f2e6-cd36-464e-5c51" name="Orc Boar Chariot" hidden="false" collective="false" targetId="8957-d66f-aed4-56c7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="120">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b544-653e-8306-27a4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="80">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-ae1f-eff0-98d9" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="219b-b8f2-4b9c-bcca" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e701-ad42-68da-8896" name="Wyvern" hidden="false" collective="false" targetId="6051-4fdb-b641-851c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="200">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="170">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2649-ad6e-fdae-95da" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a91c-3209-2470-59c7" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="98c5-ded2-4a58-4335" name="Big &apos;n Nasty (local)" hidden="false" targetId="82d5-126d-e31a-aa94" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bb94-891e-ac31-cf72" name="Equipment" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="bcc0-4602-ab5c-b9ac" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25cc-be8e-5697-0c2a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="33e4-9812-b912-571e" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dffb-b444-8a1b-05ac" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e62-1f8e-ab78-13aa" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51aa-7502-ebb1-013c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="52bf-ea1c-79dd-1ee8" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="926a-54d2-a330-b742" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b166-c630-2962-1c21" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f8e1-db45-b252-5596" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c4d6-2512-86be-057e" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5ed-6969-d1bf-4e93" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="69c8-5616-c91d-1bae" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3e06-4ce2-eddf-b564" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b544-653e-8306-27a4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ac-731c-0bd2-83e3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6df6-5ee9-ea69-4bf5" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b5fc-ef78-6d5a-79f6" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="b201-da67-ffac-9943" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-ae1f-eff0-98d9" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="387e-c786-6a24-5734" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="04be-1947-46b7-e1d5" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f19c-6a67-f33e-b978" name="Orc Chief" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="58d3-0573-1df3-0945" name="Orc Chief Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1e96-2741-f0e2-0a4b" name="Common Orc Chief Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="744a-8b60-c68a-6cb1" name="Feral Orc Chief Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15e2-0789-5775-1df6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="265b-000e-6103-0e70" name="Iron Orc Chief Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9d-b24f-3af3-6a68" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fac0-f361-c150-60e3" name="Common Orc Chief Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="223c-c437-c5cf-d982" name="Feral Orc Chief Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15e2-0789-5775-1df6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d523-5742-745c-7294" name="Iron Orc Chief Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9d-b24f-3af3-6a68" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d3d2-9365-daaa-0841" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fb96-57df-ed36-3c87" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9d-b24f-3af3-6a68" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="60e5-2b5d-fad4-f444" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15e2-0789-5775-1df6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f934-12bd-a50b-d85f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4874-89e3-d3f8-2ad9" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6da-e3ba-553d-0a3d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8705-08a8-f9ae-cbc6" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9b3-a8d2-25e6-2571" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="59c3-ae10-93b5-c01b" name="War​ ​Cry!" hidden="false" targetId="6084-6161-b449-356a" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="a6e0-02b0-bf3e-9fd2" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="1b15-59f5-3ed0-63b0" name="Army General" hidden="false" collective="false" targetId="2d2f-6b4d-ec4d-ef53" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c6da-e3ba-553d-0a3d" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4874-89e3-d3f8-2ad9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9468-aee1-4a08-77cf" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6857-46b5-8690-59d0" name="Battle Standard Bearer" hidden="false" collective="false" targetId="3dd9-3347-6a48-cb77" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b6cd-1048-aaaf-6fa1" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7db-7d16-2043-a9b0" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0a50-d46b-610a-6178" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c370-d365-7902-a163" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e9d1-cbfc-b427-3681" name="Armour Enchantments" hidden="false" collective="false" targetId="62b9-ee82-d70a-3430" type="selectionEntryGroup"/>
+                <entryLink id="662a-9a8c-07b9-9215" name="Weapon Enchantments" hidden="false" collective="false" targetId="fa05-24e8-b27c-98f3" type="selectionEntryGroup"/>
+                <entryLink id="fc09-da8f-d651-075b" name="Artefacts" hidden="false" collective="false" targetId="a10c-1edf-196a-3870" type="selectionEntryGroup"/>
+                <entryLink id="917b-6190-b5e1-660a" name="Banner Enchantments" hidden="true" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6da-e3ba-553d-0a3d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="00d1-7328-322d-76f2" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="b6cd-1048-aaaf-6fa1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9d1-cbfc-b427-3681" type="equalTo"/>
+                            <condition field="selections" scope="b6cd-1048-aaaf-6fa1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc09-da8f-d651-075b" type="equalTo"/>
+                            <condition field="selections" scope="b6cd-1048-aaaf-6fa1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="662a-9a8c-07b9-9215" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2cc3-fa41-5bce-ccef" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f03b-2954-6e79-c835" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ed-a456-4a52-f9e2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="15e2-0789-5775-1df6" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="140"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75b5-4f7a-211d-ae93" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f1d6-b7ac-9562-7cd6" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="120"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ed8-8ea6-2add-136f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bc9d-b24f-3af3-6a68" name="Iron Orc" hidden="false" collective="false" targetId="989b-3f4f-b070-0b7a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="160"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32b2-5814-36bd-e9de" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2a94-a5d3-3b30-99ee" name="Mounts" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b40-a361-853a-b883" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ef91-12f6-8062-a5cd" name="War Boar" hidden="false" collective="false" targetId="9588-734d-c644-79eb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="40">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9d-b24f-3af3-6a68" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15e2-0789-5775-1df6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="40">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f89-f0c7-b6bf-fe68" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="66fe-5044-4657-6397" name="Orc Boar Chariot" hidden="false" collective="false" targetId="8957-d66f-aed4-56c7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="80"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="887e-490a-242f-5598" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="140c-f1b5-eee3-98e0" name="Wyvern" hidden="false" collective="false" targetId="6051-4fdb-b641-851c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="200">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="170">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f1d6-b7ac-9562-7cd6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="304e-78bb-c63d-3324" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="76e8-b8c1-0a78-cb46" name="Big &apos;n Nasty (local)" hidden="false" targetId="82d5-126d-e31a-aa94" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="87d0-dbf1-c028-f4ab" name="Equipment" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="4c32-87f4-153e-425d" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8c7-576b-cf40-c74e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="941a-5ab1-9381-07c7" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9cbc-4b35-6e7b-74ec" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a94-a5d3-3b30-99ee" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="109d-57c4-8277-2d05" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1a85-70ec-a3d9-51ab" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="29b2-5817-4c91-8536" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed7f-6699-d81f-9362" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="fccc-85ad-76bf-16ca" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b95b-af2c-d3c0-ea05" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c31-3ad8-7bce-3a68" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6566-e7b3-5f44-ea06" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="02d3-0ac9-3225-09fd" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9d-b24f-3af3-6a68" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3187-15b0-f3ac-876e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="aa95-94fd-ea0d-3cc5" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="75e9-e636-f5d1-f646" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="f19c-6a67-f33e-b978" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15e2-0789-5775-1df6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b93-1cee-2d0c-7b53" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="779b-5fa2-b85e-d332" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2444-7210-eeb8-fea3" name="Orc Shaman" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="bf3e-8d14-b182-6428" name="Orc Shaman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c603-ee71-afbf-9beb" name="Orc Shaman Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="50de-90c5-a8f0-51c2" name="Feral Orc Shaman Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="2444-7210-eeb8-fea3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="578e-2c4b-e0d4-2498" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0b30-3aaa-47c0-359c" name="Common Orc Shaman Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="2444-7210-eeb8-fea3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="723a-536d-2bac-9a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ac88-c2e3-3b84-66ce" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2444-7210-eeb8-fea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="723a-536d-2bac-9a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3de6-427c-ae5f-bb1e" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2444-7210-eeb8-fea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="578e-2c4b-e0d4-2498" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="189b-396b-b10a-d5ac" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8b74-4186-ba69-4230" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a79-d75e-fc8c-92fe" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd39-dabd-6e40-e02d" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8d98-63e3-6356-61ea" name="War​ ​Cry!" hidden="false" targetId="6084-6161-b449-356a" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="0107-4717-aa7b-6e9b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="4abc-ed3d-0a27-3aef" name="Army General" hidden="false" collective="false" targetId="2d2f-6b4d-ec4d-ef53" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ec7b-3705-a74f-0a9e" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="63af-80bc-f76a-2337" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6a77-3a2a-c715-5156" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="7035-c984-a67f-868e" value="200">
+                  <conditions>
+                    <condition field="selections" scope="2444-7210-eeb8-fea3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d630-c68b-b266-dc14" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7035-c984-a67f-868e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3505-8336-9f51-1df6" name="Armour Enchantments" hidden="false" collective="false" targetId="62b9-ee82-d70a-3430" type="selectionEntryGroup"/>
+                <entryLink id="fe29-afe3-06b9-b76b" name="Weapon Enchantments" hidden="false" collective="false" targetId="fa05-24e8-b27c-98f3" type="selectionEntryGroup"/>
+                <entryLink id="cde8-1f83-dc0f-238a" name="Artefacts" hidden="false" collective="false" targetId="a10c-1edf-196a-3870" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="400f-4531-4c81-64b2" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42ca-db4f-fed9-504a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c429-66a1-f705-771e" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1b98-1adb-3dd4-25e5" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a4e-38d1-5417-a8fb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35f8-2586-5c67-e6fb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="578e-2c4b-e0d4-2498" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="170"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e5-858f-b073-9771" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="723a-536d-2bac-9a32" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="155"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a174-df41-3866-277c" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7bbb-1803-a77b-eeb2" name="Mounts" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e550-9743-4c6e-f9ef" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2722-e98f-19cb-e501" name="War Boar" hidden="false" collective="false" targetId="9588-734d-c644-79eb" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="20"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c582-d3b0-6f24-da53" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ee94-78d4-387e-cb46" name="Orc Boar Chariot" hidden="false" collective="false" targetId="8957-d66f-aed4-56c7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="25"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="2444-7210-eeb8-fea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="723a-536d-2bac-9a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e25-9a8b-ab12-e0c8" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="7a5f-14e5-536b-ed51" name="Wyvern" hidden="false" collective="false" targetId="6051-4fdb-b641-851c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="120">
+                  <conditions>
+                    <condition field="selections" scope="2444-7210-eeb8-fea3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="578e-2c4b-e0d4-2498" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="2444-7210-eeb8-fea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d630-c68b-b266-dc14" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="105">
+                  <conditions>
+                    <condition field="selections" scope="2444-7210-eeb8-fea3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="723a-536d-2bac-9a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="589a-25aa-dc74-c743" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="a689-9ee5-c6c3-f906" name="Big &apos;n Nasty (local)" hidden="false" targetId="82d5-126d-e31a-aa94" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4562-4a47-fe3f-f78a" name="Wizard Level" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71a8-7209-58fe-4297" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e21-32fb-ab80-99ba" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3bb1-b524-1eef-8e42" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d3c-b385-a9a2-af25" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d966-2177-9eed-c2c4" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="90d0-0ddc-04b5-172a" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="608f-ac3b-21cb-e5d6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="91ea-9451-bc8c-65ca" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d630-c68b-b266-dc14" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a697-5092-90f6-0fa4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="37b3-c563-9e78-5420" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="70bc-a439-f34c-2efb" name="Path of Magic" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="9503-68e1-dc1b-f694" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9503-68e1-dc1b-f694" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28fd-e26e-2bcf-e2b9" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="74dd-6236-50dd-9984" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5907-1178-8ae9-1869" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d327-bd2c-4d46-d1c0" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe35-5419-7773-89b9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="92bf-0b33-3718-ad92" name="Thaumaturgy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77e5-5160-b13b-037b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0529-6d77-3eaf-61ef" name="Goblin King" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0fc1-c677-c7c9-931a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3339-aea1-feee-8b88" name="Goblin King Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d38c-ca85-5624-1eab" name="Goblin King Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="128e-51cc-562c-1408" name="Goblin King Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f01c-807f-e7e7-b864" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0529-6d77-3eaf-61ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d540-9203-fb95-af25" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fc9c-4ed6-5fdc-c7a5" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4773-4ba1-b048-3b11" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8553-0337-d6df-0fe9" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c5cb-3575-f952-dac7" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="693c-eff3-39f7-ecea" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0272-ecf7-5dd2-e44c" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6684-ef3e-0812-97be" name="War​ ​Cry!" hidden="false" targetId="6084-6161-b449-356a" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="e413-cb0b-195f-ec7e" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="daa4-98b1-0b6a-343f" name="Army General" hidden="false" collective="false" targetId="2d2f-6b4d-ec4d-ef53" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e7ef-7058-7982-6ac1" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8e6-d93b-68c4-628f" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e087-103b-120b-77bb" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f29-5d62-9ce5-0dc8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8d3f-83ff-f7df-49e8" name="Armour Enchantments" hidden="false" collective="false" targetId="62b9-ee82-d70a-3430" type="selectionEntryGroup"/>
+                <entryLink id="5d63-20ba-ae7a-3322" name="Weapon Enchantments" hidden="false" collective="false" targetId="fa05-24e8-b27c-98f3" type="selectionEntryGroup"/>
+                <entryLink id="842f-1ebb-f13a-6945" name="Artefacts" hidden="false" collective="false" targetId="a10c-1edf-196a-3870" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="078d-d743-dc4b-d069" name="Bow (3+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c2-cc62-a104-a831" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3f28-d1d7-bbea-250a" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (3+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3c46-ccd5-5bfa-dee9" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bec9-9a15-9519-e61d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b74c-2036-774f-d676" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d540-9203-fb95-af25" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0226-d706-41e9-e2b1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b112-73ff-62a2-8ea3" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="da69-b3d2-c332-5785" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcdf-ff11-88df-a642" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b2c-3bc0-c143-9a54" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4773-4ba1-b048-3b11" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="140"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d3c-f4fe-e09e-2eae" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="cb4c-7591-036f-a140" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="115"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0d9-bf43-c529-ee22" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5de7-ff51-f9d2-ac29" name="Cave Goblin" hidden="false" collective="false" targetId="64d8-0040-c30f-c791" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="115"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4a2-bcca-4cf3-a0bb" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c276-0663-22b0-ec10" name="Mounts" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b2f-995c-4a87-70e9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e57d-119a-cee6-5abc" name="Wolf" hidden="false" collective="false" targetId="ec59-310c-9734-1559" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb4c-7591-036f-a140" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa8-6c7c-8899-a8e0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="957c-cf3a-d575-e229" name="Goblin Wolf Chariot" hidden="false" collective="false" targetId="03ee-790f-d976-662c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="60"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb4c-7591-036f-a140" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90c3-a3ee-1388-fe1c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="d872-5e58-3c0b-d838" name="Cave Gnasher" hidden="false" collective="false" targetId="f6fd-3aa5-c028-f3c5" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5de7-ff51-f9d2-ac29" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb87-d4cc-946d-0e4f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e121-b3b2-7c41-6309" name="Scuttler​ ​Spider" hidden="false" collective="false" targetId="91b7-4e67-9d08-8ef4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4773-4ba1-b048-3b11" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65b3-e45d-0028-bbae" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="c9c2-483d-0bcb-3dbc" name="Huntsmen ​Spider" hidden="false" collective="false" targetId="a3e2-84b3-8dd8-13bd" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4773-4ba1-b048-3b11" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92b7-2f2c-74f9-4271" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="4808-dc5e-868a-bdc1" name="Gargantula" hidden="false" collective="false" targetId="0b2e-f21e-81e6-4153" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="410"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4773-4ba1-b048-3b11" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d071-4511-002e-e238" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="134e-5d45-744f-a639" name="Big &apos;n Nasty (local)" hidden="false" targetId="82d5-126d-e31a-aa94" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fb38-85af-7081-688c" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c60-ff2e-d9b4-acf4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="016c-3d01-4f12-8dec" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e10-860c-81c6-2cf9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6134-8419-47b3-19c6" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="18c7-ad07-1810-bca8" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c276-0663-22b0-ec10" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba2-5191-0716-ac91" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ccd1-f95e-e0ac-7152" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3a04-75fa-1f29-cfb0" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b800-9640-6f64-39b7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="baac-2a07-4c22-62b9" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="913d-d9c4-2389-c48d" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0529-6d77-3eaf-61ef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c276-0663-22b0-ec10" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab44-3039-0c39-8b89" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7900-3fd7-c83a-d2e4" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="92e7-d9d8-c21d-b118" name="Goblin Chief" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="d5e6-73bf-de9f-298b" name="Goblin Chief Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dee3-1547-0b84-5747" name="Goblin Chief Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="27f1-8b68-1014-8f77" name="Goblin Chief Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9ef9-01c4-e54d-6134" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="4999-a331-fb17-ffe7" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b47-ebaf-5050-8aff" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8fa5-2fd2-3354-2c19" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7f29-0314-58d9-0d5f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b54c-6f7e-f436-2ec7" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="92e7-d9d8-c21d-b118" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4195-1f4f-d482-36a1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf81-3620-0731-dee5" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6242-8647-b556-dcb2" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fa84-b739-49f2-0868" name="War​ ​Cry!" hidden="false" targetId="6084-6161-b449-356a" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="a7b3-c32e-f43e-f6db" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="3f2e-2e21-f64c-7864" name="Army General" hidden="false" collective="false" targetId="2d2f-6b4d-ec4d-ef53" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e1dc-5e12-03be-1ea3" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b45d-321c-a709-6632" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a87c-7781-9809-b8a5" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f24f-94dc-4b32-9252" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="621f-8b85-503b-7871" name="Armour Enchantments" hidden="false" collective="false" targetId="62b9-ee82-d70a-3430" type="selectionEntryGroup"/>
+                <entryLink id="772d-4285-a0bc-e0e5" name="Weapon Enchantments" hidden="false" collective="false" targetId="fa05-24e8-b27c-98f3" type="selectionEntryGroup"/>
+                <entryLink id="99ca-77cb-a997-34fa" name="Artefacts" hidden="false" collective="false" targetId="a10c-1edf-196a-3870" type="selectionEntryGroup"/>
+                <entryLink id="fea7-9a62-d74b-a9c6" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="00d1-7328-322d-76f2" value="2">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="e1dc-5e12-03be-1ea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="621f-8b85-503b-7871" type="equalTo"/>
+                            <condition field="selections" scope="e1dc-5e12-03be-1ea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="772d-4285-a0bc-e0e5" type="equalTo"/>
+                            <condition field="selections" scope="e1dc-5e12-03be-1ea3" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99ca-77cb-a997-34fa" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c414-409d-4bf7-f106" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0f96-fa50-8af1-9ceb" name="Bow (3+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe5d-f82d-092f-9d52" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b223-ed08-8d6d-489a" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (3+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4195-1f4f-d482-36a1" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="92e7-d9d8-c21d-b118" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b54c-6f7e-f436-2ec7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c584-81d5-6a77-b0c8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c414-409d-4bf7-f106" name="Battle Standard Bearer" hidden="false" collective="false" targetId="3dd9-3347-6a48-cb77" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c5cd-c2b9-3045-7c77" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0f4-ec20-21f6-855c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3900-5d3f-95a8-c0fa" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5b47-ebaf-5050-8aff" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="80"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1d5-00c0-40d4-8e01" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2171-ffaa-b812-fda2" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e8-d41e-d18b-53a4" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bde9-7f91-6c6f-e1be" name="Cave Goblin" hidden="false" collective="false" targetId="64d8-0040-c30f-c791" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4457-16a4-c8b8-1508" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e0cf-4624-f15c-4d46" name="Mounts" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ae6-9824-9b87-f2d4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c866-d33e-208f-f72b" name="Wolf" hidden="false" collective="false" targetId="ec59-310c-9734-1559" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="50"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2171-ffaa-b812-fda2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61ec-ac53-6181-4f26" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="d049-459a-81e9-11b8" name="Goblin Wolf Chariot" hidden="false" collective="false" targetId="03ee-790f-d976-662c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="60"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2171-ffaa-b812-fda2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4486-462c-0604-0a4d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6559-1108-f002-0161" name="Cave Gnasher" hidden="false" collective="false" targetId="f6fd-3aa5-c028-f3c5" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="65"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bde9-7f91-6c6f-e1be" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d74e-1745-7675-e43c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="633f-7839-53c3-d2c6" name="Scuttler​ ​Spider" hidden="false" collective="false" targetId="91b7-4e67-9d08-8ef4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="25"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b47-ebaf-5050-8aff" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a22b-ee3f-2aab-e4fc" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="695f-d44f-f99b-4245" name="Huntsmen ​Spider" hidden="false" collective="false" targetId="a3e2-84b3-8dd8-13bd" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="40"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5b47-ebaf-5050-8aff" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e479-eadc-4ec7-7db7" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1ab3-0101-bc78-3e2e" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ed6-2682-5219-a3f5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="93ca-4edb-1156-3494" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e58-f7b7-146f-610a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="339b-b1ed-931a-eb30" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0c89-16bf-c944-e1da" name="Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0cf-4624-f15c-4d46" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c01-a7ae-8a44-5277" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2889-6db7-2c72-95d4" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2bc7-42a3-c1c6-c085" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d62b-3ca3-8b69-2fdd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ed3e-7d8d-66c6-7648" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0abc-d709-405d-14ca" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="92e7-d9d8-c21d-b118" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0cf-4624-f15c-4d46" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e9a-0410-6398-c920" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ed3a-1142-ae4d-ae9a" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72b8-5864-ab83-b1a0" name="Goblin Witch Doctor" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="076a-23d6-e1f6-3b31" name="Goblin Witch Doctor Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7d19-9226-c1d9-c932" name="Goblin Witch Doctor Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c332-00de-f204-6041" name="Goblin Witch Doctor Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="3">
+              <conditions>
+                <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="091e-f871-b0ee-08b9" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6b3d-2251-fe45-5093" name="2 Power &apos;Shrooms" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94b5-8d88-62f0-fb2a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>One use only. The model can use each of its Power ‘Shroom once per game. Declare usage just before the model is rolling a casting roll for a non-Bound Spell. Any Dispel Attempt made against this spell suffers -D3 to its dispel roll (roll this dice directly when using the Power ‘Shroom). If a natural ‘1’ is rolled for this D3, the model using the Power ‘Shroom suffers 1 hit with Toxic Attacks. This is an exception to the Casting and Dispelling Modifier rule (i.e. it is allowed to modify the dispel roll by more than -2).</description>
+        </rule>
+        <rule id="7eb9-b23f-16c8-2788" name="Spider-Mother​ ​Shrine" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b98-25a3-b30b-2431" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>The model gain Aegis (5+, against Ranged Attacks) and knows one additional Learned Spell.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1311-f10c-b17f-d5c4" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b80-5c93-ef70-9096" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6f02-116b-feee-d453" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8516-ece5-57fc-866a" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="609f-9957-b4ec-ce46" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4984-cadf-8bf7-c722" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e624-6b70-4342-f1ff" name="War​ ​Cry!" hidden="false" targetId="6084-6161-b449-356a" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="1a2f-b8e3-79d8-28e7" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="e19c-65a9-7500-e339" name="Army General" hidden="false" collective="false" targetId="2d2f-6b4d-ec4d-ef53" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b016-0ee9-4659-20c0" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="605f-3770-f855-1f85" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f777-89e6-09da-b201" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="d0a1-0b2a-fc3c-9bc7" value="200">
+                  <conditions>
+                    <condition field="selections" scope="72b8-5864-ab83-b1a0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="091e-f871-b0ee-08b9" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0a1-0b2a-fc3c-9bc7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="69db-9b36-277e-2a3b" name="Armour Enchantments" hidden="false" collective="false" targetId="62b9-ee82-d70a-3430" type="selectionEntryGroup"/>
+                <entryLink id="1c6a-05f2-9b3b-af5b" name="Weapon Enchantments" hidden="false" collective="false" targetId="fa05-24e8-b27c-98f3" type="selectionEntryGroup"/>
+                <entryLink id="fb16-e443-35d2-c67d" name="Artefacts" hidden="false" collective="false" targetId="a10c-1edf-196a-3870" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a227-9b62-c210-0c6d" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94b5-8d88-62f0-fb2a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="800d-c9ad-64f4-c9c8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9bee-9530-88dd-b26d" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="24d4-a90d-8b44-5faf" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f5-3668-1f1f-bc44" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ded-51fa-cf59-5f94" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e3db-6a3a-c7d8-42d1" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="115"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a445-675b-8835-ef5d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="3b80-5c93-ef70-9096" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="115"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65be-81ef-eaa6-abb2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="94b5-8d88-62f0-fb2a" name="Cave Goblin" hidden="false" collective="false" targetId="64d8-0040-c30f-c791" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="150"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baab-8538-5d3f-5f49" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="169c-7fe6-bc44-6bae" name="Mounts" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c12f-2539-f2af-3bc0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a4cb-a02a-d6c8-9417" name="Wolf" hidden="false" collective="false" targetId="ec59-310c-9734-1559" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="20"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b80-5c93-ef70-9096" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95de-4908-e27a-286d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e690-a63b-5bfb-dfab" name="Goblin Wolf Chariot" hidden="false" collective="false" targetId="03ee-790f-d976-662c" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="30"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b80-5c93-ef70-9096" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4f1-ff0b-decf-c419" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ff5a-c856-93d4-53c2" name="Scuttler​ ​Spider" hidden="false" collective="false" targetId="91b7-4e67-9d08-8ef4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="20"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e3db-6a3a-c7d8-42d1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c40-bc29-4217-dd32" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="4b98-25a3-b30b-2431" name="Gargantula" hidden="false" collective="false" targetId="0b2e-f21e-81e6-4153" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="24fd-8af8-0c78-001c" value="500"/>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e3db-6a3a-c7d8-42d1" type="equalTo"/>
+                        <condition field="selections" scope="72b8-5864-ab83-b1a0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="091e-f871-b0ee-08b9" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4ab-163f-8c89-cde4" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="2b03-a811-e5d3-baf8" name="Big &apos;n Nasty (local)" hidden="false" targetId="82d5-126d-e31a-aa94" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b2e1-df6b-f806-8e6f" name="Path of Magic" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="95d4-6e41-9fa3-3f46" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95d4-6e41-9fa3-3f46" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="176c-a60e-f72a-e48f" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="12cb-8bfd-d5a5-6718" name="Witchcraft" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c1e-749c-e0d8-b071" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5db0-e87b-dd86-3018" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf1-b765-68d0-bdb5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f77c-5cba-ccfa-4b9e" name="Thaumaturgy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d77e-1b7d-ebf7-f16c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="67b4-d146-489f-169b" name="Wizard Level" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3173-2f5b-58c5-06d0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="815b-feb6-ef79-e929" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ee78-2c56-490c-1de3" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="357f-5e9f-4440-8a54" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f392-3779-0e95-02dc" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="2e31-0b72-53ad-25ca" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aa16-0209-e6ad-7319" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aa0-e634-c6dd-7969" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="44e3-8ed7-cb36-9497" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="091e-f871-b0ee-08b9" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="557a-c633-ada5-827f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6a36-a0dc-98d1-12f5" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="245.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c02b-468b-1b79-1ee9" name="Orcs" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="a24b-9aaa-e4ab-5e5f" name="Orc Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="279d-20ec-96b8-8690" name="Feral Orc Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7757-e7b0-2a13-57ed" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fac3-e71d-1a7a-3f81" name="Common Orc Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59e7-df5c-714d-9583" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7fe6-73eb-a57c-a9de" name="Orc Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5460-fda1-65d1-6679" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="c02b-468b-1b79-1ee9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59e7-df5c-714d-9583" type="equalTo"/>
+                    <condition field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a113-bec3-a520-cc11" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="683d-b6d8-0e56-d1cf" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6807-6c06-ae25-0211" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="895c-bfa3-2a96-c619" name="Orc" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1f8-7c36-005f-0c7c" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f8-6064-d3bf-a645" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="11.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1a75-4feb-5840-a3bd" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c02b-468b-1b79-1ee9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ba6-d759-2f63-8dad" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ee28-97b5-c612-5672" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="00d1-7328-322d-76f2" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a113-bec3-a520-cc11" name="Heavy Armour and Crossbow (4+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="6">
+              <repeats>
+                <repeat field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="895c-bfa3-2a96-c619" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c02b-468b-1b79-1ee9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59e7-df5c-714d-9583" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9ee-fd7b-76ff-c2d2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="db6a-c0e8-7cf9-69fb" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="5c95-9460-d3bd-2ff9" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="790a-d79e-a937-927c" name="Mammoth Stabber" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c02b-468b-1b79-1ee9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7757-e7b0-2a13-57ed" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dd7-9b94-268b-fa35" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="135d-40cc-205c-0597" name="Mammoth​ ​Stabber" hidden="false" targetId="ab83-567a-7466-6d1f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4675-26d2-5419-d51b" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c98-503f-2112-a1a2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13bf-d81f-a091-97f3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7757-e7b0-2a13-57ed" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="895c-bfa3-2a96-c619" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42f8-f801-3dac-30f9" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="59e7-df5c-714d-9583" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0f9-7d20-cd91-305e" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d0c2-b52b-add9-453c" name="Equipment" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="a753-4f67-c5f5-0bac" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="895c-bfa3-2a96-c619" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a113-bec3-a520-cc11" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea04-9d8c-ce34-439f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6492-9ad3-9cb9-ac4e" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2fd0-d996-9097-578e" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="895c-bfa3-2a96-c619" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1730-cd23-fc03-ed0c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2016-f39b-f56f-f862" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ea93-f75f-41dd-5c3b" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="895c-bfa3-2a96-c619" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a113-bec3-a520-cc11" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="964a-98e9-0b99-f1ae" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b62e-0815-bcde-8eb5" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ba20-37f9-d216-443f" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="895c-bfa3-2a96-c619" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="c02b-468b-1b79-1ee9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a113-bec3-a520-cc11" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c4-e152-1abd-78f4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9583-33b4-f6eb-f6f8" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="03b2-225d-5e00-f2ee" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0e01-9f54-f641-eaf4" name="Orc &apos;Eadbashers" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5506-17e5-f10b-c1b9" name="Orc &apos;Eadbasher Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2f78-388c-4c7d-b2d7" name="Feral Orc &apos;Eadbasher Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="0e01-9f54-f641-eaf4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77c-a0a5-6a97-4c7a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="199a-b724-00fb-e863" name="Common Orc &apos;Eadbasher Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="0e01-9f54-f641-eaf4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c09-d6a9-d51f-99c6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0ba3-ad02-0cab-d9d8" name="Orc &apos;Eadbasher Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d876-bdd0-2ce6-5e95" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0e01-9f54-f641-eaf4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c09-d6a9-d51f-99c6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="22ee-96cd-ee1e-15ae" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b1f0-ecfb-abfb-8d8c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8145-9d5b-71e0-d6e7" name="Orc &apos;Eadbasher" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed5d-3387-8da5-3860" type="min"/>
+            <constraint field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fb-15fc-3ed8-e199" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d399-fbe5-2dbe-a336" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0e01-9f54-f641-eaf4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0150-84bd-0ae2-d09a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="244e-185d-f686-a341" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="00d1-7328-322d-76f2" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e6bc-5e1e-e5b9-ff8d" name="Mammoth Stabber" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="0e01-9f54-f641-eaf4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77c-a0a5-6a97-4c7a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="328a-be22-486a-7ca5" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="aa29-0100-0240-4846" name="Mammoth​ ​Stabber" hidden="false" targetId="ab83-567a-7466-6d1f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="179d-a294-6524-4795" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a82-0c9b-b734-a898" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="678c-7cf2-e75d-7bb0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a77c-a0a5-6a97-4c7a" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="0e01-9f54-f641-eaf4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8145-9d5b-71e0-d6e7" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dfc-92fe-13f6-d0e6" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8c09-d6a9-d51f-99c6" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35d7-817e-31ea-43b0" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c438-e09d-f8f9-a376" name="Equipment" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="6d14-9fa9-c67a-b9eb" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="0e01-9f54-f641-eaf4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8145-9d5b-71e0-d6e7" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d335-820f-6c4d-cad2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a909-b517-a6dc-3682" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fdb0-68e6-ea7e-9856" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="0e01-9f54-f641-eaf4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8145-9d5b-71e0-d6e7" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fe0-b026-fb31-4c91" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a26d-3148-cc6b-618b" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3480-92e4-746e-8b62" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0e01-9f54-f641-eaf4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8145-9d5b-71e0-d6e7" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8251-9061-0fbe-c205" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ebf5-63ea-8fb4-3c06" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3ec5-bc49-4fd4-9a2b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6759-0464-b8f4-19c2" name="Orc Boar Riders" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="082b-44c1-34d0-6707" name="Orc Boar Rider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f841-cf59-eb2b-503c" name="Feral Orc Boar Rider Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="6759-0464-b8f4-19c2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a47e-c4a7-2496-1a5f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="83db-63cc-3d4d-3857" name="Common Orc Boar Rider Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="6759-0464-b8f4-19c2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3669-8226-cbae-87fa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0ebe-920e-6e74-b91c" name="Orc Boar Rider Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="33ec-dbd4-8ef4-c927" name="War Boar Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f75f-631a-1fc9-2a35" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="6759-0464-b8f4-19c2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3669-8226-cbae-87fa" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bea4-9286-a38b-8546" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5745-47a9-d01b-408d" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bbc2-1f5b-6fdc-5211" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="e42d-7491-cb70-e69d" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6759-0464-b8f4-19c2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a47e-c4a7-2496-1a5f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7a49-d7d1-c820-6537" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3e26-4051-362f-0dff" name="Orc Boar Rider" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e67a-20cf-ac01-0dc9" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dba-5d68-8847-af0c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f76b-c9c9-8a48-a655" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6759-0464-b8f4-19c2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0452-8777-39a2-7224" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6854-f8f3-d2e6-4287" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="00d1-7328-322d-76f2" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fb43-e9f0-ebe9-b781" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="6759-0464-b8f4-19c2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e26-4051-362f-0dff" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee9-fb8b-cc18-0c56" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6991-3830-4474-509b" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1305-8dce-da8b-5896" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="6759-0464-b8f4-19c2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e26-4051-362f-0dff" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6759-0464-b8f4-19c2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a47e-c4a7-2496-1a5f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2af6-3426-858f-10af" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ed04-fb20-652c-f815" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="52cc-2e0d-072d-ead2" name="Lance" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="6759-0464-b8f4-19c2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e26-4051-362f-0dff" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6759-0464-b8f4-19c2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3669-8226-cbae-87fa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="924c-dbc5-f49f-ef0c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f9bd-7bb8-2c9c-e1fb" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="37ac-80a8-8b01-869e" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f37-33c9-3586-38e1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cda-8c16-9243-5c61" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a47e-c4a7-2496-1a5f" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d65-6bda-8fce-2a8b" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="3669-8226-cbae-87fa" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3733-2e80-0767-b577" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4035-46e3-fbc3-9847" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="89db-5db2-624a-72ed" name="Goblins" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c01e-1857-4042-3e30" name="Goblin Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e3af-9575-ad01-03a5" name="Common Goblin Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9bc0-8411-e6ce-286e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fcfb-acd2-0d40-a375" name="Common Goblin Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="752b-75e3-bdf2-9368" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dcfc-86d7-9df4-8c5f" name="Common Goblin Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="752b-75e3-bdf2-9368" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f373-45a3-09da-55c6" name="Forest Goblin Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bd90-4a88-a1b2-1be2" name="Forest Goblin Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ae1e-1d96-783d-42c3" name="Cave Goblin Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9bc0-8411-e6ce-286e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3a64-39a5-997b-0cea" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="752b-75e3-bdf2-9368" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9d18-0abb-efe1-5ad7" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ee17-a75f-fe69-d0b1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ec7a-f876-a817-4cb8" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e468-011a-3594-8612" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0503-98a0-3f1f-3e10" name="Goblin" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="66ba-e7d0-1665-67ec" value="20">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ee17-a75f-fe69-d0b1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e169-0b51-a47c-c44f" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66ba-e7d0-1665-67ec" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="6.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="84bd-ffd4-277b-3a1e" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="20fe-0488-6c86-7bab" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a42d-daef-78fa-56f9" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="00d1-7328-322d-76f2" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d7a8-0f79-6b3a-dc8a" name="Shield" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="752b-75e3-bdf2-9368" type="equalTo"/>
+                    <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f92-061c-0d6f-393c" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ab0-f8e6-3718-b3e1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7cc7-5521-f29c-6802" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="53da-13db-c303-900f" name="Shady Git" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="752b-75e3-bdf2-9368" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="e20f-31b5-6f8a-bb17" value="3">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e20f-31b5-6f8a-bb17" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4204-fed7-90a6-d934" name="Shady Git Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="15db-22f7-5fa3-848b" name="Shady Git Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4b7b-d1c4-ad2f-5a55" name="Shady Git Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e03a-711b-09dc-6070" name="Sneaky" hidden="false">
+              <description>The model gains +3 Agility and Lightning Reflexes in the first Round of Combat. Shady Gits are deployed in the unit that purchased them and are Champions, except they do not gain First Among Equals or Order the Charge.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="8404-04e0-f796-d1e9" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+            <infoLink id="9eb7-df98-c983-d054" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+            <infoLink id="cd40-f326-e05e-d8a2" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6fdf-b01a-bc6d-deb3" name="Nets" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9bc0-8411-e6ce-286e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e8b-179c-7cdc-b7e5" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0103-168b-68e3-bf1b" name="Nets" hidden="false" targetId="b6ae-e591-efec-e156" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="902a-e212-9694-1caa" name="Mad Git" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9bc0-8411-e6ce-286e" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="ef08-0486-664b-0353" value="2">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" type="atLeast"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="ef08-0486-664b-0353" value="3">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="45.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef08-0486-664b-0353" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c976-0dcf-75a4-a581" name="Mad Git Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2D6</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a61b-6d88-9484-427d" name="Mad Git Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">0</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f6eb-07bf-5f91-67c8" name="Mad Git Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">0</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="369e-41f4-ad57-e68e" name="Surprise" hidden="false">
+              <description>A Mad Git is not deployed. Instead it is said to be concealed inside the unit that purchased it. It is a unit upgrade, and as such is ignored when calculating Victory Points (its points are already included in the Goblin unit concealing it, and Victory Points are awarded for destroying the unit concealing it). Until released and moved out of its unit, a Mad Git cannot be harmed or otherwise affected, or affect the game in any way. When a Mad Git is removed as a casualty, it does not cause Panic Tests. It still moves, acts, and is influenced by all rules independently like a normal unit (once released) and does not count towards the model count of the unit concealing it.
+
+Mad Gits can be released in two ways:
+Mad Gits may be released when their unit is declaring a Stand and Shoot Charge Reaction with a Shooting Weapon (the unit still shoots as normal). If the unit does not have any Shooting Weapons, it may declare a Stand and Shoot Charge Reaction with Mad Gits. If so, all Mad Gits in the unit must be released.​
+At the start of owning player’s Shooting Phase, if a unit with one or more concealed Mad Gits is not Engaged in Combat, not Fleeing, and is within 8&quot; of an enemy unit, it must immediately release all its Mad Gits.
+Resolve released Mad Gits one at a time. Place the released Mad Git just outside of base contact with the concealing unit and choose a direction to move the Mad Git in (ignore the Mad Git’s Running Amok!!). This cannot be a direction that can potentially bring the released Mad Git into contact with its concealing unit. When releasing it move it using the Shambolic rules in the chosen direction. During this move, rolling the same result does not cause the Mad Git to lose D3 Health Points or move in a random direction. </description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="673b-1718-c007-753d" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+            <infoLink id="402b-1f3a-79b8-125d" name="Shambolic" hidden="false" targetId="24b3-4352-5103-4c13" type="rule"/>
+            <infoLink id="6cd5-5f92-7770-f96f" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (2D6)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="85dc-e1be-3ab0-b3cc" name="Ricochet​ ​(X)" hidden="false" targetId="b032-48af-073c-1d3e" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Ricochet (D6)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="c87d-87cd-8b99-cedb" name="Running​ ​Amok!!" hidden="false" targetId="0626-c5ce-f60c-8000" type="rule"/>
+            <infoLink id="1dfe-e8ba-87e6-7a6d" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1bbc-cb79-ea19-b3d7" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aa4-b3d9-5206-74d4" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="995a-9d80-8adf-1230" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (5+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee17-a75f-fe69-d0b1" name="Gain Skirmisher and lose Scoring " hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8540-269b-749f-094e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="41a1-f881-9ecd-0cf1" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c862-910b-55d3-3159" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae9-f76b-15a8-f595" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="218f-d1e5-bf1c-5a27" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="010a-3167-8093-7fee" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f18d-346e-b989-80e4" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9bc0-8411-e6ce-286e" name="Cave Goblin" hidden="false" collective="false" targetId="64d8-0040-c30f-c791" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ff-93dc-a027-9eb1" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="752b-75e3-bdf2-9368" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1585-42e1-4f26-7022" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1a1b-a0d8-e9d3-620d" name="Equipment" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39b7-7cb6-9d11-0ae5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e5c4-b4d6-451a-6267" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd30-7703-35a4-f675" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1027-9ca6-2227-9248" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8f92-061c-0d6f-393c" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c58f-1952-2fab-69fe" type="max"/>
+                <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf31-a518-005e-f796" type="max"/>
+                <constraint field="24fd-8af8-0c78-001c" scope="roster" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e41b-0243-ff3f-0eed" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7ed1-323d-71c1-f100" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d7b2-6898-62f2-aee6" name="Spear and Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions>
+                    <condition field="selections" scope="89db-5db2-624a-72ed" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0503-98a0-3f1f-3e10" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions>
+                    <condition field="selections" scope="89db-5db2-624a-72ed" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="010a-3167-8093-7fee" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3536-4c1d-9d9d-5314" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ba73-b4f3-6412-f3c1" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+                <infoLink id="ff6f-f83c-b7e3-8b45" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="186a-dd59-f78e-7911" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7eb2-62d6-598b-1786" name="Iron Orcs" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="1465-4081-bf2c-8378" name="Iron Orc Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="00bc-05bb-0735-a674" name="Iron Orc Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7924-98a2-a424-0f9d" name="Iron Orc Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="11fb-8ea7-b3be-239d" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+        <infoLink id="5064-2f30-c05d-a0af" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="c90e-b13f-4475-9a0a" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Iron Orc Warlord, Iron Orc Chief)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2b83-dbd0-f9ec-62f4" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="9b14-26b1-0623-7afd" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="eede-1356-2478-1749" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b7ad-8c1d-1114-eef2" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8d26-6383-cc99-eac3" name="Iron Orc" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ae-48c4-ce06-0fe8" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5adc-da8b-0b14-df63" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="27.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dcd3-0d6c-7bb1-b42a" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="7eb2-62d6-598b-1786" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88c8-5470-ff8c-eac6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3fb7-08e7-8281-e626" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="00d1-7328-322d-76f2" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="098a-8068-62ca-127b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="88b6-c1e6-775f-3835" name="Iron Orc" hidden="false" collective="false" targetId="989b-3f4f-b070-0b7a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c97-5afe-a963-e775" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c24-ba90-e599-22e5" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="5a67-66c6-7959-e315" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-110.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d159-40d7-da92-3925" name="Orc Boar Chariot" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1f0-1711-c920-2a91" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6fa8-a86c-64cd-fba5" name="Orc Boar Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0188-5ff9-b250-6d47" name="Orc Boar Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="27fb-0d76-dfdc-19a6" name="War Boar (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="35f2-fa6a-d1c5-b35f" name="&apos;Eadbasher (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="25de-ab30-942e-805e" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8e40-e2ba-ee59-e599" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f95b-d7b2-398f-f37c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="5807-102b-35fc-109a" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="9453-ef2a-5b65-acc6" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="764f-9335-c418-1166" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="e637-e584-e6e1-4d12" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bf01-4db9-7260-b893" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6139-b5fa-5616-aa23" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ab4f-5886-600f-dee0" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24ba-97c8-fe3f-dcf1" name="Mounted ‘Eadbashers" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="17a6-3935-ecea-b2a7" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="37f5-999e-7710-42fd" name="Mounted ‘Eadbasher Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a837-ca88-9687-5223" name="Feral Mounted ‘Eadbasher Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a78f-059a-3f5b-ea27" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9350-8e34-937d-1b19" name="Common Mounted ‘Eadbasher Defensive" hidden="true" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a3d-d902-02f5-fa4f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="275b-f787-f75d-7f4a" name="Mounted ‘Eadbasher Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d95d-5aa2-c704-7ec9" name="War Boar Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0ddf-4100-3ea0-7c1d" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a3d-d902-02f5-fa4f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9717-2d50-ef50-b846" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="bd0f-2090-2e03-2700" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8f96-af89-d99a-1ff9" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="99b3-4372-dd14-764a" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a78f-059a-3f5b-ea27" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5c47-04a1-c823-40eb" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d97e-42ab-ddb0-8d2e" name="Mounted ‘Eadbasher" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee2a-6d88-b64a-7c5c" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df1a-11fb-3836-3655" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e67a-b056-0d53-dcf6" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1f1-1fd5-f208-8faa" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="38af-da5e-5fba-ba7f" name="Banner Enchantments" hidden="false" collective="false" targetId="9272-ebfe-87bc-fd62" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="00d1-7328-322d-76f2" value="1"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a7cf-053d-7433-fad3" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="24ba-97c8-fe3f-dcf1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97e-42ab-ddb0-8d2e" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c93-da76-4a6d-f361" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cc45-8562-b1ef-8a6b" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dda2-6c99-bb59-1cde" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="24ba-97c8-fe3f-dcf1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97e-42ab-ddb0-8d2e" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a78f-059a-3f5b-ea27" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f4f-e512-fd8a-3a90" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="eec0-6590-9ea8-9503" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="08a5-79c2-7ba8-6d5a" name="Lance" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="24ba-97c8-fe3f-dcf1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97e-42ab-ddb0-8d2e" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="24ba-97c8-fe3f-dcf1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6a3d-d902-02f5-fa4f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3e9-fbb7-b658-9aa5" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="55cf-744a-f105-c853" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4174-0058-8fa4-2658" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd3e-8647-a24f-e3e2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82f7-0d66-17bf-9df8" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="e58a-4510-9309-e5ad" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="a78f-059a-3f5b-ea27" name="Feral Orc" hidden="false" collective="false" targetId="6e95-55c3-41f3-eb46" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da3e-1fa7-3326-06e6" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6a3d-d902-02f5-fa4f" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="24ba-97c8-fe3f-dcf1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97e-42ab-ddb0-8d2e" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf1e-e035-a750-2c1e" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a815-3b3b-b56c-87fa" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="18b1-f44c-2247-7a7e" name="Goblin Raiders" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="decrement" field="3f14-01c6-3450-7d4e" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="2196-feb7-ba21-3c2c" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f14-01c6-3450-7d4e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d84d-bb99-19d7-40ca" name="Common Goblin Raider Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="260b-ac4e-0d79-5e6d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b5c1-42f2-e5f7-53da" name="Goblin Raider Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b105-3a70-b0e2-1227" name="Goblin Raider Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="08e9-f22a-7f3c-3bbe" name="Wolf Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="260b-ac4e-0d79-5e6d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2ff7-5ed1-c8e7-4fa2" name="Forest Goblin Raider Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5419-2def-e68c-b650" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d48c-7170-635a-d3a9" name="Scuttler Spider Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5419-2def-e68c-b650" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f5d1-edb3-b644-9ffd" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="260b-ac4e-0d79-5e6d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7c64-213b-8618-5e45" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="65be-c5f5-cb0d-b1d5" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="e044-6a2b-2dfd-2480" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="905e-d381-445b-6909" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5419-2def-e68c-b650" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="281b-e896-ed38-88eb" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="a2ee-0e6a-b366-db38" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5419-2def-e68c-b650" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f1c8-27d6-4b9d-fb54" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="18b1-f44c-2247-7a7e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5419-2def-e68c-b650" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5fb0-636e-9c66-ad35" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b9d7-d709-ceb3-6cbd" name="Goblin Raider" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e648-d0d5-042d-16cd" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5679-0de4-d0b6-bcfd" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="13.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fbc5-48a9-1786-cd3a" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea2-9045-fef8-fbf0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ab4-005e-75da-b4f0" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="f190-9b66-2c78-1e72" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="5419-2def-e68c-b650" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a1c-abcc-c921-91bd" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="260b-ac4e-0d79-5e6d" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a33-86d9-966a-2e7a" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0207-04ce-fa46-a1a2" name="Equipment" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="ce9a-2995-5db9-ce07" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9d7-d709-ceb3-6cbd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1255-44ca-76a9-f32e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4c37-a912-88b2-f476" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="417d-dcb2-2184-d7c4" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9d7-d709-ceb3-6cbd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e275-40e0-af7f-10fc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="92de-264a-b761-0f95" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e021-a2ba-968e-8389" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9d7-d709-ceb3-6cbd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42db-7b26-405d-662c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5a75-c56d-031a-f06b" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f2cf-d602-4de7-60e5" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="18b1-f44c-2247-7a7e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9d7-d709-ceb3-6cbd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="18b1-f44c-2247-7a7e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5419-2def-e68c-b650" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcac-d544-056b-df4b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="907b-319b-a487-a47e" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3b7c-0c11-9793-1b5c" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2196-feb7-ba21-3c2c" name="Goblin Raiders (Core)" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="decrement" field="96a5-4d2d-c054-f094" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="18b1-f44c-2247-7a7e" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="96a5-4d2d-c054-f094" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b90a-5739-2efa-f9c5" name="Common Goblin Raider Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f915-de07-cc7f-cf7b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0756-fbd7-5d33-9e39" name="Goblin Raider Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cb59-262d-842d-1dad" name="Goblin Raider Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4972-ed9c-3b79-7c95" name="Wolf Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8800-31c9-47cd-928b" name="Forest Goblin Raider Global" hidden="true" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0a25-ff9a-cbdc-92ac" name="Scuttler Spider Offensive" hidden="true" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ef42-58d7-e62d-37ff" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f915-de07-cc7f-cf7b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b290-4a08-9e1e-4433" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="db4c-652d-09d5-383c" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="de45-1f23-c7aa-d70e" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="fd89-3797-66dd-4b11" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0b34-fd0a-0c31-bd1e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="eb48-5930-36ff-9a2f" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4193-25f5-69a8-2a1f" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="2196-feb7-ba21-3c2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9393-1d31-39f1-ada5" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="468e-33d3-72b9-eb3b" name="Goblin Raider" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="921b-3967-5af1-5078" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f07f-4ce7-1a89-0090" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="13.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d959-22cd-8697-553c" name="Greenhide Race" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93b4-4d8b-4f2e-d518" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5faf-0283-5755-4310" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e13a-fec2-4dd6-264f" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d165-2a00-1027-67ef" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f915-de07-cc7f-cf7b" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9874-e940-27f3-c109" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="295e-6421-d7aa-b54c" name="Equipment" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="8454-53a9-8f45-fd92" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="468e-33d3-72b9-eb3b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f52-ea34-d2e5-5358" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="75fa-3949-6d44-58fc" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="763d-09d1-59bb-80eb" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="468e-33d3-72b9-eb3b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63ca-2222-7c76-54da" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9bc0-db3e-3393-1086" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3dc0-e421-338e-7b19" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="468e-33d3-72b9-eb3b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3a0-de03-496f-2801" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5761-c7f0-c23b-c64e" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9669-f6fa-b842-b6de" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="2196-feb7-ba21-3c2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="468e-33d3-72b9-eb3b" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="2196-feb7-ba21-3c2c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e13a-fec2-4dd6-264f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e6d-f4c0-7ee2-fd80" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2bc8-85bb-d412-4e44" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d570-6fe3-53ad-fddc" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa1b-2229-3302-27e3" name="Goblin Wolf Chariot" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e5f-0fcf-0615-9355" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6ef6-2ebe-2925-1709" name="Goblin Wolf Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6923-4575-bcec-39d7" name="Goblin Wolf Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a728-7904-92af-15ad" name="Wolf (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d414-6c9d-8158-f14b" name="Goblin (3) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="69cc-65ad-3518-1ecd" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c521-1164-eb4b-6c7f" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="63f4-d0a1-32dd-1090" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="a3cb-9712-02f4-3c57" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="8a5c-bd96-095b-0363" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="430b-e01e-fa97-d267" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="2ffb-cf6f-4bf6-02c4" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1a57-6f84-d927-5974" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f1fd-63d7-5504-75c4" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fbe8-e83d-6403-96dc" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="82d9-8348-7b41-98e5" name="Goblin Wolf Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fb1-4056-cdd5-7452" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff3-a59f-333a-d430" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8650-7cb0-7d00-2a94" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e7-8131-0675-ca33" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00d0-4f24-21e3-96f7" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3a66-2fe7-8f3b-5652" name="Gnasher Dashers" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="74c7-80a5-647e-2cff" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="49ff-0732-de13-9fec" name="Gnasher Dasher Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 5&quot;, Fly 6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 10&quot;, Fly 12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="02ab-b3d8-9c57-c863" name="Gnasher Dasher Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="22fe-c6fe-e24d-829d" name="Goblin Rider Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4b37-b538-ce18-574a" name="Gnasher Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="20d5-4c84-13b1-57c4" name="Rows of Teeth" hidden="false">
+          <description>Gnashers can make Supporting Attacks even though they have Harnessed. Their goblin riders cannot make Supporting Attacks. 
+Gnasher Dashers gain Impact Hits with the following exception from the normal rules: instead of causing a number of hits per charging Gnasher Dasher model, a charging Gnasher Dasher unit causes D3 hits for each 5 Gnasher Dashers in the unit, rounding fractions up, to a single enemy unit in base contact with the unit’s Front Facing (for example, a unit of 1 to 5 Gnashers Dashers would inflict D3 Impact Hits, while a unit of 6 to 10 Gnasher Dashers would inflict 2D3 Impact Hits).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3ad8-e41d-55a7-0e6a" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="c020-e161-4e1d-a2eb" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="920e-e90e-c12f-2272" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="5812-4b26-1960-78b6" name="Oi it bites!" hidden="false" targetId="9a66-5dc3-9d5a-3404" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="775a-25aa-a770-d1a0" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b8ff-8daf-e20c-5d5e" name="Gnasher Dasher" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ddf-d530-b8ed-7b4b" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b91f-507e-b89b-11dd" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="61a1-09a9-faab-3c4e" name="Cave Goblin" hidden="false" collective="false" targetId="64d8-0040-c30f-c791" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6faa-9dec-b0b5-cb1e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3bf-063b-9a1b-6bd3" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7059-ba1f-b409-6b89" name="Gnasher Herd" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4321-142a-1241-d221" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="cdb5-8bc7-bce3-a914" name="Gnasher Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8779-f284-084b-d8bb" name="Gnasher Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="82d5-3c34-6664-3364" name="Gnasher Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="52df-5947-f79c-e927" name="They’re Everywhere!" hidden="false">
+          <description>When a Gnasher Herd Breaks from combat, it is immediately removed as a casualty, and all units within 6’’ suffer 1 hit for every 5 Gnashers in the Gnasher Herd, rounding fractions down. Hits are resolved with Strength 5 and Armour Penetration 2.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="be95-ea55-cc56-d279" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="cdc1-de25-b7a6-e203" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="0780-207a-ff0f-4a5d" name="Oi it bites!" hidden="false" targetId="9a66-5dc3-9d5a-3404" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="475f-393e-348f-e368" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="98c2-54a7-199b-6cd4" name="Gnasher" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6119-92e2-233b-0f40" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61e5-5fb0-4ac3-1e28" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c9f2-d177-a316-c27b" name="Gnasher Wrecking Team" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2876-6306-8c1c-676e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0448-3ba0-850e-7d8a" name="Gnasher Wrecking Team Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3D6</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">3</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="535c-298c-ef2f-6155" name="Gnasher Wrecking Team Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">0</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8b5f-7149-d597-ba74" name="Gnasher Wrecking Team Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">0</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5f30-56aa-c3ce-c5fa" name="Look At ‘Em Go!" hidden="false">
+          <description>After contacting a unit for the first time, a Gnasher Wrecking Team gains Running Amok!! for the remainder of the game.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="aa58-0b9c-a69b-4eb5" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="c421-69f9-b8d5-9623" name="Shambolic" hidden="false" targetId="24b3-4352-5103-4c13" type="rule"/>
+        <infoLink id="0db5-cdc4-0f51-6986" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="76d7-55b4-39e8-ee37" name="Ricochet​ ​(X)" hidden="false" targetId="b032-48af-073c-1d3e" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Ricochet (2D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a0d4-86ec-46a2-a8b6" name="Running​ ​Amok!!" hidden="false" targetId="0626-c5ce-f60c-8000" type="rule"/>
+        <infoLink id="9c89-88ab-38d1-f3d3" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="167d-76be-9f81-221d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="140.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24dd-e102-939c-386e" name="Trolls" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89e3-8924-8619-d2c1" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d202-4018-5bde-c67d" name="Troll Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d80c-5ded-255b-9ea5" name="Troll Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="597b-8735-3dd1-0e70" value="3">
+              <conditions>
+                <condition field="selections" scope="24dd-e102-939c-386e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="89db-ac08-1cbf-adc2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3127-ca6f-f75f-de1e" name="Troll Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f8b8-928a-b48f-ce97" name="Stupid" hidden="false">
+          <description>At the start of each friendly Player Turn, each unengaged non-fleeing unit with one or more models with Stupid must take a Discipline Test. If the test is failed, all models in the unit become Shaken until the end of the Player Turn, and in the Movement Phase, directly after Rallying Fleeing units, the unit must move D6&quot; directly forward, stopping 1&quot; before Impassible Terrain or other units.</description>
+        </rule>
+        <rule id="9889-e980-00c2-b79f" name="Troll Belch" hidden="false">
+          <description>Special Attack.
+At the model part’s Initiative Step, it may choose to not perform its Close Combat Attacks and instead choose an enemy unit that the attacking model would be able to attack with Close Combat Attacks. This unit suffers a hit, which is resolved with Strength 5 and Armour Penetration 10.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6c3f-81d0-9d51-40dc" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="379c-f66a-033e-227b" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9b57-4e3d-aafa-9499" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="42ad-851a-6497-5133" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="55eb-a8d4-6501-f4a6" name="Troll" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9617-5821-1fc3-fae1" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="408e-0889-3528-a26c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1694-6b3a-e9f1-ca5f" name="Troll Race" hidden="false" collective="false" defaultSelectionEntryId="a047-3e4f-86cb-25ad">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f490-a321-2685-0a5c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ccb-06b0-d4d7-6dfa" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a047-3e4f-86cb-25ad" name="Common Troll" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eede-46ef-e2f1-31b5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="89db-ac08-1cbf-adc2" name="Cave Troll" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="14">
+                  <repeats>
+                    <repeat field="selections" scope="24dd-e102-939c-386e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="55eb-a8d4-6501-f4a6" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="016c-18fd-2cd7-74e9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6d1f-17d8-3a4a-f292" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="74a3-b2c5-e70a-bb1c" name="Bridge Troll" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="9">
+                  <repeats>
+                    <repeat field="selections" scope="24dd-e102-939c-386e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="55eb-a8d4-6501-f4a6" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd98-c593-10ee-2fd3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="003d-13ba-bd54-b2ab" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+                <infoLink id="a28f-d5ec-9a93-d2c3" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (Water)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b0cd-a1e3-fcce-a961" name="Grotlings" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba1f-1116-dbeb-146e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="57a2-8b34-81a9-7833" name="Grotling Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fc09-f603-e3eb-a0c5" name="Grotling Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bdaa-07aa-91e1-313c" name="Grotling Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a0e1-7f27-e836-ea99" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="2f6c-76b8-33b4-361f" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5a75-65e9-0ed4-2751" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="c5f0-3ff7-1fab-44a8" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="d02c-25b2-f459-fc59" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="029d-54a1-4c6a-a03e" name="Unstable" hidden="false" targetId="b642-5b33-158d-421b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1d34-096b-5a3a-7aac" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7bd9-7327-6a5a-8cb1" name="Grotling" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49c2-6092-ad4e-a326" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae74-e36e-a4ef-c925" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a2a-9b48-b7a5-6779" name="Scrap Wagon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="72c2-4362-1fb6-c79d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b84e-b548-4213-729c" name="Scrap Wagon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3D6</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b1a8-bec0-8748-6610" name="Scrap Wagon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7194-0f87-5ba2-3d83" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="202b-4b20-2dff-f415" name="Grotling Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="47ee-2504-ab15-1f56" name="Pursuit Mode" hidden="false">
+          <description>The roll for the distance moved with Random Movement in the Movement Phase is subject to Maximised Roll (consider only the used 3 dice for the purpose of Shambolic).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ebec-d78c-f498-6702" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="d24a-b6cf-99cf-adc0" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="10f2-58fc-bcfc-c6e1" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="bab6-8c52-8984-44a6" name="Shambolic" hidden="false" targetId="24b3-4352-5103-4c13" type="rule"/>
+        <infoLink id="d978-2611-bfd8-59cf" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fc47-6983-f6c3-aec4" name="Unstable" hidden="false" targetId="b642-5b33-158d-421b" type="rule"/>
+        <infoLink id="72e4-1958-b3b6-8947" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="4307-b4cf-e9b5-d66d" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="41d2-0676-a5a4-44a6" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7a12-e5e7-bf8c-8c80" name="Skewerer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d62-251d-3214-9061" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fdf2-7860-5c7c-7597" name="Skewerer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e688-2ff4-1915-5fa4" name="Skewerer Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bc95-8531-858c-ec15" name="Goblin Crew Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="40dd-1774-2ae7-f748" name="Ballista (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3[6]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Bolt Thrower. [Multiple Wounds (D3)]</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="06e0-b956-6182-8194" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="c564-0808-53c1-0564" name="Shambolic" hidden="false" targetId="24b3-4352-5103-4c13" type="rule"/>
+        <infoLink id="e128-d601-be46-26f3" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="1e2d-c9d7-b3bb-3705" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a70f-2033-36b2-ad2e" name="New CategoryLink" hidden="false" targetId="213d-78ab-6a2f-1664" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2d84-aaa9-43fb-dd6b" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac2-118f-51d5-5db6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac18-9172-9feb-7744" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9a2c-536e-8563-7088" name="Greenhide Catapults" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b6c-fd43-ec65-61df" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="1a73-aaee-782a-6371" name="Greenhide Catapult Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="be28-67a6-2280-9eaf" value="7">
+              <conditions>
+                <condition field="selections" scope="9a2c-536e-8563-7088" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97ea-59c6-77ff-cccb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="2e17-9c12-bfb4-59b0" value="Large">
+              <conditions>
+                <condition field="selections" scope="9a2c-536e-8563-7088" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97ea-59c6-77ff-cccb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d07e-7a4f-e53f-d50d" name="Greenhide Catapult Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="6">
+              <conditions>
+                <condition field="selections" scope="9a2c-536e-8563-7088" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97ea-59c6-77ff-cccb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2481-3bf6-14c6-b7a4" name="Goblin Crew Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2525-ae9b-45a3-9dba" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="9a2c-536e-8563-7088" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97ea-59c6-77ff-cccb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9b21-03d1-a37e-bf4d" name="Shambolic" hidden="false" targetId="24b3-4352-5103-4c13" type="rule"/>
+        <infoLink id="7b83-5583-4c2b-8d21" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="15c2-d015-ac78-0c06" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="356b-3fb2-9b35-21d6" name="New CategoryLink" hidden="false" targetId="213d-78ab-6a2f-1664" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="97ea-59c6-77ff-cccb" name="Orc Overseer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b402-b068-4236-e7b1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="827b-db85-45f1-e100" name="Orc Overseer" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c0c6-d3a1-6147-bdea" name="Orc Overseer" hidden="false">
+              <description>When the Greenhide Catapult rolls on the Misfire Table, it may choose to lose 1 Health Point in order to reroll the dice.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="70c9-9e24-56c1-8c97" name="Artillery Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f80-0ec1-e46b-8e96" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af37-f06b-b7bd-06d9" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f6f6-3b2f-4c8a-f5e0" name="Git Launcher (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2b5-aa71-ba19-25c4" type="max"/>
+                <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f095-a8e8-eda4-1683" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="bbee-d12a-c4ca-3111" name="Git Launcher (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;-60&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">4</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult. This weapon follows the rules for Catapult Artillery Weapons with the following exceptions: if the weapon hits (including with a Partial Hit), instead of causing a hit with Area Attack, the unit suffers D3+1 hits with the weapon’s profile. In case of a Partial Hit, neither the number of hits nor their Strength and Armour Penetration are reduced.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="185.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8e43-f816-fa9a-aa5b" name="Splatterer (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="302e-3089-da62-3f67" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fd62-ab60-f814-8d50" name="Splatterer (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;-60&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3[7]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0[4]</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (4). [Multiple Wounds (D3, Clipped Wings)].</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d89a-37bd-8192-c5bf" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4006-f95b-94c2-1506" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5513-5891-9fd9-b081" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd77-83fc-3821-a549" name="Gargantula" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="a399-d999-1fba-ccc6" value="1">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b2e-f21e-81e6-4153" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a399-d999-1fba-ccc6" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="53db-8fa7-5ab9-0aae" name="Gargantula Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5a09-3cf9-8469-03fc" name="Gargantula Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">8</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="199a-76f9-61d0-7c63" name="Gargantula Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8217-29eb-1c85-a7ba" name="Goblin (8)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="14c9-f1d1-5d03-bcef" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="bcb2-789b-98e2-9301" name="Venomous​ ​Fangs" hidden="false" targetId="78ae-7dd6-cae5-0ff5" type="rule"/>
+        <infoLink id="af29-f71c-d453-31b5" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule"/>
+        <infoLink id="0bf5-4427-fb9b-5977" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="05a4-c8eb-b5ef-d219" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="9f4a-bc2a-9207-f538" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="6cdd-77cc-7fee-fffc" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="7718-ab39-705d-86bf" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ed8b-830e-bccc-a5d5" name="New CategoryLink" hidden="false" targetId="82d5-126d-e31a-aa94" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3c73-03a4-2d92-c211" name="Web Launcher" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="383a-c3a8-ba03-62f6" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3fbc-034a-84da-d92f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0bda-ebe2-b8fc-10ab" name="Web Launcher (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">6&quot;-36&quot;</characteristic>
+                <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+                <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+                <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (4). All models in a unit that is hit by one or more Web Launchers are considered Stuck until the end of the next Player Turn. Stuck models suffer -D3* Agility. In addition, they treat Dangerous Terrain (1) as Dangerous Terrain (2), and all terrain (including Open Terrain) that normally would not be Dangerous Terrain for them as Dangerous Terrain (1). *Roll a single D3 directly when hitting with the weapon and apply the result to all models in the unit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="9baf-c2c8-6ce9-1b1a" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95c1-e15c-2296-1647" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38f6-3d29-9115-935f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="510.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4618-2909-c145-1a55" name="Great Green Idol" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ff8-6dd3-4905-49fe" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6d89-5287-5c6a-8e97" name="Great Green Idol Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a306-e4ad-0377-9fa9" name="Great Green Idol Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">8</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c36d-2c0f-c64e-66b6" name="Great Green Idol Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1614-9408-bf93-d19f" name="Smash ‘Em Flat" hidden="false">
+          <description>Melee Attacks from units within 6&quot; of a friendly Great Green Idol must reroll natural to-wound rolls of ‘1’.
+Break Tests taken by units within 6” of one or more friendly Engaged Great Green Idols are subject to Minimised Roll.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="5169-9b1a-cd8b-cc2d" name="Crush Attack" hidden="false" targetId="9371-5924-2a39-1652" type="rule"/>
+        <infoLink id="0006-2a12-3db8-e214" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="ccbd-6691-daa7-04ca" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
+        <infoLink id="08d9-66f6-9387-aa61" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="34c8-da10-7463-0343" name="New CategoryLink" hidden="false" targetId="82d5-126d-e31a-aa94" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d60d-bf08-82b5-79da" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="611e-b0c6-5d49-d293" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7188-c1ca-5575-7166" name="Battle Standard Bearer" hidden="false" collective="false" targetId="3dd9-3347-6a48-cb77" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="365.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2926-86d3-f605-c0f3" name="Giant" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a087-f608-c962-ff3e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5304-1281-04e1-1be4" name="Giant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fe92-627a-fdc3-b659" name="Giant Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="f381-7850-7fa8-3440" value="8">
+              <conditions>
+                <condition field="selections" scope="2926-86d3-f605-c0f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="009d-b5d4-2b93-4394" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="826b-46dc-92d7-0813" name="Giant Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="c65d-7a6d-8edf-3f2f" name="Giant See, Giant Do" hidden="false">
+          <description>The model gains Born to Fight.</description>
+        </rule>
+        <rule id="9fc0-47fb-7d88-6066" name="Rage" hidden="false">
+          <description>Whenever the model loses a Health Point, it gains +1 Attack Value. Whenever it gains a Health Point, it suffers -1 Attack Value.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="cb8b-f932-5f23-288b" name="New CategoryLink" hidden="false" targetId="82d5-126d-e31a-aa94" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="009d-b5d4-2b93-4394" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b97f-0dde-9729-35fa" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="4b26-5492-4458-4607" name="Big Brother" hidden="false">
+              <description>The model&apos;s Health Points are set to 8, and its base size is changed to 75x100mm.
+The roll for the number of hits from its Stomp Attacks is subject to Maximised Roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f2a5-b162-b70b-e081" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4d6-97e1-f4a4-5c8a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="81fc-9106-48c1-2fd6" name="Giant Club" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8eb0-e77d-4930-8fac" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8cd2-d632-21a4-1851" name="Giant Club" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="13ba-98fe-a48b-0cff" name="Nets" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f9-0c96-50cb-f303" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6bdb-1c32-52cc-af8a" name="Nets" hidden="false" targetId="b6ae-e591-efec-e156" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="56d4-73c0-af41-66fe" name="Wrecking Ball" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3262-aec7-2bb6-c224" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="1a12-5e63-1998-c7d4" name="Wrecking Ball" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+                  <characteristics>
+                    <characteristic name="Str" typeId="7d4e-b182-dd11-52a0"/>
+                    <characteristic name="AP" typeId="646b-1e72-1589-5083"/>
+                    <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains Fearless, Random Movement (3D6), Shambolic, and Grind Attacks (D6+X), where X is equal to the number of Health Points the model currently has below 7. The wielder cannot perform Close Combat Attacks.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="5203-fbbd-79f1-fa1b" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+                <infoLink id="2f06-f2fe-1df0-ae0a" name="Shambolic" hidden="false" targetId="24b3-4352-5103-4c13" type="rule"/>
+                <infoLink id="f103-c669-6f9c-d663" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (D6+X)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="7378-380e-6e51-9db9" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3D6)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="285.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="eb74-41c3-a88b-fdc8" name="Common Orc" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f87f-9df8-a547-7d36" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="39b1-4a5e-f7b5-660a" name="Born​ ​to​ ​Fight" hidden="false" targetId="c03a-e7a0-e3fc-8df5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e95-55c3-41f3-eb46" name="Feral Orc" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ac1-558d-2b51-4777" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ba2c-9403-0300-9740" name="Born​ ​to​ ​Fight" hidden="false" targetId="c03a-e7a0-e3fc-8df5" type="rule"/>
+        <infoLink id="3f3b-031f-2ecb-c3a6" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="0a78-c968-89e7-7d14" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5fb3-4b1a-99b1-df0d" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="989b-3f4f-b070-0b7a" name="Iron Orc" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b09c-c194-85f5-f786" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c766-7478-45d9-a6f1" name="Born​ ​to​ ​Fight" hidden="false" targetId="c03a-e7a0-e3fc-8df5" type="rule"/>
+        <infoLink id="90d7-b268-9966-1982" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+        <infoLink id="c7bb-b84d-f3f8-83ef" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d834-36fc-8be8-cec5" name="Common Goblin" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f18d-3452-55db-297b" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9244-791a-c232-c407" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="64d8-0040-c30f-c791" name="Cave Goblin" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f73-8b82-1b80-8321" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ff7b-3b3c-3f5c-d42b" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f0f-ec4f-b30c-c225" name="Forest Goblin" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef2-a173-e72b-d8ef" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ebb0-385d-2299-0fef" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="7479-1cee-6d0d-5a0b" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2d2f-6b4d-ec4d-ef53" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d1d-f327-7714-fde4" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddbb-2beb-ce56-6c9e" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3e4-48e9-d74c-b3eb" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c892-14a1-7970-7927" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8245-2605-c403-0df2" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dd9-3347-6a48-cb77" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1104-53d0-5461-4c6e" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b564-314c-0814-2b6b" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b94c-bf9b-9362-13e9" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7efd-6a64-de3f-63fc" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9588-734d-c644-79eb" name="War Boar" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="9534-cc66-f19d-9b74" name="War Boar Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0a5b-fc20-f9cd-1afb" name="War Boar Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="40c2-097b-cb65-0773" name="War Boar Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d828-55ae-0d98-33b6" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8d7d-a5e1-147f-ea22" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8957-d66f-aed4-56c7" name="Orc Boar Chariot" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="89dc-5123-44f9-59d4" name="Orc Boar Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="19ab-d062-69be-7365" name="Orc Boar Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="365e-8162-86bf-ca67" name="War Boar (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dc44-72b1-36ea-a7d9" name="&apos;Eadbasher Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4049-6089-3ba0-554a" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="09af-9c6f-fab6-7392" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0453-abc9-0687-0d81" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="d3a8-fd7c-a643-41da" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="e425-cbdf-afb0-447c" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="3daf-e42c-ee8a-d5d9" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="bc9f-c7f4-070d-d00f" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="0c16-21d4-4723-b670" name="Common Orc" hidden="false" collective="false" targetId="eb74-41c3-a88b-fdc8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff2-9a26-6d29-e449" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e907-2486-54b4-35b3" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6051-4fdb-b641-851c" name="Wyvern" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09f2-1a3d-f1ca-0da5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bcef-75f9-d03e-f7bd" name="Wyvern Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 4&quot;, Fly 8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 8&quot;, Fly 16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7ea6-23a4-0d3d-03aa" name="Wyvern Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ab24-edc1-0b4e-53e4" name="Wyvern Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ba21-3043-cabc-202b" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="3851-963f-1686-6733" name="Venomous​ ​Fangs" hidden="false" targetId="78ae-7dd6-cae5-0ff5" type="rule"/>
+        <infoLink id="d96f-672b-5968-9388" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="30b3-d4cb-ab5e-7e60" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="bbe9-37fe-1da4-acf0" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="6051-4fdb-b641-851c" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ad7-93c4-4a91-584b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="3ad7-93c4-4a91-584b" name="Big Wing" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb16-3296-2aaf-eee5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="43f4-18cd-86b1-c8b0" name="Big Wing" hidden="false">
+              <description>The Wyvern gains Devastating Charge (+1 Str, +1 AP) and changes its base size to 75x100mm.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec59-310c-9734-1559" name="Wolf" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="f757-abe5-3f48-7082" name="Wolf Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="efac-27d4-e2bc-e5c1" name="Wolf Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="91d7-7a4a-eee0-6d8b" name="Wolf Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="fe2b-45b3-e661-45b9" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="df12-8e31-9d19-6c49" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="df1d-f192-1b43-08a3" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="14d8-60ee-70fc-15f8" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="03ee-790f-d976-662c" name="Goblin Wolf Chariot" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="a119-d4a5-41a3-30b4" name="Goblin Wolf Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">9&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7e89-2484-c800-b1f8" name="Goblin Wolf Chariot Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="44a5-a88a-23c9-a35c" name="Wolf (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7c6b-123a-746c-220b" name="Goblin (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="850e-f470-fb93-7751" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="026c-bf3c-ee9f-0bb3" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="44a0-a09b-5108-7e29" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="e08c-4a75-2fa5-730b" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="2146-cffb-2b1b-76d2" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="9b84-f0ec-a9fa-7198" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="32ec-a314-26d5-e1bf" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4b7b-bd55-b2f3-f83c" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="ebdf-6dd7-d962-7b7d" name="Common Goblin" hidden="false" collective="false" targetId="d834-36fc-8be8-cec5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200a-6b07-4b81-6c87" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2c9-00d9-6906-e388" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f6fd-3aa5-c028-f3c5" name="Cave Gnasher" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5679-feb0-2fcc-3d9c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7f2c-ae61-5477-ced4" name="Cave Gnasher Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 5&quot;, Fly 6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 6&quot;, Fly 12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3200-1b1a-68c7-f436" name="Cave Gnasher Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b3c0-16ac-5da0-32f5" name="Cave Gnasher Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="746c-f599-98b8-ebab" name="Bouncers" hidden="false">
+          <description>May only join units of Gnasher Dashers and other Characters on Cave Gnasher (ignore the restrictions under Oi it bites!).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="4440-4581-3910-475c" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="b1ae-6663-ec87-a063" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="4335-7212-6cae-afb0" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="f9e0-03f7-9e24-40de" name="Oi it bites!" hidden="false" targetId="9a66-5dc3-9d5a-3404" type="rule"/>
+        <infoLink id="4dd0-900a-fac8-012a" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="91b7-4e67-9d08-8ef4" name="Scuttler​ ​Spider" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="0722-a0b3-1dd6-60e0" name="Scuttler​ ​Spider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7772-bc8d-5d93-18d5" name="Scuttler​ ​Spider Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4262-16b0-8f87-dd50" name="Scuttler​ ​Spider Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9475-578b-b176-fa47" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="892a-0ff1-d4cf-07c2" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="62b2-9c35-1907-1e28" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="7606-8245-d2b2-2e61" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="30c1-7fbb-89f1-c7cb" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule"/>
+        <infoLink id="f200-76c7-4a5b-6133" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="f689-1155-4f54-83e8" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b2e-f21e-81e6-4153" name="Gargantula" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7bb-2d5f-958b-663f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="85a4-34cc-fb52-4902" name="Gargantula Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a9ad-4b4e-0e47-352b" name="Gargantula Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">8</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6766-39d7-599e-4b88" name="Gargantula Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d41b-81ca-b52c-9c61" name="Goblin (8)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="023d-e52a-6031-362a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="a0e2-bf16-4c1f-e617" name="Venomous​ ​Fangs" hidden="false" targetId="78ae-7dd6-cae5-0ff5" type="rule"/>
+        <infoLink id="35d1-d3a2-2a17-d09e" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule"/>
+        <infoLink id="1480-4a96-5a96-c86a" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="7236-1526-bf1d-ef81" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="d96b-770d-5305-52ee" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="c8ab-3e49-ad4d-12a8" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="d06a-c8df-96a8-266c" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="02ba-c047-8bfd-3856" name="Forest Goblin" hidden="false" collective="false" targetId="2f0f-ec4f-b30c-c225" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bac-d624-cdb7-8ff3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6209-2750-8376-4ca7" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a3e2-84b3-8dd8-13bd" name="Huntsmen ​Spider" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2fcc-2077-98ab-e071" name="Huntsmen ​Spider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="614d-846a-816c-832c" name="Huntsmen ​Spider Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fce6-a619-0ab2-01f8" name="Huntsmen ​Spider Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="59b0-68a0-27d5-ae2f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3e2d-805f-3402-e227" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule"/>
+        <infoLink id="85be-3727-9a15-2b19" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="cc36-bcd6-e979-93aa" name="Weapon Enchantments - OnG" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a46c-5518-3922-0c90" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="e853-8587-4ce6-2b8b" name="Omen of the Apocalypse" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="136a-67c8-5844-a6b2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1ed-fbb1-54a6-23de" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9eed-1a1a-a977-c06d" name="Omen of the Apocalypse" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder gains +X Attack Value, +X Strength, and +X Armour Penetration when using this weapon. X is equal to the roll of a single D3, which is rolled at the Initiative Step in which the wielder is attacking. The modifiers are in effect only during this Initiative Step. Attacks made with this weapon gain Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9b7f-e9e1-ab56-6051" name="Shady​ ​Shanking​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ca4-7330-04e7-5661" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="20b7-aa02-f6d5-33b2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2be2-8ad3-e605-b90d" name="Shady​ ​Shanking​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon and Paired Weapons enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain Lightning Reflexes, Lethal Strike, and Magical Attacks. When fighting in a Duel, failed to-wound rolls with this weapon must be rerolled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f838-63be-253f-e9e7" name="Maza&apos;s​ ​Zappin​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee66-e80a-a8cf-7ccd" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2f6-afa3-8e01-7eb1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1c7a-8752-b799-6dd6" name="Maza&apos;s​ ​Zappin​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Bow enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder’s unit gains Quick to Fire. This Bow gains Aim (2+) and has its profile changed to: Range 24&quot;, Shots 3, Str as user, AP as user, Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="fa05-24e8-b27c-98f3" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d4e-d3d1-6088-2b7a" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="d0b3-8c53-9d8c-54e6" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+        <entryLink id="0912-1fc3-8bae-319f" name="Weapon Enchantments - OnG" hidden="false" collective="false" targetId="cc36-bcd6-e979-93aa" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6bd3-1fe0-d63c-6e32" name="Armour Enchantments - OnG" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c148-74d5-b3bc-7059" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c84c-559c-18d9-59b7" name="Tuktek’s Guard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac84-5d7e-4a2b-702c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef20-8343-63e8-f555" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5bd8-7bdf-4b31-6320" name="Tuktek’s Guard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suits of Armour enchantment. Standard and Large Size models only.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer’s model gains +1 Resilience, and attacks against the wearer with Lethal Strike lose this Attack Attribute.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="62b9-ee82-d70a-3430" name="Armour Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43ba-ba2a-99c9-ff32" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="b413-5bdb-ebc5-a9a1" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+        <entryLink id="de3e-e13c-dcd6-f4b3" name="Armour Enchantments - OnG" hidden="false" collective="false" targetId="6bd3-1fe0-d63c-6e32" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="633e-9706-3601-009b" name="Artefacts - OnG" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42b9-7006-c6ef-8588" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="7f21-06e3-82e1-808a" name="Crown of the Cavern King" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7d4-42b0-522c-05da" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f22-d734-27fc-aaa3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7610-79c7-46b6-c05c" name="Crown of the Cavern King" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Cannot be taken by models with Towering Presence.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">All models in the bearer’s unit that have at least one model part of the Greenhide Races Common Goblin, Cave Goblin, or Forest Goblin gain Vanguard and Feigned Flight. If the bearer is Common Goblin, Cave Goblin, or Forest Goblin, its Commanding Presence and Rally Around the Flag range (if available) is increased by 6&quot;.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c434-8355-60fb-360a" name="Skull​ ​Fetish​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edb0-673a-4afc-655a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2da3-3e00-8ec9-91d1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="201e-5b25-c555-fc60" name="Skull​ ​Fetish​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Dominant. Wizards only.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of any friendly Magic Phase, add X Veil Tokens to your pool, where X is the number of friendly units Engaged in Combat minus the number of friendly Fleeing units, ignoring negative results. You cannot gain more than 3 Veil Tokens this way. These tokens are in addition to Veil Tokens gained from other sources. Skull Fetish can never cause a loss of Veil Tokens.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c12f-fc49-45a8-aeba" name="Troll​ ​Ale​ ​Flask​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d2a-477d-bc95-a851" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5788-b4d7-cbc6-8340" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cf8b-10f0-2f36-73fc" name="Troll​ ​Ale​ ​Flask​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the bearer’s Initiative Step, choose an enemy unit Engaged in Combat with the bearer, that the bearer is able to attack with Close Combat Attacks. This unit suffers a hit, which is resolved with Strength 5 and Armour Penetration 10. This is considered a Special Attack.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4041-ea51-f24c-e15b" name="Pan​ ​of​ ​Protection​ ​Pinchin’​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="508e-d070-aec4-ba6a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="01ea-e227-1b9a-b145" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f4b4-4689-8458-7930" name="Pan​ ​of​ ​Protection​ ​Pinchin’​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When successfully wounded, the bearer may use the Armour of the model that inflicted the wound, and either its Aegis or Fortitude. Additionally, when the bearer’s unit is the target of a spell, the bearer gains the same Magic Resistance as the Caster of the spell.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a10c-1edf-196a-3870" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecef-0b63-a750-4f85" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="5472-e43a-0879-862a" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+        <entryLink id="8ad8-68c4-2ca5-d84c" name="Artefacts - OnG" hidden="false" collective="false" targetId="633e-9706-3601-009b" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3947-b0c4-c5ae-f0ca" name="Banner Enchantments - OnG" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee9b-5b63-e6ae-b9b5" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="ff12-8c58-8694-2df1" name="Green​ ​Tide​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0e3-b78c-9cea-a25d" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d80d-4fcb-2e6f-8e9b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ded5-ffc8-d77e-1c65" name="Green​ ​Tide​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Fight in Extra Rank.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a59b-4478-b1e2-31da" name="Mikinok’s​ ​Totem​" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2b5-db11-3548-da60" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d741-b3a8-c9de-a0b0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2110-70a6-007d-c1e0" name="Mikinok’s​ ​Totem​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Cannot be taken by Core units</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of each Round of Combat, choose a Special Equipment carried by a model in an enemy unit in base contact with the bearer&apos;s unit. The chosen Special Equipment cannot be used during this Round of Combat.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9272-ebfe-87bc-fd62" name="Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="00d1-7328-322d-76f2" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="daa4-2c43-4d9b-c3c2" name="Banner Enchantments - OnG" hidden="false" collective="false" targetId="3947-b0c4-c5ae-f0ca" type="selectionEntryGroup"/>
+        <entryLink id="a356-c0ac-96d6-c520" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="9a66-5dc3-9d5a-3404" name="Oi it bites!" hidden="false">
+      <description>Units with model with Oi it bites! cannot be joined by Characters.</description>
+    </rule>
+    <rule id="b6ae-e591-efec-e156" name="Nets" hidden="false">
+      <description>At the start of each Round of Combat, choose one enemy unit in base contact with one or more models with Nets and roll a D6. On 2+ the chosen unit suffers -1 Strength and -1 Armour Penetration. On a roll of ‘1’ the unit with Nets suffers -1 Strength and -1 Armour Penetration. Effects last until the end of the Round of Combat. A unit can only be affected by Nets once per phase.</description>
+    </rule>
+    <rule id="24b3-4352-5103-4c13" name="Shambolic" hidden="false">
+      <description>Units with Shambolic models cannot be joined by Characters. When rolling for Random Movement with a Shambolic unit, if all the dice show the same result, the unit loses D3 Health Points (with no saves of any kind allowed), and then moves in a randomised direction instead of the chosen direction. When units with Shambolic touch the Board Edge, stop 1&quot; away from Impassable Terrain, or come into base contact with any Terrain Feature other than Open Terrain or Hills, all models in the unit must take a Dangerous Terrain (2) Test.</description>
+    </rule>
+    <rule id="0626-c5ce-f60c-8000" name="Running​ ​Amok!!" hidden="false">
+      <description>When a unit with Running Amok!! moves using Random Movement, it must move in a randomised direction instead of the chosen direction.</description>
+    </rule>
+    <rule id="b032-48af-073c-1d3e" name="Ricochet​ ​(X)" hidden="false">
+      <description>Models with Ricochet cannot charge enemy unit and can move through all units (friend or foe) as if they were Open Terrain. If its own move is ended in contact with another unit, or within 1&quot; of a unit it has moved through, its move distance is extended; keep moving the model in the same direction (still moving through other units) until it can be placed 1&quot; away from all other units. If, after an extended move, the model would end up within 1&quot; of Impassable Terrain or in contact with the Board Edge, immediately remove the model as a casualty.
+If a unit&apos;s Boundary Rectangle is contacted by a Ricochet model’s initial move (i.e. excluding an extension of the move distance needed to clear units), this unit suffers X hits, where X is given in brackets. For this purpose, all units Engaged in the same Combat are treated as a single unit. The owner of the model with Ricochet distributes the hits between all units Engaged in this Combat as evenly as possible (after this follow the normal rules for distributing hits to models within each unit).
+Enemy units cannot charge models with Ricochet. Units (friend or foe) can move through models with Ricochet. However, if a unit moves into contact with a Ricochet model, it immediately (before completing the move) suffers X+D6 hits, and the model with Ricochet is removed as a casualty. This is not triggered by moves that can move through units normally (e.g. Flying Movement), unless the move is ended in contact (note that units can move into contact with multiple Ricochet models simultaneously).
+Hits are resolved with the Strength and Armour Penetration of the model with Ricochet.</description>
+    </rule>
+    <rule id="c03a-e7a0-e3fc-8df5" name="Born​ ​to​ ​Fight" hidden="false">
+      <description>The model part’s Close Combat Attacks gain +1 Strength and +1 Armour Penetration during a Round of Combat
+● If it is the first Round of Combat.
+● Or if the model part’s unit is Steadfast at the start of the Round of Combat.</description>
+    </rule>
+    <rule id="78ae-7dd6-cae5-0ff5" name="Venomous​ ​Fangs" hidden="false">
+      <description>Before rolling to hit, nominate one Close Combat Attack from a model part with Venomous Fangs. This attack gains Multiple Wounds (D3+1). If the attack is turned into more than one hit (e.g. a hit with Battle Focus), only a single hit, chosen by the owner, gains the effect.</description>
+    </rule>
+    <rule id="ab83-567a-7466-6d1f" name="Mammoth​ ​Stabber" hidden="false">
+      <description>If the unit is Charging and has at least one Full Rank, nominate a single R&amp;F model in the unit at Initiative Step 10. This model gains Impact Hits (D3). These Impact Hits are resolved with Strength 5, Armour Penetration 2, and Multiple Wounds (D3+1, against Towering Presence).</description>
+    </rule>
+    <rule id="6084-6161-b449-356a" name="War​ ​Cry!" hidden="false">
+      <description>Once per game, at the start of a Player Turn, the General may utter a War Cry!. All friendly units gain +1 Advance Rate, +2 March Rate, and Swiftstride until the end of the Player Turn.</description>
+    </rule>
+  </sharedRules>
+</catalogue>

--- a/saurianAncients.cat
+++ b/saurianAncients.cat
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3557-241b-5999-a3b1" name="Saurian Ancients 2.0" revision="20" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3557-241b-5999-a3b1" name="Saurian Ancients 2.0" revision="21" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="0a69-f7af-e4da-3ad0" name="Jungle Guerrilla (local)" hidden="false"/>
-    <categoryEntry id="634f-0995-844c-451a" name="Thunder Lizards (local)" hidden="false"/>
+    <categoryEntry id="0a69-f7af-e4da-3ad0" name="Jungle Guerrilla" hidden="false"/>
+    <categoryEntry id="634f-0995-844c-451a" name="Thunder Lizards" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="0839-a5fd-63c0-99d5" name="Saurian Ancients (local)" hidden="false">
+    <forceEntry id="0839-a5fd-63c0-99d5" name="Saurian Ancients" hidden="false">
       <categoryLinks>
         <categoryLink id="92c8-fc84-71d5-d53e" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -3335,9 +3335,6 @@
                   <description>The Model gains Channel (1)</description>
                 </rule>
               </rules>
-              <categoryLinks>
-                <categoryLink id="558b-bb48-95c1-6919" name="New CategoryLink" hidden="false" targetId="1976-36a2-72b9-c7b0" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>

--- a/saurianAncients.cat
+++ b/saurianAncients.cat
@@ -1,0 +1,4434 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="3557-241b-5999-a3b1" name="Saurian Ancients 2.0" revision="20" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="0a69-f7af-e4da-3ad0" name="Jungle Guerrilla (local)" hidden="false"/>
+    <categoryEntry id="634f-0995-844c-451a" name="Thunder Lizards (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="0839-a5fd-63c0-99d5" name="Saurian Ancients (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="92c8-fc84-71d5-d53e" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="bc83-32d9-0641-a337" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7fa9-6336-851f-7862" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="5b54-44c1-02e8-c5a3" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a0b3-9961-77ba-90d9" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="1def-b953-8bdf-ba5f" name="Jungle Guerrilla (local)" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="572d-496e-b143-54e4" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="677b-cd73-3569-dfad" name="Thunder Lizards (local)" hidden="false" targetId="634f-0995-844c-451a" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="4f80-d6bb-df87-3540" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="46e2-fcb1-5337-a50e" name="Saurian Warlord" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="4a9b-bc8e-01e6-a248" name="Saurian Warlord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="20e4-7ef2-8f64-24c5" name="Saurian Warlord Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ccb2-3285-e565-9a58" name="Saurian Warlord Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c5f0-6795-3cae-3d5a" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="41ac-df0b-34e1-ebd3" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="b8f8-089e-ae17-34a8" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="46e2-fcb1-5337-a50e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aae6-b719-01ab-6e12" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="daa8-d2c6-d600-3a02" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0a9c-5e46-6e74-afae" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b665-2724-bd5d-5cd7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="bc05-f9e6-fd26-736e" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aaf6-c4aa-5b1b-af18" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e8e8-a648-c2c5-2aaa" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="ac30-e8f5-c3b2-9d4b" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac30-e8f5-c3b2-9d4b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="b2bb-6f0f-586d-d5db" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="a634-7568-f0e0-dd59" name="SA Armour Enchantments" hidden="false" collective="false" targetId="6fe8-04b0-a5d9-54c8" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3a74-109a-5b27-c597" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c2b9-8104-6ffa-bdcd" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9af5-7f1b-de4a-2036" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="844b-bed4-d609-12e4" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="dde3-2577-d04c-6af6" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2344-12ea-d9bc-32af" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="dd33-9eb8-8cc9-42c4" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="54d8-e0e5-f9a6-7335" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fe42-eca0-f2ce-453f" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b130-0aa4-b908-052e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d1d9-8c19-c09e-9c71" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="376d-7dfb-a4d0-abd1" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5756-5e4c-aa88-45c6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f0c2-0ebd-00f3-bc47" name="Carnosaur" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="791e-28b8-f2f0-8401" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="06ad-977a-9a5e-44f0" name="Thunder Lizards (local)" hidden="false" targetId="634f-0995-844c-451a" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="cf52-9038-1169-4137" name="Carnosaur" hidden="false" collective="false" targetId="f48b-b975-d560-7aa5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="260.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dd98-6047-314b-fbc4" name="Raptor" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58b5-bffb-5ee6-bb96" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3faa-cd5c-466f-47af" name="Raptor" hidden="false" collective="false" targetId="72ce-5533-a7d3-7d9f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f7a5-3ed2-a15b-4ead" name="Alpha Carnosaur" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c001-4a95-f4a9-e758" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="9405-c944-0c4d-351c" name="Thunder Lizards (local)" hidden="false" targetId="634f-0995-844c-451a" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="85de-63ad-d894-fdb4" name="Alpha Carnosaur" hidden="false" collective="false" targetId="1a35-f5d6-d8da-bdbe" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="490.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fe1b-5fd7-ea68-1faa" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="aae6-b719-01ab-6e12" name="Heavy Armour (Foot only)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8882-67eb-bb59-1253" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bfd6-043c-4bbc-d95e" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6842-78a8-549a-033e" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2021-7a8e-26e9-5980" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="71a5-c607-a89d-3225" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bc85-1c50-0a1b-44bb" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9bbc-402b-65ba-ff47" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6a19-26c6-25c6-3821" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d23-58b6-fb8e-fcf7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="46f5-603f-6725-d684" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fbd3-f450-fbc9-2f62" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bf4-05c2-c18c-d0ef" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7810-1af0-2b90-45e8" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7519-5f76-3fad-997f" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="689d-7495-ea12-b7cb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="766b-cc41-5788-06c9" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5fe9-0881-37ec-cb21" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8e8-004b-14b6-c032" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="56a6-2f78-5151-0938" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="279c-8174-f70b-e2f0" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b25-ef64-5dbd-e7e1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5636-fd94-1b8c-873a" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="260.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c995-c5a3-27fd-4fef" name="Saurian Veteran" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="840b-ef00-c9a5-19f4" name="Saurian Veteran Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4a14-c150-2cfe-f8f9" name="Saurian Veteran Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c006-16a2-8a18-4e56" name="Saurian Veteran Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b059-73a0-1738-020d" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="4eaa-8934-5800-4eb2" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="c241-3452-c4b5-a777" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c995-c5a3-27fd-4fef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9bd4-63d6-c489-977f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="653a-f69a-fc9a-1e6f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9fca-00e6-a879-d3b8" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d6c6-29bf-007a-65de" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96de-fedb-f578-93f6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c8f8-ffb3-75ca-bbfc" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d6c6-29bf-007a-65de" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c995-c5a3-27fd-4fef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9fca-00e6-a879-d3b8" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b33-e585-3059-d902" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6cf5-07f3-3f5f-6eaf" name="Battle Standard Bearer" hidden="false" collective="false" targetId="72de-6c90-9501-10e4" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2584-3ee0-2388-f2e1" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f84-c17d-abe6-7e74" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e6be-dc9b-fe87-5c47" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d443-d757-b3fe-4925" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="03e1-e67c-2807-3a13" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="7587-44fc-543c-545c" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7587-44fc-543c-545c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c93a-6a3b-3dbb-0704" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="eb4e-e9fe-8170-b4b2" name="SA Armour Enchantments" hidden="false" collective="false" targetId="6fe8-04b0-a5d9-54c8" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3066-72e2-9635-9b89" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0634-bc14-f0be-6ddf" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0998-c1f2-8b03-269d" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="b085-8d33-9a44-44dd" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="37f7-c678-0af8-c665" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b82-f018-4c14-0aad" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0864-da0a-88c8-27f4" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="43b3-e669-bb35-7e6d" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="73f6-3b6e-8393-a497" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="c995-c5a3-27fd-4fef" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72de-6c90-9501-10e4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e35f-ef36-8a13-7256" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="af6b-4ddd-d401-5a23" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="9998-aaaf-e603-9875" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3aca-5920-ab41-01c7" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1d8-f41e-1abc-8100" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fb47-28ec-2d06-0d69" name="Carnosaur" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65c3-6c9b-bf6e-59e9" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="cf86-82d3-7c1d-a829" name="Thunder Lizards (local)" hidden="false" targetId="634f-0995-844c-451a" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="a49b-af57-be60-c1f1" name="Carnosaur" hidden="false" collective="false" targetId="f48b-b975-d560-7aa5" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="270.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a741-daf8-ebf3-350f" name="Raptor" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da80-95ed-a88c-20ef" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e506-459d-caad-b1fd" name="Raptor" hidden="false" collective="false" targetId="72ce-5533-a7d3-7d9f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f609-5be2-8fc4-c4d3" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f90-8942-dc1e-2d1b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="687c-72ff-e610-3c6c" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b69-2e10-216c-d8b5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5430-ac54-2bbb-f1b6" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1610-7c63-ba97-0c59" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="936b-fdfd-659a-ff42" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="af11-648f-9a5b-5e4f" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5b80-d186-15b0-5c2b" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99eb-7dde-7971-3ff8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="58c0-b53c-197a-2294" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5eeb-0989-33bd-0eda" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7bbe-b445-6b22-bf5c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8e1a-6360-789c-ab83" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1614-3178-06b6-3fe5" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1e1-b450-149e-f741" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c3f9-594b-d939-f585" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ebe4-98c1-63c3-0542" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="9bd4-63d6-c489-977f" name="Heavy Armour (Foot only)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8365-be8b-b23f-aeb4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0298-f6b3-4f61-d495" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9c2b-fb45-8e26-fc30" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2cb2-5208-b70d-6107" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dd87-54ac-ee50-23b5" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0193-48cd-e080-e2c8" name="Cuatl Lord" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="8757-eddf-8e49-30ca" name="Cuatl Lord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="78af-1e10-1564-c06d" name="Cuatl Lord Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3d83-d9bc-9026-7fcd" name="Cuatl Lord Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1bb4-0393-597a-22b0" name="Palanquin" hidden="false">
+          <description>When a Cuatl Lord is in a unit with 5 or more models with Bodyguard, it gains Stand Behind . A model with this Model Rule can be the General even if it is also the Battle Standard Bearer, and it cannot be chosen by the enemy as the model that refuses a Challenge. The model counts as being Mounted.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="cc95-4207-7113-dd74" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="948b-0787-ad9b-f7ac" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+        <infoLink id="e46d-ebd4-ffaf-b3d5" name="Tall" hidden="false" targetId="229b-fa84-b9fe-b1ff" type="rule"/>
+        <infoLink id="28e8-e7a2-bba1-4c07" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e7b6-e5de-2aac-f440" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5c0f-0866-553b-be7c" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7cd-aa10-37b3-28f7" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="64ad-c868-e619-428d" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fb4e-ed5a-fc5e-6d17" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94f3-abac-32e3-2448" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="10f8-3cba-a926-3559" name="Battle Standard Bearer" hidden="false" collective="false" targetId="72de-6c90-9501-10e4" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c911-9fba-0254-6b12" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2501-664f-8446-e171" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b28a-b411-9000-937a" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="82f2-9c3e-9d70-3eb7" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b3ef-fe98-3a06-013d" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c89f-b8d1-e7f6-0ea1" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7cdd-e3a6-9162-548d" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="b67b-77e5-5e51-898c" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6586-595f-4c43-e987" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="63a3-51b2-a6f8-4ac5" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="1c9a-6bd6-bcbf-9de7" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="cfc9-c636-b571-3ffd" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="34b9-8544-49be-ed47" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="0193-48cd-e080-e2c8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10f8-3cba-a926-3559" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6002-814a-cf1d-9725" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5d71-005f-1557-17db" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="a3a4-9a5a-98e0-5e8b" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5717-f516-180d-d8e9" name="Magic Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="4e17-2496-467f-c53a" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75e6-6e2f-bf7d-84dd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e17-2496-467f-c53a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c992-d95c-606c-a9db" name="Alchemy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba69-2c59-4003-95fb" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="422f-04be-9820-bb97" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5875-19fa-fcc7-6aeb" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="db51-3dd5-dacd-97c0" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c7c-c0be-9b67-55ff" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8e45-c477-5618-e048" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cc9-1e00-c07d-d6c5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="73de-21f6-35b4-a017" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0193-48cd-e080-e2c8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d1c0-33bd-8434-25c4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f1-530f-58bb-cb77" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="94b5-b7c6-bd0c-e61a" name="Disciplines" hidden="false" collective="false">
+          <constraints>
+            <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b0ca-4f5a-f9b4-8e83" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c40a-7dc8-b376-7740" name="Master of Reality" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07fc-6422-a04b-e18f" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bdf-2740-b63f-5789" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="f360-8759-5998-57ee" name="Master of Reality" hidden="false">
+                  <description>During Siphon the Veil, the owner must turn Veil Tokens into Magic Dice for a cost of 2:1 (instead of 3:1). At the end of each friendly Siphon the Veil subphase, all Veil Tokens that have not been turned into Magic Dice are discarded.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="135.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0ade-1e54-8877-cfa9" name="Grasp of the Immortal" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13ba-a0ba-5f94-e16b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2467-3996-e5d3-e017" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="5a36-9151-2e1f-179d" name="Grasp of the Immortal" hidden="false">
+                  <description>The Cuatl Lord gains Channel (1) and a +1 modifier to its casting rolls. When rolling casting rolls with a single Magic Dice, a natural roll of ‘1’ or ‘2’ on the Magic Dice is always a failed Casting Attempt, regardless of any modifiers.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="95c3-d71a-20c9-7653" name="Ancient Knowledge" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="0193-48cd-e080-e2c8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="422f-04be-9820-bb97" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="361b-a053-9e09-ebb7" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a93e-3ca9-1e6e-6ea3" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="40db-5835-4972-b05e" name="Ancient Knowledge" hidden="false">
+                  <description>Instead of selecting spells, the Cuatl Lord knows all spells from Divination. A single Learned Spell may be exchanged for the Hereditary Spell during Spell Selection. All friendly model parts with telepathic link within 12&quot; count as a wizard for the purpose of &quot;The Conclave&quot;.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d1c0-33bd-8434-25c4" name="Protean Potentate" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ad-8531-970b-ad28" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8803-d40c-0281-f184" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="b50c-7ebe-6de9-0554" name="Protean Potentate" hidden="false">
+                  <description>The Cuatl Lord gains Protean Magic and access to Druidism, and knows all the Learned Spells it now has access to as well as its Hereditary Spell. This Discipline cannot be combined with Ancient Knowledge or the Sun Tablet Artefact.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0528-729c-7d28-c9d0" name="Soulfire Weaver" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9caf-83a3-7f74-c20d" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b9d0-8204-a17d-a203" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="8757-315d-aa10-aa3d" name="Soulfire Weaver" hidden="false">
+                  <description>Every time the Cuatl Lord successfully casts a spell from Evocation, it can choose to discard one or more Veil Tokens instead of casting the Attribute Spell. For each Veil Token discarded this way, choose one unengaged enemy unit within 12” of a target of the spell (no unit can be chosen more than once per spell). Each chosen unit suffers a hit with Strength 4, Armour Penetration 0, Area Attack (2), and Magical Attacks</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1eb6-0c10-2df5-4a6a" name="Breaker of Spells" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56df-4009-1547-19f4" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee4e-ee74-f2fc-b97b" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="70f3-4116-b027-b68a" name="Breaker of Spells" hidden="false">
+                  <description>The owner of the Cuatl Lord may reroll its first failed Dispel Attempt in each enemy Magic Phase.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9690-4a10-f0e2-7a44" name="Trained from Birth" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34bd-c1d0-5960-0ec9" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58f4-3af8-98f0-bef5" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="628f-c070-dfa3-da62" name="Trained from Birth" hidden="false">
+                  <description>The Cuatl Lord knows Learned Spell 1 in addition to its regular spells from its chosen Path.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ef98-0079-8579-3c12" name="Symbiosis" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0724-d7e4-5167-a9c6" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd00-c6e4-5d2b-09fc" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="5501-6e42-b8dc-7167" name="Symbiosis" hidden="false">
+                  <description>The Cuatl Lord may cast spells of any type through models with Telepathic Link. When casting spells through a Telepathic Link, the range of spells of the type &quot;Damage&quot; without &quot;Aura&quot; is not reduced. Otherwise follow the normal rules of Telepathic Link.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="470.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bb82-02bc-5d73-8912" name="Skink Captain" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="decrement" field="834f-1ba5-2c62-2a7d" value="1">
+          <repeats>
+            <repeat field="selections" scope="953d-22cd-7ee1-36dc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31c1-8fb9-67db-b5b9" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="834f-1ba5-2c62-2a7d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6ab5-8cea-0501-3399" name="Skink Captain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a7cd-5b3e-1b74-fa98" name="Skink Captain Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b03a-5190-8abf-2bf4" name="Skink Captain Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9a4d-bef1-3d09-03dc" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="e692-c31d-f98a-ee34" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="448e-e06f-34bf-ae23" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="281b-c8fb-0602-da0d" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="bb82-02bc-5d73-8912" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b53-03de-9c84-13de" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10c9-496e-1421-f936" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d80e-3e02-26aa-3447" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b53-03de-9c84-13de" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="bb82-02bc-5d73-8912" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="281b-c8fb-0602-da0d" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8465-4857-81f9-13cf" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d913-185a-266e-9fb0" name="Battle Standard Bearer" hidden="false" collective="false" targetId="72de-6c90-9501-10e4" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5a69-1fb6-7a01-30fc" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4735-d9ae-9537-a283" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="349a-8f57-f215-e3a7" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b362-9240-86f4-b4d3" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="d150-bf2c-59a2-b467" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="a84c-bceb-1530-9d64" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a84c-bceb-1530-9d64" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2505-2ec0-d8e9-9ba0" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="5a5c-dfcb-9173-58b6" name="SA Armour Enchantments" hidden="false" collective="false" targetId="6fe8-04b0-a5d9-54c8" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="308d-e030-292d-8e9d" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fdf2-6852-4440-4445" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7027-2aaf-c14c-3f0b" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="58c1-b06d-4325-023b" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="9a4b-f8e1-d2d8-4bfe" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1522-c12d-97ec-06b2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="83b3-0c8b-2945-8cd0" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="8956-d69b-00cb-3a78" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e8d7-cfd4-8833-ae98" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="bb82-02bc-5d73-8912" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d913-185a-266e-9fb0" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0db-e732-2e1c-c106" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="81f1-1c6b-90c2-a627" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="eca2-d4e9-dc43-63e0" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2655-3941-58fc-19c3" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9483-2946-f57d-7dad" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f0da-787b-a825-d5e9" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="87d7-9e58-f810-3167" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="c712-cecb-794f-45fa">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8486-4d4e-1bd3-7a4f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4428-fcca-d7ad-73a3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c712-cecb-794f-45fa" name="Blowpipe (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7057-d801-d726-daeb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5ac3-a88e-995e-56f3" name="Blowpipe" hidden="false" targetId="7d16-fc1d-6a00-9eb1" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="41b7-4943-fe33-b2c4" name="Bow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3779-8c08-76fc-4b45" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2f73-a997-04bd-6daf" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1388-7403-cfaa-8088" name="Poisoned Javelin (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4438-857b-db6d-64c9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e1e4-653d-43ff-c07c" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="20e2-4f5e-56ed-58e3" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03d3-20e0-4f2f-af7e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9f9e-e33c-cbf5-5a4b" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ca-4b67-9831-d25f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0757-a283-8dbb-0fb1" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="df5b-6eec-6fda-95e5" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fff-8a5e-f9cb-6d18" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="81be-53d9-d25c-f1a9" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b2dc-8e23-4fac-17a0" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="319a-b3ea-c32c-1f4b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8715-6a17-6027-c682" name="Taurosaur" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be4b-c013-79cd-71dd" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="9862-2797-0ce2-852b" name="Thunder Lizards (local)" hidden="false" targetId="634f-0995-844c-451a" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="ec46-3e8e-4e7e-d372" name="Taurosaur" hidden="false" collective="false" targetId="dcca-3010-963b-204c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="435.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b5d3-df16-0c28-471b" name="Skink Priest" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="1970-5e4a-1dc6-527a" name="Skink Priest Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5d57-f635-a9ad-7562" name="Skink Priest Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3ecb-73ab-6534-5c32" name="Skink Priest Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6d49-9e82-3255-3293" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="5aa5-1b24-0966-884c" name="Telepathic Link" hidden="false" targetId="cf78-dd60-d1a6-0a34" type="rule"/>
+        <infoLink id="9cf3-ede3-7b52-dfca" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4de9-0b90-09d4-6092" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d000-af26-404b-cb90" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fc6-673f-652e-479c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ae99-c20f-2245-a6c5" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5a56-6409-339c-8f2c" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="67fa-758c-4034-cdbc" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3c18-b014-3f12-1acf" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2d6-c920-0df4-cd1c" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="aa09-d188-14bb-1176" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="b5d3-df16-0c28-471b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d000-af26-404b-cb90" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="619a-0701-0cbb-f8a4" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="cb15-ad4d-713c-31bb" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="13d9-d919-16ca-864a" name="SA Armour Enchantments" hidden="false" collective="false" targetId="6fe8-04b0-a5d9-54c8" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="dd3e-9826-cf74-4265" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e86f-5a0d-92d8-02b2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5b1c-4deb-3e69-4db3" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="744a-0511-9dd7-3892" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c07c-f43b-ada9-8250" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0c6-f0ff-8157-29f9" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="70a2-fac8-b4f4-037f" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="af0a-dac9-6bc2-a431" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="94c7-67e2-3a5e-2f61" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23e5-bba8-5b54-6d8c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a8d5-a908-bbdf-87fb" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bc4d-d7c1-f07f-afae" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="f6b9-84e8-1de9-91fe" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77ec-fc60-a56e-3a89" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b9-84e8-1de9-91fe" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9111-cb98-3ede-e32b" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3f4-34be-e853-48d2" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="72ce-a47b-ded1-fd96" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ea6-0127-db5a-4701" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="953f-de0f-4aa6-745e" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="7982-7cb3-5c5c-36a1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="612b-b5e7-0dfc-fc72" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e87b-5542-71a5-4a0c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d308-772c-8f86-9446" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67e6-86c2-abf5-ace4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f42d-a72d-a910-2a10" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7982-7cb3-5c5c-36a1" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4529-0f0a-7e02-d553" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3d94-8a9a-29f3-222a" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7171-4dbd-7910-4a5f" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fb6-8dd8-3c06-293b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7a1a-702c-e2a4-12cd" name="Skink Palanquin" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b73-358b-6ee8-a12c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5cc9-f5b0-4e0c-0550" name="Skink Palanquin" hidden="false" collective="false" targetId="c89a-f606-6965-c79b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3b5e-d5ba-0c35-2d94" name="Taurosaur" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc46-869f-2b00-38dc" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="ca1d-a3f2-2b8b-8571" name="Thunder Lizards (local)" hidden="false" targetId="634f-0995-844c-451a" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="f0c7-c955-159f-a791" name="Taurosaur" hidden="false" collective="false" targetId="dcca-3010-963b-204c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="435.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b408-00c4-1454-0ccb" name="Caiman Ancient" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="7247-f4e8-9fda-4c14" name="Caiman Ancient Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c516-25d5-8b59-76a5" name="Caiman Ancient Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a228-ef73-ebc6-eeee" name="Caiman Ancient Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c078-32f7-9c7b-c145" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="3944-0acb-0ac3-8b80" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="466c-b03d-c200-7558" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="63fa-6581-7a00-42b1" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="a8f4-06da-28a1-d328" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c08e-0558-1953-19bf" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1a60-166d-af8e-716c" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b408-00c4-1454-0ccb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a899-1103-6ffe-4c2b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce00-b389-2dfa-ef84" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="125b-5d7d-c7ad-d4cf" name="Battle Standard Bearer" hidden="false" collective="false" targetId="72de-6c90-9501-10e4" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5efc-9a18-8e90-e36c" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b408-00c4-1454-0ccb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a60-166d-af8e-716c" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c9-4ac5-3eec-ce1a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a899-1103-6ffe-4c2b" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a00d-fe3c-8c94-f0ed" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f186-a87c-acd0-1e4e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fad0-3101-fd49-a47d" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="96b0-7089-e460-355d" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8e85-eebc-5794-141c" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="6748-6505-2074-a6d0" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6748-6505-2074-a6d0" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c386-a063-7247-8e45" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="6848-5395-3798-9e04" name="SA Armour Enchantments" hidden="false" collective="false" targetId="6fe8-04b0-a5d9-54c8" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="a672-7668-2da1-9a59" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df60-b95c-bfd8-2919" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="42d5-d10c-c971-379a" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="1799-66c5-00b3-30e7" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="0cc8-2c7d-b0d7-dac7" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47f5-533f-0674-0093" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="268a-d12f-b3db-a0fd" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="7ddb-be56-50c9-fa51" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="de0d-2706-c2c2-157d" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="b408-00c4-1454-0ccb" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72de-6c90-9501-10e4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e71-dce0-5d3d-48b9" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f528-31f1-62ca-f964" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="ec02-c589-2917-a78c" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2e82-2f57-9576-5708" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="a45a-c071-294a-9844">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5891-ae5c-7f94-e8ff" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cfb-a7e1-0797-9917" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a45a-c071-294a-9844" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef84-54d4-7be4-5472" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f53f-c464-3b41-c614" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5859-abc0-bf00-b1c6" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f6d-6162-2713-a279" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3c41-7d30-0263-9c78" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec7c-18f7-71ee-668a" name="Saurian Warriors" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="e2b2-089d-9db5-74e2" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="5054-56ed-f95d-2867" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="6acf-1b94-40a3-364a" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="46b0-a378-5771-af35" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2014-d144-3a90-3597" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0977-d6db-94fa-f6e9" name="Saurian Warrior" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2195-2618-5674-466a" type="min"/>
+            <constraint field="selections" scope="parent" value="35.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ff9-2584-fbb1-82be" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="76fa-ba30-83b8-1cd7" name="Saurian Warrior Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3695-c766-8954-ec3d" name="Saurian Warrior Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5b6f-eaa9-3b41-4b26" name="Saurian Warrior Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="set" field="2a23-367f-8828-c297" value="3">
+                  <conditions>
+                    <condition field="selections" scope="ec7c-18f7-71ee-668a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6cd6-0aa4-1ea3-9361" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="21.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aa1f-2fff-1016-a072" name="Spears" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="ec7c-18f7-71ee-668a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0977-d6db-94fa-f6e9" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aec-5b55-caf2-e594" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1c34-d70a-b6ef-7062" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8c23-c021-c91d-50c7" name="Banner Enchantments" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6319-d984-811e-b395" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="748f-b503-aed7-2613" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59c7-307d-ab8d-25a5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0702-b3ab-a9d7-b6e9" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="175a-88d4-3803-e6b9" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2c41-4baa-fe9f-f252" name="Totem Animal" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffb0-3cab-24f3-455d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="aafc-520d-c77c-310c" name="Piranha" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="ec7c-18f7-71ee-668a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0977-d6db-94fa-f6e9" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4415-1531-51a9-adb3" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="20d8-a7ca-5329-8e3c" name="Piranha" hidden="false">
+                  <description>The Saurian Warrior gains Fear</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="3c41-b827-044f-b8a8" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6cd6-0aa4-1ea3-9361" name="Serpent" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="ec7c-18f7-71ee-668a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0977-d6db-94fa-f6e9" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4708-7745-8d97-55c7" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="4713-c55c-c075-2a79" name="Serpent" hidden="false">
+                  <description>The Saurian Warrior gains +1 Agility and Fight in Extra Rank.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="6c54-e24c-718a-1c3a" name="Fight in Extra Rank" hidden="false" targetId="f07b-fa49-1de5-8a2b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0653-8ee0-35f4-a39b" name="Jaguar" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="ec7c-18f7-71ee-668a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0977-d6db-94fa-f6e9" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0d2-28ed-2c83-6bde" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="711e-4c87-45a4-95a9" name="Jaguar" hidden="false">
+                  <description>The Saurian Warrior gains +1 Advance Rate and +2 March Rate.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e159-6644-282e-e8ec" name="Crocodile" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="ec7c-18f7-71ee-668a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0977-d6db-94fa-f6e9" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93fb-193a-d746-dfbe" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="2035-7c76-30a8-0c83" name="Crocodile" hidden="false">
+                  <description>The Saurian Warrior gains +1 Armour against Close Combat Attacks.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f5ab-5a90-c176-c37b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6d6a-55bb-f04f-5b8f" name="Skink Braves" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="58ec-ff9e-eebe-bb20" value="1">
+          <repeats>
+            <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f841-4839-8388-1b9c" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58ec-ff9e-eebe-bb20" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="597a-951e-ce93-0b87" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="12ce-084a-96f2-1904" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3821-94e9-a2ac-22b2" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f116-6256-a205-3024" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="92a6-7b0f-50b0-37ae" name="Skink Brave" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16bd-b53a-7918-f605" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ef1-24e0-6d11-15eb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c891-9bc0-1ac5-8ffb" name="Skink Brave Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7ff1-0cf0-100c-243e" name="Skink Brave Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="55c4-6cce-12a4-91ce" name="Skink Brave Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dee4-4137-3f7d-da2d" name="Caiman" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="c6b3-ae4a-ca9e-8291" value="1">
+              <repeats>
+                <repeat field="selections" scope="6d6a-55bb-f04f-5b8f" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92a6-7b0f-50b0-37ae" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6b3-ae4a-ca9e-8291" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ee69-6fda-7437-f8b5" name="Caiman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f63e-bc10-b3dc-67c8" name="Caiman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cdd7-5b1d-61a6-2656" name="Caiman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0d51-7039-ebc4-0a73" name="Combined Strength" hidden="false">
+              <description>Skink Braves and Caimans in the same unit do not share a common Health Pool even though they are both R&amp;F models. Instead, each type have their own Health Pool (lost Health Points are never passed between the types, and any excess Health Points are lost). 
+
+­ Distributing Hits: When distributing hits to the unit (i.e. for attacks towards the unit as a whole), first distribute hits between R&amp;F models and Character(s). Then randomize all hits distributed onto R&amp;F models. Roll a D6 for each hit: 1­4 hits a Skink Brave, 5­6 hits a Caiman. If the R&amp;F Skink Braves lose enough Health Points in order to wipe them all out, any remaining Heath Point losses suffered are distributed onto the Champion.
+­ Stomp Attacks: When distributing hits from Stomp Attacks, ignore all models in the unit that are not Standard Infantry. Hits distributed onto Skink Braves are not randomized.
+­ Allocating Attacks: Close Combat Attacks can be allocated as normal towards different Health Pools in base contact</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="4b74-5d3a-df41-febb" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+            <infoLink id="d6ec-3864-0cb8-57ec" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4c8e-77ed-4d4d-eb5a" name="Banner Enchantments" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a73-c269-0cfe-d847" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9d4d-23ae-c410-491d" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a07b-2ac0-7094-fc3d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="64f6-5f39-dd40-80f8" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="873c-cbb5-487d-0904" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba05-3f2d-9e5a-dd48" name="Weapon Option" hidden="false" collective="false" defaultSelectionEntryId="f355-8654-860c-b2c7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fca-019c-8f23-8447" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="012c-56aa-f496-178d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f355-8654-860c-b2c7" name="Hand Weapon &amp; Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2fc-9775-04aa-ca90" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4a3a-9546-bc68-e41f" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="41d2-2aa2-e1bf-6dd5" name="Bow (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="6d6a-55bb-f04f-5b8f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="92a6-7b0f-50b0-37ae" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df0d-85c3-e19a-f624" type="max"/>
+                <constraint field="24fd-8af8-0c78-001c" scope="roster" value="80.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f8eb-755d-4f78-06f8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ad6c-cd2e-9057-01e1" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a67e-6d58-8e33-effb" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f841-4839-8388-1b9c" name="Skink Braves with Poisoned Javelins" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="3121-0761-90fd-b49d" value="1">
+          <repeats>
+            <repeat field="selections" scope="primary-category" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d6a-55bb-f04f-5b8f" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3121-0761-90fd-b49d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="30fe-6221-863a-2660" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="3942-8ede-de18-5caf" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="06d7-6464-5f31-9abb" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1956-b3de-eee8-86be" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e049-8f4b-7623-c845" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="e722-4039-0fd8-0b78" name="Jungle Guerrilla (local)" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0e53-5e2b-6831-6c29" name="Skink Brave" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7db-d0bc-abcf-6f14" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c0-f172-d10d-b538" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6bec-587e-6efa-4a63" name="Skink Brave Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="74f3-2fdf-9cdf-efee" name="Skink Brave Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="14bf-9a10-3514-8917" name="Skink Brave Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2ca1-a6f0-7ede-2223" name="Caiman" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="3a4c-a3b6-ef34-e472" value="1">
+              <repeats>
+                <repeat field="selections" scope="f841-4839-8388-1b9c" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e53-5e2b-6831-6c29" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a4c-a3b6-ef34-e472" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="080b-969b-a337-139c" name="Caiman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6c9a-079a-7228-6b43" name="Caiman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9e3d-feb3-0f5c-63b8" name="Caiman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="909d-bc9c-deb8-7722" name="Combined Strength" hidden="false">
+              <description>Skink Braves and Caimans in the same unit do not share a common Health Pool even though they are both R&amp;F models. Instead, each type have their own Health Pool (lost Health Points are never passed between the types, and any excess Health Points are lost). 
+
+­ Distributing Hits: When distributing hits to the unit (i.e. for attacks towards the unit as a whole), first distribute hits between R&amp;F models and Character(s). Then randomize all hits distributed onto R&amp;F models. Roll a D6 for each hit: 1­4 hits a Skink Brave, 5­6 hits a Caiman. If the R&amp;F Skink Braves lose enough Health Points in order to wipe them all out, any remaining Heath Point losses suffered are distributed onto the Champion.
+­ Stomp Attacks: When distributing hits from Stomp Attacks, ignore all models in the unit that are not Standard Infantry. Hits distributed onto Skink Braves are not randomized.
+­ Allocating Attacks: Close Combat Attacks can be allocated as normal towards different Health Pools in base contact</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="2a34-4056-c89b-3967" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+            <infoLink id="565e-84c9-1366-6783" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d6ca-b49a-4664-224d" name="Banner Enchantments" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1893-e0f0-0d12-7f2e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6027-87bd-cdf4-c698" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b9cb-1d35-43d6-8c64" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2c05-0af0-1d7a-050f" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="5e14-2b50-15bb-b79b" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="5bd4-bbfc-2b1b-0d11" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9dd1-eabb-2bae-1eaa" name="Temple Guard" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="581e-63a1-d51a-1a1c" name="Cobalt Club" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+          <characteristics>
+            <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+            <characteristic name="AP" typeId="646b-1e72-1589-5083">0</characteristic>
+            <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ad4e-a204-344a-1a39" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (General)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4ef5-fb41-8d8b-4897" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="c375-f199-d695-e424" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="663d-6a85-904a-50f8" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="714f-de90-0ba9-2f96" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="6508-2dee-bad7-d32c" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="7182-2277-125f-4ba8" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9561-cabe-7a6a-9d82" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1925-c019-9ea9-4f1e" name="Temple Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5724-beeb-0812-a70a" type="max"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6dad-4b79-0eaf-5e76" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="7d46-545f-dc97-1cd0" name="Temple Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="54d5-7bf6-d8b9-d062" name="Temple Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2614-9b2a-c130-630a" name="Temple Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="41b1-099f-7dff-cdb4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="32.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7459-c625-7b4e-3eda" name="Banner Enchantments" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da01-791c-b841-ad17" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="48a6-b2a8-4c0f-a26d" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="254c-9f3c-52f3-975a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="93b8-9c87-4a53-d5c2" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="d864-12fd-621f-0690" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7034-f2c9-76d2-ba90" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="307e-bcd7-0a5a-1fa9" name="Raptor Riders" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aa7-43bb-9fe0-6d35" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1cd5-5e49-48fd-da65" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="a3f3-ea1f-1366-8f25" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="9396-8ce7-3e14-2451" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3923-1dbe-853e-616b" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="2ee2-bacc-207a-c5dd" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="ceb2-76f4-0231-3ba9" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b3e4-6a49-eb46-3aad" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d9f5-a7a4-e504-278c" name="Raptor Rider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29d4-c24b-6c09-3761" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9e9-305d-c2a4-8f30" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a005-5d3d-254d-2987" name="Raptor Rider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="796b-f5f3-1992-8d12" name="Raptor Rider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="93a1-7679-5327-596b" name="Raptor Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cb0a-3b0d-3364-e83e" name="Raptor Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="9cae-a84e-f2fc-823b" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1192-6bc7-db61-2e67" name="Banner Enchantments" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfc0-231a-4d65-b78a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="69c8-8d04-b5fd-76ae" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ec4-507d-710f-4951" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d761-7d99-717d-4b06" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="4d03-00e5-f632-3c88" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="59f8-ba2c-6e86-c202" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="56f2-0046-f90a-d2cf" name="Caimans" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="3ae9-1691-7c78-ba7e" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="3613-0a30-ce1f-b663" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="a01f-79c9-7040-f44c" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3f06-88dd-9f69-7f6e" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ac84-137c-a6b6-d8cd" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5e05-40b7-db4a-4e7f" name="Caiman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3041-4159-b160-2222" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9807-bb7f-fbbb-5312" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a0b3-2d4c-3741-10d6" name="Caiman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7887-ea77-1811-804a" name="Caiman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ae42-2e17-c726-4831" name="Caiman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0267-35ff-59dc-fa5d" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="931c-110d-e390-b389">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da79-24ee-53aa-11c1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a147-1b9a-1b70-e87e" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="931c-110d-e390-b389" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e559-3e18-7541-60b2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5ce8-4918-ac90-5a87" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16f9-8004-7d66-99ae" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="6">
+                  <repeats>
+                    <repeat field="selections" scope="56f2-0046-f90a-d2cf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e05-40b7-db4a-4e7f" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b2a-ff22-db02-525a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ccb4-baba-bef7-fcac" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5cd3-f1cd-210e-53db" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="889f-5702-f98f-1605" name="Snake Swarms" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="094e-82c4-8219-bbd6" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="0528-c3cc-6b21-49a3" name="Venomous Tide" hidden="false">
+          <description>All models in enemy units must take a Dangerous Terrain (1) test after successfully charging a unit of Snake Swarms.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="df55-4ef0-8734-dc0c" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="474d-fcd8-8405-ab0e" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="b3ee-463c-0beb-1a65" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="4b96-7832-29ac-1757" name="Unstable" hidden="false" targetId="b642-5b33-158d-421b" type="rule"/>
+        <infoLink id="3308-ce09-2a8d-775e" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="152e-bbdf-3103-d082" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2258-f13c-792c-80aa" name="Snake Swarm" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="492d-8976-fa8b-70e3" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d81f-64d0-7157-18e9" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="aeaa-80ec-93c4-b8b5" name="Snake Swarm Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="620c-f3b3-0052-0608" name="Snake Swarm Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="adaa-b39b-f68e-dce3" name="Snake Swarm Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4127-dc90-b37a-bb7b" name="Scout" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+              <repeats>
+                <repeat field="selections" scope="889f-5702-f98f-1605" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2258-f13c-792c-80aa" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fde-befd-7507-b615" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="eeda-57cf-742d-6b3a" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b51-ef75-d0bd-20d6" name="Skink Hunters" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4279-55f7-5e69-5de0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1887-46e4-33f7-d89e" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="2875-ca8b-ea5b-e583" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="6b0b-56a8-9f42-d630" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0f45-652e-c364-2fdf" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8add-59fb-f572-c59d" name="Jungle Guerrilla (local)" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9458-4735-c47a-42fb" name="Skink Hunter" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d775-46fb-981d-b892" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8a5-e096-3bbe-0c0b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0e2c-bffa-1c6f-5512" name="Skink Hunter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="362e-4672-db3c-6dc0" name="Skink Hunter Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7daf-d695-8071-fc00" name="Skink Hunter Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3eaa-51fa-7cb8-eede" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a440-8791-c2cb-1db1" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0553-8fea-dc17-c2b8" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d1a-56f6-a172-12a2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="035a-72db-b660-a750" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bc61-559e-87fa-ae5b" name="Weapon" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="43de-0f07-7470-ba50" name="Poisoned Javelin &amp; Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96e0-feb0-0c51-556a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8725-ae41-de0f-ac3b" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3455-a6fa-6fef-469e" name="Blowpipe" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="6b51-ef75-d0bd-20d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9458-4735-c47a-42fb" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e40-0611-c9b8-d45d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7164-3183-9900-fd05" name="Blowpipe" hidden="false" targetId="7d16-fc1d-6a00-9eb1" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c47d-f1d3-eaf7-54e1" name="Chameleons" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e4c-c64f-446b-9c25" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d9da-42ad-189a-92a6" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="26b6-8794-945d-9de3" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="b873-15ba-2706-cbd2" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="92ab-a16f-9cdc-3200" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="2a0c-3708-f5f2-5e5d" name="Blowpipe" hidden="false" targetId="7d16-fc1d-6a00-9eb1" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a240-4af0-5886-46c0" name="New CategoryLink" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9907-512b-a517-ea53" name="Chameleon" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff14-ff70-6bc3-c68a" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="805b-d297-fb25-c2cf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0a08-a9fe-e6d6-d2c4" name="Skink Hunter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2b8a-f455-3360-9554" name="Skink Hunter Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6bf7-ccbf-406b-cfbe" name="Skink Hunter Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="083a-b4e4-f1b9-226e" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c989-82d6-8173-59d5" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b559-dce8-c95d-fc08" name="Weapon Beasts" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5df-1edf-4f29-797a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d298-188b-b40f-65ff" name="Weapon Beasts Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9324-cace-82a6-ff5c" name="Weapon Beasts Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2532-ec6d-57c9-b74b" name="Weapon Beasts Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b52c-9103-b617-b372" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="42e3-b6df-ff42-1e67" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="05f9-78d1-0f29-2805" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3df6-9bef-04de-85bd" name="New CategoryLink" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="865f-aebd-d259-dbf7" name="Spearback" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b559-dce8-c95d-fc08" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0cf-fa78-91ab-de9d" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="976e-8b8c-4465-a72c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e144-8211-ff12-b26b" name="Shoot Spikes" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+                <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6</characteristic>
+                <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+                <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire. Cannot be used if the model performed a March move. Must declare Stand and Shoot as a Charge Reaction if possible, but does not suffer -1 to hit modifier.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a0cf-fa78-91ab-de9d" name="Salamander" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="b559-dce8-c95d-fc08" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="865f-aebd-d259-dbf7" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b9c-8799-0f33-a805" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fdc3-be71-dd09-b27c" name="Spout Flames" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">8&quot;</characteristic>
+                <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+                <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Flame Thrower Artillery Weapon, Flaming Attacks. If a Misfire is rolled, the Salamander always counts as rolling the 5+ Malfunction result.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0b7-f470-5bd9-2343" name="Pteradon Sentries" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="985d-861b-40a3-3a7e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="faae-8259-1053-d58c" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="a613-1066-b6eb-e85c" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="2582-7573-0daf-8cf8" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="6044-e912-b849-5b55" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="570f-a656-82cf-bd7f" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7a1d-0610-7168-3326" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="d72f-b69e-499d-a89d" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="6593-c38d-9f19-2748" name="Release Rocks" hidden="false" targetId="8673-0260-df96-1ca2" type="rule"/>
+        <infoLink id="b5d1-0367-4c48-5f17" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b0b2-34f9-6eab-0fc4" name="New CategoryLink" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="74e7-e743-41a4-a508" name="Pteradon Sentry" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed4c-5f9d-8c19-198b" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f701-a572-9f1c-3eb4" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="97ae-1d61-178c-3db4" name="Pteradon Sentry Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2598-29f9-5ae8-c488" name="Pteradon Sentry Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="210f-101a-8166-94df" name="Pteradon Sentry Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e39a-70e0-03eb-80e8" name="Pteradon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5c36-96fc-cc98-7910" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+              <repeats>
+                <repeat field="selections" scope="e0b7-f470-5bd9-2343" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74e7-e743-41a4-a508" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="766d-6961-8ef9-4f36" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2432-e8ab-b80d-8148" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="948f-9183-3942-0747" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5730-e7a3-11ed-aa48" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d05c-3251-8b91-01ec" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="bf88-5ad3-8074-6f38">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b9e-657f-4aef-1511" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3d49-f30b-cba4-b2f6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bf88-5ad3-8074-6f38" name="Poisoned Javelin (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50b8-6eae-aae9-ff18" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e47c-e465-0b91-d54c" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16fd-bf48-8a19-27ac" name="Fire Bola (4+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="e0b7-f470-5bd9-2343" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="74e7-e743-41a4-a508" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7508-2b29-6fd4-1e4e" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="28d3-f270-bdc5-3d24" name="Fire Bola (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">8&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Flaming Attacks, Quick to Fire.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e90-3f58-5696-193e" name="Ramphodon Riders" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7540-9fb6-5793-cbdb" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="27a4-f066-1be2-695a" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="33d5-e2b5-1be1-31c3" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="fcc0-e3f3-1d86-0b73" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="0af1-fb16-b98d-e92f" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="567a-22b3-1b0e-3421" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="d865-8d00-25f5-eecd" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="e0c3-5eba-62f6-f317" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="045c-7671-b3ca-9141" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="cd83-21c1-4ef4-dec0" name="Prey Scent" hidden="false" targetId="4f66-9166-2062-6337" type="rule"/>
+        <infoLink id="eb38-9220-d373-215c" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="7c41-2479-ae8e-83f4" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="4db6-2316-a754-79b6" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="f9fb-9e0d-e74c-617d" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="0c5b-8f0c-9e77-98ea" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fd45-dd2d-de5a-9f1e" name="New CategoryLink" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c9bd-3e81-e42d-c4e1" name="Ramphodon Rider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2269-a895-7780-7517" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec93-5a2f-afb9-8e29" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3e41-80e9-4de1-26df" name="Ramphodon Rider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (8&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (16&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="07e7-509f-2d95-53d2" name="Ramphodon Rider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4916-e1ca-15da-cff0" name="Ramphodon Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3579-987a-dbb6-f883" name="Ramphodon" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="62.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3228-1b46-622d-e3ed" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+              <repeats>
+                <repeat field="selections" scope="6e90-3f58-5696-193e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c9bd-3e81-e42d-c4e1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cdd-5a79-4348-6161" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d08b-092f-766e-28ea" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="247a-9f0b-0963-3c12" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="340a-4e6a-2d29-b859" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="29.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7aec-c5e2-0281-0b84" name="Taurosaur" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="774b-1fa0-6a9b-9082" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fae9-4b42-d050-978a" name="Taurosaur Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b3e5-b4e5-0ce6-de85" name="Taurosaur Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="991c-303d-d632-28ea" name="Taurosaur Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1899-faa2-9872-7404" name="Skink Crew (5) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="e8b3-ab0a-35fa-1234" name="Sharp Horns" hidden="false">
+          <description>The model part may reroll the dice for number of Impact Hits it causes.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="86b7-60ec-eed6-78ac" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="0c6c-87b4-160c-42c6" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="50fe-8701-5086-2a99" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f183-76d5-8b19-a9bd" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="43b5-cc94-7a24-6ff4" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="77ea-9d2f-15d2-3a3e" name="New CategoryLink" hidden="false" targetId="634f-0995-844c-451a" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0f56-008b-58c3-974b" name="Options" hidden="false" collective="false" defaultSelectionEntryId="c322-0240-1ade-7b34">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb3-936c-d599-e89f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d5-982d-a50f-1887" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c322-0240-1ade-7b34" name="Giant Blowpipes" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2558-30d0-a20c-5bb1" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6aa7-b788-f704-b23b" name="Giant Blowpipes" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">8</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Poisoned Attacks</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e5a4-e538-f631-901a" name="Giant Bow" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d97b-f0b0-16fd-5b39" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="b595-1c4d-8e37-9a23" name="Giant Bow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">36&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3[5]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple wounds (D3)], Quick to Fire</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="13c6-218c-5392-bed0" name="Engine of the Ancients" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dba-a6d8-4681-1208" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c774-989e-48d9-2203" name="Engine of the Ancients" hidden="false" targetId="bca6-c3cb-3ba2-61f1" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="450.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5f37-052e-e523-e174" name="Stygiosaur" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af8-829a-02f1-cab5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5ac8-7c07-bb06-4682" name="Stygiosaur Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4149-3fc6-f1a8-caca" name="Stygiosaur Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8ef8-dd4c-bd03-2ed6" name="Stygiosaur Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="80fc-e591-be9c-32c6" name="Skink Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="dad1-0ee7-ce84-4ba3" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="22ff-6256-99dc-8389" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="5282-7bb2-1b0d-5c7e" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="1009-a892-028c-e5c2" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="afb0-1391-0b1c-95eb" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="cc19-772b-4d9e-712d" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="75a3-3ab3-f7f9-a109" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Toxic Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ca4f-4b78-f4c0-04f8" name="Stomp Attacks" hidden="false" targetId="4810-6726-807b-e78e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5ea0-8ea5-d335-1669" name="New CategoryLink" hidden="false" targetId="634f-0995-844c-451a" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9c0e-b8da-fc72-14ba" name="Mystic Traveller" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="222c-0a87-727c-e45f" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="9b11-0cd1-30b0-a7c0" name="Mystic Traveller" hidden="false">
+              <description>The model part gains Telepathic Link and is a Wizard Adept that selects 2 spells from Swarm of Insects, Savage Fury, Awaken the Beast (Shamanism), and Spark of Creation (Hereditary Spell) during Spell Selection. This rule overrides the normal Spell Selection rules connected to being a Wizard Adept.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="8b5b-1885-d588-86d8" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+            <infoLink id="3cc7-59d4-4db5-5080" name="Telepathic Link" hidden="false" targetId="cf78-dd60-d1a6-0a34" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="305.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c39-d252-7c8a-162b" name="Thyroscutus" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b9f7-fb1c-2df0-d105" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2823-7ef6-1457-9c8d" name="Thyroscutus Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="18d7-3e50-fdb1-9dd1" name="Thyroscutus Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7acf-c7c5-b3f3-72cc" name="Thyroscutus Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4997-ce3d-79a8-5639" name="Skink Crew (4) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1ce9-59b9-204d-0e1b" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="536b-09e3-aa7e-321b" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="fe95-59a9-ed8c-6636" name="Crush Attack" hidden="false" targetId="9371-5924-2a39-1652" type="rule"/>
+        <infoLink id="1690-5b9d-4ab5-35ae" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="590c-1af4-e3b0-696d" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d415-c671-5182-bfbe" name="New CategoryLink" hidden="false" targetId="634f-0995-844c-451a" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="54f6-3cb9-73e4-3271" name="Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1461-23ba-6158-5466">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a5f-96bd-1a28-31ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="052c-9722-9615-bf31" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1461-23ba-6158-5466" name="Altar of the Snake God" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="018b-a537-a32b-1d92" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2411-d672-6b93-64f9" name="Altar of the Snake God" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">2D6</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="fe0d-1bda-70f1-941d" name="Altar of the Snake God" hidden="false">
+                  <description>The model gains 2D6 attacks with the following profile: Agi 1, Off 2, Str 2, AP 0, Poison Attacks.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="a16f-2d5b-16ae-8415" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d9d9-f662-0249-3e18" name="Sun Engine" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b37d-1414-ac88-95dc" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="876a-ba23-43ed-efe6" name="Sun Engine" hidden="false">
+                  <description>The Model gains Channel (1)</description>
+                </rule>
+              </rules>
+              <categoryLinks>
+                <categoryLink id="558b-bb48-95c1-6919" name="New CategoryLink" hidden="false" targetId="1976-36a2-72b9-c7b0" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="320.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="31c1-8fb9-67db-b5b9" name="Skink Captain on Flying Mount" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="decrement" field="3265-ec6d-5129-c6f7" value="1">
+          <repeats>
+            <repeat field="selections" scope="953d-22cd-7ee1-36dc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bb82-02bc-5d73-8912" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3265-ec6d-5129-c6f7" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9fcc-207e-9d07-2abb" name="Skink Captain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d666-2987-4dd4-203c" name="Skink Captain Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="365c-9092-4321-d0aa" name="Skink Captain Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a8fa-67c7-2979-0ec9" name="Cold Blooded" hidden="false" targetId="c357-84cc-757a-d28b" type="rule"/>
+        <infoLink id="68ea-9527-2d7c-67ef" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Water)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b7d7-bf2d-0258-7cb1" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="cdbc-d4c5-0535-303c" name="Jungle Guerrilla (local)" hidden="false" targetId="0a69-f7af-e4da-3ad0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e58b-336b-9230-65af" name="Army General" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="31c1-8fb9-67db-b5b9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="132c-cf56-db36-e216" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2f-f7d1-88c4-e1b7" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a0f2-87ee-f02a-9152" name="Army General" hidden="false" collective="false" targetId="e83f-913c-3c4d-e94f" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="132c-cf56-db36-e216" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="31c1-8fb9-67db-b5b9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e58b-336b-9230-65af" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="311d-d99c-e5c0-9c96" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5c23-5d1c-3809-2610" name="Battle Standard Bearer" hidden="false" collective="false" targetId="72de-6c90-9501-10e4" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ce6c-5766-d561-beac" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cd42-3489-861f-1387" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8d72-95a4-9ec0-c392" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="624b-8f51-a861-10be" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9434-04ea-4e0d-7309" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="6c96-3878-5f62-2c2d" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c96-3878-5f62-2c2d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="eb7f-cb56-4712-70ef" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                    <entryLink id="8536-921b-f9f2-a1b6" name="SA Armour Enchantments" hidden="false" collective="false" targetId="6fe8-04b0-a5d9-54c8" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6364-0c0c-fc76-ca68" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c08-8231-4ee0-5ae3" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6d99-d419-b7f7-89c7" name="Charms" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="f9a3-011e-f0a5-1663" name="SA Charms" hidden="false" collective="false" targetId="a0e3-1a30-8bc0-a21b" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="2ed8-e4eb-fe4e-532d" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86d2-ab78-c647-bf2f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="41c2-e6ca-f2d0-6161" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="bc6c-4135-9fa1-cf6c" name="SA Weapon Enchantments" hidden="false" collective="false" targetId="c844-a799-25b1-f0a2" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="ba4e-8404-4c42-6301" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="31c1-8fb9-67db-b5b9" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="132c-cf56-db36-e216" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e6b1-b1f8-d752-f9e8" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ff91-808e-69e5-546b" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="aa58-03fc-2dd6-fe28" name="SA Banner Enchantments" hidden="false" collective="false" targetId="8e5e-ed54-0253-b5c1" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2e82-b811-b87a-5da6" name="Shield" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f731-e77e-d9f5-a13f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="42f3-553e-efce-33bd" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8675-b017-ee79-3ce0" name="Ranged Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1173-552d-feb8-6e57" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2a0-3ea8-3ca8-1a85" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="79ec-4067-063a-3348" name="Blowpipe (4+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6004-9d29-61c2-a900" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="225e-09a2-ef1c-95dd" name="Blowpipe" hidden="false" targetId="7d16-fc1d-6a00-9eb1" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ada6-6dcc-7c86-e5ab" name="Bow (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebca-b56d-321e-4c99" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e9f1-e21c-8fa5-2868" name="Bow" hidden="false" targetId="a564-30bf-f33f-f20d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3de7-d153-30aa-d0b8" name="Poisoned Javelin (3+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dab8-fbcc-7c9d-d0d8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3510-a9b3-3c61-9bfd" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e97f-7d2e-5619-cfb4" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="10ed-a4b5-17ea-058e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e5c6-6e22-6f3b-2768" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea8-787b-9068-8235" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="116e-b664-7215-17a4" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1f17-e3c4-d725-537b" name="Light Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="940c-5e90-99c4-30d1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c1b5-af46-504f-c33e" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6e96-f721-2d68-26b2" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e9e8-ba4f-4d2a-4016" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f1e-0476-7bb2-8e6e" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a98e-e776-82fb-4169" name="Alpha Pteradon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1242-d879-f259-2345" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6d13-c564-c5b6-f16a" name="Alpha Pteradon" hidden="false" collective="false" targetId="374e-280b-e6df-55c3" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f587-f507-e759-74c6" name="Alpha Ramphodon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ae-012b-6a1d-60a9" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="47f8-25ac-2586-777b" name="Alpha Ramphodon" hidden="false" collective="false" targetId="966e-fff0-4a98-0db0" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="f48b-b975-d560-7aa5" name="Carnosaur" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa19-c139-e26f-47cd" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9793-d653-e433-67ff" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="ae6b-a06c-2a73-8c25" name="Carnosaur Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="20da-1fb4-2a77-edc4" name="Carnosaur Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c290-433c-1b55-2898" name="Carnosaur Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9171-799f-129b-29e6" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="37f2-0a39-c5ad-2f79" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="5b13-63df-1ada-12d2" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="3a61-b902-847b-3f31" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="bae6-6792-c2f2-6e0f" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="9a24-b943-2e9d-87bb" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="f833-f008-a735-3bc3" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, against Large)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a35-f5d6-d8da-bdbe" name="Alpha Carnosaur" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5522-1a9b-db1b-bf72" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6161-a67c-9359-cfba" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="1dab-1d82-4d64-ae93" name="Alpha Carnosaur Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9e3e-348f-6b9e-19ca" name="Alpha Carnosaur Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="be4e-c8ac-b7d4-b223" name="Alpha Carnosaur Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8091-922a-c6fe-8ec3" name="Apex Predator" hidden="false">
+          <description>When charging a single model unit with Gigantic size and/or Fly, the model gains +2&quot; to its Charge Range roll.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="fc92-7243-9e50-35c4" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="7914-ef86-d60d-ed69" name="Born Predator" hidden="false" targetId="dc2d-109e-9221-8880" type="rule"/>
+        <infoLink id="f5ea-c142-f980-7a76" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ce-5533-a7d3-7d9f" name="Raptor" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddc6-7ca1-d09d-0fc1" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1431-de7f-733a-7850" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="9b06-deb4-dd68-61e8" name="Raptor Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9085-8056-662f-f5f4" name="Raptor Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4854-4608-ccc6-9d9c" name="Raptor Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f050-aa9a-a0ba-bcde" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e83f-913c-3c4d-e94f" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4439-421c-04e6-0b92" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7df9-2700-e635-1efd" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1393-5ee8-8d0d-a784" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4fc4-798c-172e-2be1" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d113-3a75-17b9-bfb2" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72de-6c90-9501-10e4" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="270b-2e26-8f96-8ea6" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eebe-8d16-19a5-dcf3" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7492-6911-8b84-aa19" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="fcc8-c61b-c278-56be" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="374e-280b-e6df-55c3" name="Alpha Pteradon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd68-87fb-4531-8451" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f01e-ab62-c6e6-4f9c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9c41-1547-8062-3eee" name="Alpha Pteradon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5523-5147-0f8d-f946" name="Alpha Pteradon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3787-81b6-c226-6175" name="Alpha Pteradon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a981-240f-4358-5a16" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="1f8d-c219-734b-aa5a" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="a042-91fa-5310-c1c8" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="0027-b724-300a-987c" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="03d6-d29d-4476-cde5" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forests)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9ace-186f-6ac3-10d9" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="f1ed-9bcf-3ec7-7615" name="Release Rocks" hidden="false" targetId="8673-0260-df96-1ca2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="966e-fff0-4a98-0db0" name="Alpha Ramphodon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="586c-ca82-9d13-a8a1" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f2d-34df-277e-8f70" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fe6b-0886-c610-eee0" name="Alpha Ramphodon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="afc2-f8c0-e41d-d4a0" name="Alpha Ramphodon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7aee-9b07-f132-6f70" name="Alpha Ramphodon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ca45-5af2-dc73-2bc6" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3256-943f-063f-29c6" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="d197-8ce8-9cce-af07" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="5004-9eb6-1763-1738" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forests)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="366f-cd61-d7bc-9d3a" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="e1cb-f79e-2056-5350" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="56c9-9a24-7d4e-8ced" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="c1bd-ce09-a331-e97f" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="1aff-3234-5b0d-8a1c" name="Prey Scent" hidden="false" targetId="4f66-9166-2062-6337" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dcca-3010-963b-204c" name="Taurosaur" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b42b-8c27-cb66-99c8" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ce7-44b1-efcd-c033" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="315e-9f62-4a4e-4dd9" name="Taurosaur Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1174-3591-782b-fbc4" name="Taurosaur Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f124-f34f-e0cb-641d" name="Taurosaur Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a90f-00fe-62f8-97cf" name="Skink Crew (4) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="81af-1d1f-2aa7-c8d4" name="Sharp Horns" hidden="false">
+          <description>The model part may reroll the dice for number of Impact Hits it causes.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="00c0-cabe-7d0e-2b70" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="8c24-8b51-9dca-4f53" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3e34-3e39-78a9-b86d" name="Poisoned Javelin" hidden="false" targetId="7159-bd2f-96f0-eb19" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c81f-1020-77b5-5ea9" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="68b0-0a0e-c93e-80c2" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9244-0662-ce55-9ef4" name="Options" hidden="false" collective="false" defaultSelectionEntryId="6d11-f695-7253-ab5f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ff8-0cb8-934a-af9f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9b1-a68a-44d4-586b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6d11-f695-7253-ab5f" name="Giant Blowpipes" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d380-1857-60d7-33ee" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="47b4-43a8-888c-9072" name="Giant Blowpipes" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">8</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Poisoned Attacks</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="049b-40ea-7142-79e2" name="Giant Bow" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c58e-66c8-2b94-487e" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5465-a5f6-d154-0896" name="Giant Bow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">36&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3[5]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple wounds (D3)], Quick to Fire</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5054-b874-777f-182f" name="Engine of the Ancients" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ff0-2485-cafd-81d9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1bc1-7bc1-98ce-be3e" name="Engine of the Ancients" hidden="false" targetId="bca6-c3cb-3ba2-61f1" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c89a-f606-6965-c79b" name="Skink Palanquin" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f9-7c67-26c4-0189" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bd7-b3a1-f769-914c" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="15c6-6a3c-a00d-f81c" name="Skink Palanquin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1edd-bc2e-a277-2d1b" name="Skink Palanquin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1b57-aef3-5949-bb60" name="Skink Palanquin Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"/>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"/>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5"/>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6"/>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6660-59d0-4b2f-2f06" name="Skink Palanquin" hidden="false">
+          <description>The model Gains Stand Behind while it is joined to a unit of Saurian Warriors or Skink Braves that does not contain any Caiman models and counts as mounted. In addition to it&apos;s regular spells, the model knows the learned spell #1 from its chosen Path.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="eab8-a316-6306-5bbf" name="Tall" hidden="false" targetId="229b-fa84-b9fe-b1ff" type="rule"/>
+        <infoLink id="de3b-1c87-58a4-ae18" name="Restraints" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="5775-102a-5465-9515" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="42f4-67f4-c841-dc12" name="Stand Behind" hidden="false" targetId="ccc1-4db1-6ef8-8bc7" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="4ebc-0e65-8676-7430" name="Plaque of the Snake God" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="770f-adba-8c39-fb3c" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="ada2-d7f0-ac62-01d4" name="Plaque of the Snake God" hidden="false">
+              <description>All Skink model parts in the same unit as the Plaque of the Snake God gain Hatred.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="e28f-631c-fafc-9d0c" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="6fe8-04b0-a5d9-54c8" name="SA Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="f485-90a4-c99d-6543" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f485-90a4-c99d-6543" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b608-a4ab-0e0e-cf43" name="Taurosaur&apos;s Vigor" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7607-1094-f8e3-68de" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0477-15c1-0aba-4744" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0cb4-89cb-f8f5-9027" name="Taurosaur&apos;s Vigor" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and +1 Health Point.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6805-d0d3-2feb-2789" name="Serrated Scales" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="323b-d65f-297f-64d9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0951-0fed-9ebe-b477" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2b12-a0bd-fe26-fe48" name="Serrated Scales" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Grind Attacks (2) that are always resolved with Strength5 and Armour Penetration 2.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="0026-296e-f7be-d205" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c844-a799-25b1-f0a2" name="SA Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d33-886f-6de7-c2d6" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="02ba-47dc-522f-1ee8" name="Glory of the Dawn Age" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8288-b953-01c2-aa5c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba0c-5251-8cd4-5d5b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f768-24ef-491b-dc99" name="Glory of the Dawn Age" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Spear Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this enchanted Weapon gain +1 Strength, Magical Attacks and Multiple Wounds (2).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fa1c-0e08-ddf2-21eb" name="Wildfire Burst" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de04-eeb4-92f9-a55f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b665-67b7-dcd2-f010" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ec59-879d-4cfe-f4fe" name="Wildfire Burst" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Bow Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">This enchanted weapon has Shots: 4, Strength 4, Armour Penetration 1 and always hits on 3+. Attacks made with this weapon gain Flaming Attacks and Magical Attacks. A unit that is hit by these attacks loses Soft Cover until the end of the Player Turn (if it had it). If the enemy unit was in Hard Cover, it is now considered to be in Soft Cover until the end of the Player Turn. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a0e3-1a30-8bc0-a21b" name="SA Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="830a-4bf3-aa30-7fd4" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="1581-6e85-8ec5-8fe8" name="Starfall Shard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea9-359b-13f5-4d09" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc07-755f-c047-ac2a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="136b-44f9-124e-1eeb" name="Starfall Shard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The Bearer&apos;s model gains Aegis (2+, against Flaming Attacks) and Hard Target, and cannot benefit from Fortitude.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3be5-23e9-c563-1149" name="Spirit of the Stampede" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a84-0419-9074-c6f7" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e0a-0dd6-2506-7273" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ffe8-582f-029f-8224" name="Spear of the Stampede" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The Wielder&apos;s mount gains Impact Hits (+D6). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7c63-cccc-4a09-62c5" name="Egg of the Quetzal" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ead-1b0c-45c0-ead2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="512f-01b3-6f46-572d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d807-fc9f-f3d4-9dd5" name="Egg of the Quetzal" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains a Breath Attack (Strength D3+2, AP 1, Magical Attacks)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cacd-9386-b553-eed9" name="Jade Staff" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0a8-ccf0-9183-e6c4" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea23-6f90-0f45-e53f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="51ed-556d-8b2f-1e0a" name="Jade Staff" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer can cast Healing Waters from Druidism as a Bound Spell (Power Level 4/8).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5c28-afe3-e354-1ff1" name="Ancient Plaque - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75d0-ec11-8182-f991" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e491-7518-68d3-4ba0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2e91-1fbe-1300-c1ff" name="Ancient Plaque" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Once per friendly Magic Phase, the bearer may reroll one Magic Dice that was used for a casting attempt. This ability cannot be used when the bearer is casting with only one Magic Dice, and cannot reroll a dice which is one of three or more rolling the same value.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b076-fc34-9bc5-edc8" name="Obsidian Tesseract" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6572-e656-78b4-07d9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="363e-c132-598a-52ba" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f8c7-5529-1031-65b4" name="Obsidian Tesseract" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated in the opponent&apos;s Magic Phase after Siphon the Veil. When activated, remove 1 Magic Dice from the opponent’s Magic Dice pool.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c756-6eeb-7d35-a790" name="Sphere of Shielding" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9ee-cc3e-86e9-42f6" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04e5-fb87-028a-73da" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="df1d-e2ff-ebb9-d537" name="Sphere of Shielding" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models on Palanquin and Skink Palanquin only. The bearer gains Aegis (2+, against Ranged Attacks). The bearer may not take saves of any kind against Melee Attacks.   </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9cd3-1be3-7559-0fcb" name="Sun Tablet" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="060a-2bfa-4a74-59f7" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ca76-b2a2-f309-b001" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3897-bb55-ec28-6887" name="Sun Tablet" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer can select its spells from the Learned Spells 1, 2, 3, 4, 5, and 6 of its chosen Path and the Hereditary Spell of its army. This overrides the normal Spell Selection rules connected to being a Wizard Apprentice/Adept. This Artefact cannot be combined with Protean Potentate.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0372-9675-c91d-0b92" name="Raptor Spirit - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93aa-91a4-1b40-e276" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="411d-10da-1a43-0646" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="592b-7b0e-cf97-be51" name="Raptor Spirit" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +4 Advance Rate, +4 March Rate and Swiftstride. This Artefact cannot be taken by a model with Ranger&apos;s Boots.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8e5e-ed54-0253-b5c1" name="SA Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ab41-9b66-98ba-1cb0" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6e83-6c5f-2730-e11f" name="Totem of Mixoatl - Cannot be taken by Core" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c131-e9ac-5c64-705d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bf8-5c51-3a7c-7d8c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="acbc-cef9-9f15-05c4" name="Totem of Mixoatl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer&apos;s unit gains Hard Target. One use only. May be activated at the start of a Round of Combat, until the end of the Round of Combat all enemy units Engaged with the bearer&apos;s unit suffer -3 Offensive Skill.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ca34-00f9-787f-6e4b" name="Tree Frog Banner" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfb-e0f2-dd1a-a9e3" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5e7-c24d-6d04-c85e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a290-7e82-ee9f-cf68" name="Tree Frog Banner" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Close Combat Attacks from Skink* model parts in the unit gain Poison Attacks. If they gain Poison Attacks from a different source, these Close Combat Attacks with Poison Attacks automatically wound on successful to-hit rolls of 5+ (instead of 6+). *The following models are considered “Skinks”: Skink Captains, Skink Priests, Skink Braves, Skink Hunters, Chameleons, Pteradon Sentries ­ rider only, Rhamphodon Riders ­ rider only. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="dc2d-109e-9221-8880" name="Born Predator" hidden="false">
+      <description>Model parts with this Attack Attribute may reroll natural to-hit rolls of ‘1’ with their Close Combat Attacks.</description>
+    </rule>
+    <rule id="c357-84cc-757a-d28b" name="Cold Blooded" hidden="false">
+      <description>If more than half of a unit’s models have Cold-Blooded, Discipline Tests are subject to Minimised Roll.</description>
+    </rule>
+    <rule id="bca6-c3cb-3ba2-61f1" name="Engine of the Ancients" hidden="false">
+      <description>The model gains Telepathic Link. At the beginning of each friendly Player Turn, choose one of the following configurations. The effects last until the beginning of the next friendly Player Turn:
+- Choose a Magic Path. Friendly Wizards casting spells from this Path have the casting values decreased by 1.
+- During the owner’s Shooting Phase, pick an enemy unit that is not Engaged in Combat and within 9&quot; of the Engine of the Ancients. That unit suffers D3 hits with Flaming Attacks and Armour Penetration 10 that always wound on a roll equal to or greater than 7 - the target&apos;s Armour. A natural &apos;6&apos; always wounds and a natural &apos;1&apos; always fails to wound.
+- All friendly units within 6&quot; of the Engine of the Ancients gain Aegis (5+, against Ranged Attacks).
+
+The last configuration listed above is active starting from before the battle (after moving Vanguarding units) until the
+first friendly Player Turn.</description>
+    </rule>
+    <rule id="cf78-dd60-d1a6-0a34" name="Telepathic Link" hidden="false">
+      <description>A Cuatl Lord may cast spells of type “Damage” through a friendly model with this Universal Rule if it is within 24&quot; of the Cuatl Lord. When casting through the Telepathic Link, measure the Range for the spell from the Telepathic Link and use its Front Arc and Line of Sight. The Range of the spell is reduced by half. The Cuatl Lord may cast spells of type “Missile” even if it is Engaged in Combat as long as the Telepathic Link is not. If the spell is miscast, the Cuatl Lord rolls on the Miscast Table as normal and the Telepathic Link suffers a single hit with Armour Penetration 2 and a Strength equal to the number of Magic Dice used. If the Cuatl Lord casts a Learned/Trait/Bound Spell through a Telepathic Link, the Attribute Spell gets cast through it as well, applying the same restrictions as for the Learned/Trait/Bound Spell (only type &quot;Damage&quot;, Range is reduced by half, measure Range and use Front Arc and Line of Sight from the Telepathic Link. Attribute Spells with a type other than &quot;Damage&quot; are not cast). The “caster” is still considered to be the Cuatl Lord.</description>
+    </rule>
+    <rule id="8673-0260-df96-1ca2" name="Release Rocks" hidden="false">
+      <description>Sweeping Attack which can be used once per game. The enemy unit suffers D3 Strength 4 Armour Penetration 1 hits for each Pteradon in the unit.</description>
+    </rule>
+    <rule id="4f66-9166-2062-6337" name="Prey Scent" hidden="false">
+      <description>Right before the battle (during step 7 of the Deployment Phase Sequence), if you have one or more units of Rhamphodon Riders or Skink Captains on Alpha Rhamphodon, you must choose 2 units from your opponent&apos;s Army List (this may also be Characters). The models of these units are considered &apos;marked&apos;. Rhamphodons (not their riders) gain +D3 Attack Value and must reroll failed to-hit rolls with attacks allocated either towards marked models, or towards models joined to units with more than half of their models marked. The additional attacks must be allocated towards marked models or towards models joined to units with more than half of their models marked .</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="7d16-fc1d-6a00-9eb1" name="Blowpipe" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">2</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Poison Shots, +1 to against units consisting entirely of Towering Presence.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7159-bd2f-96f0-eb19" name="Poisoned Javelin" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">As User</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">As User</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Poisoned Shots, Quick to Fire</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/sylvanElves.cat
+++ b/sylvanElves.cat
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c524-67bf-fa35-6c5e" name="Sylvan Elves 2.0" revision="15" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c524-67bf-fa35-6c5e" name="Sylvan Elves 2.0" revision="16" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="456a-ede0-3f5f-0c44" name="Unseen Arrows (local)" hidden="false"/>
+    <categoryEntry id="456a-ede0-3f5f-0c44" name="Unseen Arrows" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="110f-7489-f462-85df" name="Sylvan Elves (local)" hidden="false">
+    <forceEntry id="110f-7489-f462-85df" name="Sylvan Elves" hidden="false">
       <categoryLinks>
         <categoryLink id="b252-0891-2f28-7b0c" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>

--- a/sylvanElves.cat
+++ b/sylvanElves.cat
@@ -1,0 +1,3743 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="c524-67bf-fa35-6c5e" name="Sylvan Elves 2.0" revision="15" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="456a-ede0-3f5f-0c44" name="Unseen Arrows (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="110f-7489-f462-85df" name="Sylvan Elves (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="b252-0891-2f28-7b0c" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="da06-7e11-def9-2932" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="762a-6536-b762-9578" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="510d-eaa3-ad00-5cb5" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="cf15-3561-bf4d-34da" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="4f60-cd55-0403-83df" name="Unseen Arrows (local)" hidden="false" targetId="456a-ede0-3f5f-0c44" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="7454-77c5-1d5c-11a9" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="b023-0495-c4e8-40c1" name="Forest Prince" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="4cd1-897c-62d7-e6b3" name="Forest Prince Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e5b7-82fd-ba3c-c749" name="Forest Prince Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="decrement" field="160d-4624-273f-2114" value="2">
+              <conditions>
+                <condition field="selections" scope="b023-0495-c4e8-40c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3895-4d7e-7b33-7e92" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="b023-0495-c4e8-40c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37ec-99ea-0b68-7135" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5b30-9fad-bb05-0a13" name="Forest Prince Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="increment" field="8265-800f-bc87-d00a" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="b023-0495-c4e8-40c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3895-4d7e-7b33-7e92" type="equalTo"/>
+                    <condition field="selections" scope="b023-0495-c4e8-40c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5390-209a-e46b-7d79" type="equalTo"/>
+                    <condition field="selections" scope="b023-0495-c4e8-40c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37ec-99ea-0b68-7135" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">9</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4d37-8f7a-29e3-2787" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="4570-3786-572e-935a" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="22b4-9fbc-e9b1-5d6e" name="Accurate" hidden="false" targetId="68aa-b60b-ae0b-158b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="07d8-80c4-15a3-5797" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3641-44d5-f95a-74ce" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22f8-6894-495e-3d5b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9b3c-8315-b34b-7b95" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f627-45f0-2a2e-3ce3" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="81b8-902e-00ee-c2f7" name="Weapon Enchantment" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7926-8f9b-8f57-97af" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="339a-1636-e643-4098" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="1625-5965-8a94-6558" name="SE Weapon Enchantments" hidden="false" collective="false" targetId="8dce-f531-6766-23bb" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c506-66f5-8389-09a0" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="b023-0495-c4e8-40c1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6416-5971-e93f-f961" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="3a4c-6580-686b-18e1" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a4c-6580-686b-18e1" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="83c5-2bad-8d11-d911" name="SE Armour Enchantments" hidden="false" collective="false" targetId="fc23-2fbf-fbeb-58ae" type="selectionEntryGroup"/>
+                    <entryLink id="4c2f-ae06-fc14-0f8b" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="a97a-13c9-b158-f848" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d14-94a2-a24f-917a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="adae-fef9-9710-8c9a" name="SE Artefacts" hidden="false" collective="false" targetId="cdf6-5704-7840-27c9" type="selectionEntryGroup"/>
+                    <entryLink id="4a72-9886-6146-6d73" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c90c-0844-ca44-aecc" name="Sylvan Longbow (0+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45bb-5283-486a-ac45" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="48c2-8c10-948d-1bd3" name="Sylvan  (0+)" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6416-5971-e93f-f961" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="8069-a5cb-5939-fe24" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3223-a14d-fcc3-4e2f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5d96-7fea-5a66-c90b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="089f-e9aa-8f44-f18e" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="575a-e1a5-464c-4ff1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="abef-4606-5b78-7214" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a4cd-02c6-91fe-039f" name="Elven Cloak" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e1bb-6604-7fff-5eb5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f05b-829f-ce05-0c8f" name="Elven Cloak" hidden="false" targetId="653d-57ee-da4b-ee00" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7cc9-34fc-8b54-f8da" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bb4-3a02-b548-5ec0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8b11-044c-93e5-d11b" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="922d-b44f-192d-b615" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6c6e-478b-e20c-b945" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="555e-104c-db15-c963" name="Sylvan Blades" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="286f-758f-4af1-f55a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2af0-dbd6-6ec6-7cdf" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="01d1-573b-8b7c-5504" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="60fa-f02f-9be6-e040" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9db2-c101-625e-e6e6" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fdf4-0c53-4c0c-3c89" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f0e-d615-7a45-680f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="457f-68b5-1606-424a" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4223-bfd9-0564-3229" name="Sylvan Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="deed-f4ab-cfc8-1958" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="641b-e685-01d3-459d" name="Sylvan Lance" hidden="false" targetId="eace-9ec6-ad08-1b91" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9583-ca13-4ca0-b8e3" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d32c-ba85-c59a-a747" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d723-c1db-bf41-e4ec" name="Elven Horse with Light Troops" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="173b-83e8-6d93-754a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1348-cec3-783f-2f21" name="Elven Horse" hidden="false" collective="false" targetId="3f56-ff92-d185-1325" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="36bd-3317-b38b-6561" name="Great Elk" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="249d-da62-cac2-e027" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4f5a-4331-effa-f65c" name="Great Elk" hidden="false" collective="false" targetId="6a39-e6e4-6f61-f4ba" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1040-cd90-017d-a740" name="Eagle King" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8654-1790-6861-e708" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4200-6e60-2811-f02c" name="Eagle King" hidden="false" collective="false" targetId="62ed-ad30-adba-b070" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6f70-e31c-5552-54c7" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="63dd-6e22-f7b0-9d1b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="38a4-ddee-aee0-ac32" name="Dragon" hidden="false" collective="false" targetId="142b-2963-33de-cf84" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4245-a920-582a-3d5f" name="Kindreds" hidden="false" collective="false" targetId="ac3f-6d36-5a49-1439" type="selectionEntryGroup"/>
+        <entryLink id="5620-8f73-f44a-8954" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="215.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="50fb-277b-0b46-8ba4" name="Chieftain" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="975c-2f33-9ba2-79b6" name="Chieftain Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="836c-c30d-b243-a57f" name="Chieftain Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="decrement" field="160d-4624-273f-2114" value="2">
+              <conditions>
+                <condition field="selections" scope="50fb-277b-0b46-8ba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3895-4d7e-7b33-7e92" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="50fb-277b-0b46-8ba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37ec-99ea-0b68-7135" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9e5c-d2c6-5854-3930" name="Chieftain Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="increment" field="8265-800f-bc87-d00a" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="50fb-277b-0b46-8ba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5390-209a-e46b-7d79" type="equalTo"/>
+                    <condition field="selections" scope="50fb-277b-0b46-8ba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5390-209a-e46b-7d79" type="equalTo"/>
+                    <condition field="selections" scope="50fb-277b-0b46-8ba4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="37ec-99ea-0b68-7135" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="db18-121a-960d-b8f8" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="b810-c79c-e35d-07d8" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c7a0-a007-cd4d-763b" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1803-5248-0886-97c8" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="352e-1398-4370-a99b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6189-7382-a121-cea6" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a7c4-a768-1a89-e21f" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="215a-c15e-d7a0-9293" name="Weapon Enchantment" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dca8-b3b8-238d-2aad" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="b78f-e285-8001-e208" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="81c7-3c55-3954-03bb" name="SE Weapon Enchantments" hidden="false" collective="false" targetId="8dce-f531-6766-23bb" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e35f-69d1-e21e-6601" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="50fb-277b-0b46-8ba4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f28-89c7-0ada-226c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="8d03-d0a2-8d80-db1c" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d03-d0a2-8d80-db1c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6344-e3be-1fac-2fe4" name="SE Armour Enchantments" hidden="false" collective="false" targetId="fc23-2fbf-fbeb-58ae" type="selectionEntryGroup"/>
+                    <entryLink id="219f-9d3f-dea6-f27e" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e0a4-506c-ef72-30b3" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="093c-1588-96e7-2727" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="bc31-ab4f-2e53-9902" name="SE Artefacts" hidden="false" collective="false" targetId="cdf6-5704-7840-27c9" type="selectionEntryGroup"/>
+                    <entryLink id="b21c-38b7-bc9f-ebd0" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="60e5-6880-4101-1dda" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="50fb-277b-0b46-8ba4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41ed-f7f4-df23-2ae5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75a4-dc26-fe98-c49d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e2e4-a94f-415b-08ad" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="e969-3b40-8882-1c10" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aaac-c9a1-f256-fc3a" name="Sylvan Longbow (1+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="62e4-78ed-cba8-90b9" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="12ae-87b2-0127-aeec" name="Sylvan  (1+)" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd21-b53a-973d-6ea3" name="Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6dcf-a7ad-4ffe-45fd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d59-0476-d4dd-7c08" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="000d-7f3e-1275-eb14" name="Battle Standard Bearer" hidden="false" collective="false" targetId="41ed-f7f4-df23-2ae5" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6f28-89c7-0ada-226c" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="60fa-a6dd-9836-7643" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b45-6754-e7d6-4010" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="21e5-a5f5-9fb1-d4ad" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2352-0ac2-b45c-7598" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b77a-7016-1635-c825" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2ef4-543a-0b4b-c7e6" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6b6a-f112-455e-1e1a" name="Elven Cloak" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16c9-4cfc-0424-95f5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dbd7-9f6e-ef07-9a32" name="Elven Cloak" hidden="false" targetId="653d-57ee-da4b-ee00" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="718c-d5a0-07ba-230a" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a2f-6e9a-00aa-0b84" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6dec-24b9-2ce8-e210" name="Spear" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c2f-9702-0d57-2ce5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="eefd-9982-71e2-3c77" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c8bd-697a-d834-4615" name="Sylvan Blades" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2121-9ca8-2736-2e05" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d094-edde-be74-78f8" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d103-b0ee-e746-d4e1" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1431-e620-5242-6597" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6ce6-f0f3-ce87-c612" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ef40-e80b-65ae-d790" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc65-b891-3842-4de9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bd43-f0c4-ec69-d3d2" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7e87-3781-0eac-0c55" name="Sylvan Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e8ae-df67-15f1-f304" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="309d-7ef4-1846-8d38" name="Sylvan Lance" hidden="false" targetId="eace-9ec6-ad08-1b91" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f957-6951-921a-f4a7" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d0a-208d-ad34-d1c9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="30ff-1961-5c9f-f473" name="Elven Horse with Light Troops" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4369-bd7d-5ad8-64f8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="62ad-3d87-46a5-3018" name="Elven Horse" hidden="false" collective="false" targetId="3f56-ff92-d185-1325" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e49d-4559-7e40-6574" name="Great Elk" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22d8-7e87-fe1f-8ed5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ee75-bcc2-f104-0632" name="Great Elk" hidden="false" collective="false" targetId="6a39-e6e4-6f61-f4ba" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16f6-9842-4813-14cf" name="Eagle King" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8376-d645-5d1e-5e7f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="aadf-0a93-136e-f838" name="Eagle King" hidden="false" collective="false" targetId="62ed-ad30-adba-b070" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="140.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="dc51-2ddf-3842-841a" name="Kindreds" hidden="false" collective="false" targetId="ac3f-6d36-5a49-1439" type="selectionEntryGroup"/>
+        <entryLink id="f1b4-69e1-7aa3-8679" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41ed-f7f4-df23-2ae5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="145.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="007c-a130-48f3-47d0" name="Druid" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="43e4-63ec-d3ab-1bb7" name="Druid Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7b18-8676-a57d-37be" name="Druid Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="075b-608c-43a2-86fd" name="Druid Offence" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13"/>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6"/>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf"/>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0"/>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a5d9-8de5-8e4a-4b0e" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="43de-f948-9b64-7105" name="Tree Singing" hidden="false" targetId="838c-8a27-8500-a2d8" type="rule"/>
+        <infoLink id="9dfa-2d1f-6f6e-3ecc" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="34f0-613d-d0bb-6c68" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3623-c39d-c0cd-b09f" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be21-397a-20b6-0bb4" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8817-ac85-56e6-52d2" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="b96b-89dc-a609-941d" value="200">
+                  <conditions>
+                    <condition field="selections" scope="007c-a130-48f3-47d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="79f1-829b-6984-84fb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b96b-89dc-a609-941d" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="56b6-3a33-e958-6fb5" name="Weapon Enchantment" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39d5-793e-e653-07b6" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8764-4cd5-8bc3-721e" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                    <entryLink id="a631-627b-0795-5709" name="SE Weapon Enchantments" hidden="false" collective="false" targetId="8dce-f531-6766-23bb" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="473a-0060-e96f-1e7f" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b88-768b-8b3a-fe1b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ea4c-29de-7ff5-8972" name="SE Artefacts" hidden="false" collective="false" targetId="cdf6-5704-7840-27c9" type="selectionEntryGroup"/>
+                    <entryLink id="cfe9-eff7-07dc-5945" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4a8a-94b1-2b27-f329" name="Sylvan Longbow (3+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c77f-6736-dd1e-a918" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="812a-ab73-eba8-0cca" name="Sylvan Longbow (3+)" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e80c-10de-271e-5a39" name="Sylvan Blades" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce1c-6c93-7271-be6c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3e73-54cd-b017-f481" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c71a-7e3d-e9f7-cc37" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="4e0d-d4ae-58b5-824a">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="074b-3bbf-cac4-46c6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="302b-7d1a-1a2a-775c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4e0d-d4ae-58b5-824a" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43f3-8e3e-4d0d-2adf" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a6ae-53aa-2e22-36bc" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5b5e-ed64-8325-b5ab" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08e2-1dfc-3df5-c0db" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0790-039f-d2b5-b9c4" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="79f1-829b-6984-84fb" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c32f-5075-6cf7-0fb8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2b4d-18eb-a99b-084f" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a17f-d46d-b7a8-80a6" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="aa46-4ac6-aa57-0131" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aeb-1b47-2fb2-5798" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa46-4ac6-aa57-0131" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7296-6bd0-ba2f-5e80" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d66-fd80-4e57-00d5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c782-847b-b6b8-4717" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8bd0-f8e0-e6dd-6c34" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a4fa-c65f-238e-8135" name="Cosmology" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4daf-68c1-0ad1-2aae" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2230-9625-9db2-9e58" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0279-fab7-4ded-270c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1da8-d978-2321-0bc2" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe91-353e-567b-5c88" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4058-5f48-3f17-74ad" name="Elven Horse" hidden="false" collective="false" targetId="3f56-ff92-d185-1325" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5479-75f6-0383-ed39" name="Eagle King" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d64-94e1-043c-b7d5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c8fe-fe2d-8e72-a092" name="Eagle King" hidden="false" collective="false" targetId="62ed-ad30-adba-b070" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="65f6-5443-d5bb-bb15" name="Sylvan Unicorn" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a359-8acf-b7c7-4fad" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="abe8-5d55-28c3-e57f" name="Unicorn" hidden="false" collective="false" targetId="e48b-318c-1daf-3318" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cdda-235e-f4a4-b156" name="Dragon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f49-0c57-05c6-7bfc" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e247-338b-b682-2e8b" name="Dragon" hidden="false" collective="false" targetId="142b-2963-33de-cf84" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9bff-f1cb-c36a-d974" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="140.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a735-b492-9f88-9bd7" name="Treefather Ancient" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f47-e6b5-fab3-032e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="436f-c6eb-081d-e670" name="Treefather Ancient Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b21b-5104-4e97-2628" name="Treefather Ancient Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c5f6-178f-bea8-e586" name="Treefather Ancient Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4fb2-a4fa-7d1f-b956" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="5860-0549-d978-e212" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="0b25-80c1-bf54-a493" name="Tree Singing" hidden="false" targetId="838c-8a27-8500-a2d8" type="rule"/>
+        <infoLink id="12e8-49dd-90ad-bc4c" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule"/>
+        <infoLink id="b868-2904-ea6b-5acd" name="Impaling Roots (4+)" hidden="false" targetId="e86f-9c35-81dc-f09d" type="profile"/>
+        <infoLink id="6f6e-0e90-50a6-ab87" name="Crush Attack" hidden="false" targetId="9371-5924-2a39-1652" type="rule"/>
+        <infoLink id="8378-5121-9f72-8044" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+        <infoLink id="ef4c-9a44-2827-b3b2" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3e69-40f6-98cd-c4a3" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8848-7712-09e7-77b7" name="Wizard Level" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="628d-d08a-fa23-e7a4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="25da-135c-4fa0-de5d" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="822b-f0c5-380a-1b87" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ab1d-b599-c83c-7896" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="edcf-c948-2395-b5b8" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ed2-25d9-7a52-dd7e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7dda-7e88-104c-143e" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a4ed-0aa2-a0ba-e12d" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ae1-3d9e-906f-53a0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b138-38ac-1c65-990d" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="265.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a9f1-1cd7-b38f-f1bc" name="Artefact (No Dragonfire Gem)" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8848-7712-09e7-77b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3723-3ae8-ead6-338b" type="max"/>
+            <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22d4-d84d-485b-c1af" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f7b6-3220-f87e-99a5" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+            <entryLink id="be1d-3d48-fa01-10f6" name="SE Artefacts" hidden="false" collective="false" targetId="cdf6-5704-7840-27c9" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3575-981e-8b21-ac1e" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="24ca-deb8-54db-9af0" value="2">
+              <conditions>
+                <condition field="selections" scope="a735-b492-9f88-9bd7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="9981-b2b3-393a-186f" value="0.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8848-7712-09e7-77b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8848-7712-09e7-77b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9981-b2b3-393a-186f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24ca-deb8-54db-9af0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="070d-5439-af59-af7e" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="534f-89d3-043f-0b33" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="73c9-10bb-927e-ed03" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7a8-93b5-3faa-2a9b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7733-8776-bf02-953f" name="Aspects of Nature" hidden="false" collective="false" targetId="f998-cb94-e4fd-75e7" type="selectionEntryGroup"/>
+        <entryLink id="1cb4-9d10-bd7b-a64d" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="470.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a24-2eb3-7301-f9fe" name="Avatar of Nature" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ac7-93c8-5ee3-964e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a607-b2ac-1901-4e9f" name="Avatar of Nature Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a52f-e87c-bbd4-37c5" name="Avatar of Nature Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="90e7-1509-b45a-01ed" name="Avatar of Nature Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">6</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="668d-2233-2c6d-d7aa" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="0fcb-5414-ddb6-b4fb" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="49ff-8bb0-68cc-4600" name="Tree Singing" hidden="false" targetId="838c-8a27-8500-a2d8" type="rule"/>
+        <infoLink id="6e08-4535-4923-f845" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule"/>
+        <infoLink id="5a4d-881e-3b51-7196" name="Impaling Roots" hidden="false" targetId="e86f-9c35-81dc-f09d" type="profile"/>
+        <infoLink id="44da-af94-3486-5a2f" name="Crush Attack" hidden="false" targetId="9371-5924-2a39-1652" type="rule"/>
+        <infoLink id="2609-f5db-b1bd-3ac7" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+        <infoLink id="3165-9c47-788d-e895" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d6c1-647f-9c90-cbf6" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2bc6-5779-270f-6d68" name="Aspects of Nature" hidden="false" collective="false" targetId="f998-cb94-e4fd-75e7" type="selectionEntryGroup"/>
+        <entryLink id="c717-9a43-4759-b8d6" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="630.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="74f9-3d57-73a9-3c9b" name="Dryad Ancient" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="b705-f00f-934d-c5cc" name="Dryad Ancient Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bd30-b6b5-1db7-9457" name="Dryad Ancient Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fc48-d66f-9186-ae91" name="Dryad Ancient Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b57e-70e4-6bf6-ad76" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="dd59-2b6d-1dcf-af2f" name="Tree Singing" hidden="false" targetId="838c-8a27-8500-a2d8" type="rule"/>
+        <infoLink id="b4c4-fb21-fd8b-231c" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+        <infoLink id="17c2-1a02-b04e-7bd0" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fb33-2b58-02f1-85ed" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cc7e-9c25-b6bf-a8eb" name="Wizard Level" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c150-1bea-da9d-818d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3ce5-3fb4-db49-546a" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0cc-044e-4e10-d901" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7a9b-11bf-a4a7-f484" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1563-7381-c536-8b88" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a683-b51d-e2e7-ace0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0686-84a5-f63a-ac9b" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="afac-8783-b45f-a79d" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc7e-9c25-b6bf-a8eb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="8554-3663-3f27-fb8d" value="0">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc7e-9c25-b6bf-a8eb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8554-3663-3f27-fb8d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="50b4-a108-20bd-e543" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e72d-0135-7367-4799" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23bf-dd1c-5898-93c4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e6fa-bf60-b340-c228" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f7b-fd98-1e40-522f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7bad-2e6e-99f3-7a12" name="Aspects of Nature" hidden="false" collective="false" targetId="f998-cb94-e4fd-75e7" type="selectionEntryGroup"/>
+        <entryLink id="4d06-6bb0-8d9d-1f40" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db2e-06f5-8999-54a7" name="Thicket Shepherd" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c512-5c91-7fe6-438b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4546-b1a9-0b87-38b8" name="Thicket Shepherd Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0dc7-5d07-d87f-7430" name="Thicket Shepherd Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0b88-78ec-0db5-051b" name="Thicket Shepherd Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="ec39-c92f-ab92-e580" name="A Shepherd and its Flock" hidden="false">
+          <description>The model cannot join a unit that contains another model with this rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="5cb8-e22c-993f-13e9" name="Emboldening Boughs" hidden="false" targetId="b76c-3fbe-5461-6570" type="rule"/>
+        <infoLink id="7b32-d7cf-dffe-1f02" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="f523-c227-a090-6362" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule"/>
+        <infoLink id="7957-dd5c-c961-b835" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ae03-51af-956f-6752" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2c8e-6006-5b6c-233f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f902-8ec3-4850-2b03" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1489-c9c0-007f-bb0c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b4bc-8582-add3-61cd" name="Battle Standard Bearer" hidden="false" collective="false" targetId="41ed-f7f4-df23-2ae5" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="2049-a182-78e4-9dcc" name="Aspects of Nature" hidden="false" collective="false" targetId="f998-cb94-e4fd-75e7" type="selectionEntryGroup"/>
+        <entryLink id="3d8d-0db3-2662-510d" name="Army General" hidden="false" collective="false" targetId="6dcf-a7ad-4ffe-45fd" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="250.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="09de-b5cf-56fc-800a" name="Forest Guard" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="8ebd-866c-1bd2-561e" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="bf87-c8e0-9ade-217a" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="0493-c399-8137-45ef" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="88c9-05b2-33a9-6509" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f682-e4ab-8fd8-1d0e" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="34d5-3733-ab27-fa6e" name="Forest Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa10-4e55-1dfe-1b9b" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68da-3361-c241-f48b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1ec8-cd10-7aa5-1f51" name="Forest Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8943-6525-bb51-8a78" name="Forest Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3780-05ae-940c-cd23" name="Forest Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9156-44b6-fd0c-d8f1" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb71-504e-2898-eee2" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="062a-24f2-a64c-1b7d" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04a9-8297-bc1b-818c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5d7d-11b8-aee7-e38f" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="06ab-ed4b-aaaf-56fd" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dfc7-7e69-8f12-e89b" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="abb9-6790-59d9-7487">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0b0-f0d9-6404-8769" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="174d-d1a8-d5e4-aa6f" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="abb9-6790-59d9-7487" name="Spear and Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75f7-ccdb-ddbc-3fbd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="55aa-30d0-87eb-41aa" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+                <infoLink id="aee7-ab6c-83ba-45e6" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f49c-e707-1b0c-4248" name="Elven Cloak and Sylvan Blades" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="09de-b5cf-56fc-800a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34d5-3733-ab27-fa6e" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0af7-a508-79cb-384d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7581-730e-4c63-93d8" name="Elven Cloak" hidden="false" targetId="653d-57ee-da4b-ee00" type="profile"/>
+                <infoLink id="d86d-cf0b-19e0-ac19" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9f76-5b9f-55d3-dc37" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup">
+          <categoryLinks>
+            <categoryLink id="b5c5-ed99-018b-aa8d" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fcfd-0115-c5ee-407c" name="Sylvan Archers" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="1085-2dda-f7a1-36e0" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="e5f6-81de-c148-519e" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3e24-f842-e1a3-3d09" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="9973-ce90-e603-4865" name="Sylvan Longbow" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="df39-87e9-c4e1-b56a" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="22a7-cbba-00c2-851d" name="Sylvan Archer" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6874-91fb-b1d0-e37b" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbc7-a6b5-83d6-07cc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4113-3b33-11d9-8691" name="Sylvan Archer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cbcf-414e-ceb4-38a3" name="Sylvan Archer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c200-be37-0280-9acc" name="Sylvan Archer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="24.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f2f5-e3af-257a-162c" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ae6-95fb-e7ec-2338" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="19ad-8940-21c4-587c" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb5d-df3d-b33d-b5e3" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8136-7af9-48a7-bfd9" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="6797-d283-a719-8744" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="cd66-c012-9541-f244" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2e18-ac0c-d5db-4c8e" name="Heath Riders" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="95cf-98ab-b833-cff8" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ca3-5e76-0aa4-c22f" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95cf-98ab-b833-cff8" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e9cf-b80e-35df-6f3a" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="8f1b-c00f-c85d-546d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="4213-aa3d-6934-f99f" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="3c98-5ea3-3036-afcf" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="ef85-acff-3e5b-38ba" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="088a-8ba0-26da-e655" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="3ce6-66fa-a1da-48e4" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c4dd-9ade-903c-0c1b" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4bcf-b23d-13c5-56e0" name="Heath Rider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7767-cae7-7c41-af6f" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b43-4f9d-7f61-822f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a8d2-af4a-5387-983a" name="Heath Rider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c041-2fa2-90c8-b343" name="Heath Rider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="efd0-b391-602b-e794" name="Heath Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="24cb-21d2-1fa7-892b" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="32.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e2dd-e704-29b6-52cf" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8eee-d890-3047-cadb" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="78cc-53e3-a154-bb8b" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5afd-ac47-cd11-7e47" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6d04-e8e9-c464-75e3" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="9e98-6dad-3dac-c85e" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="6b40-8a3c-c716-d439" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8273-b85e-e788-9ff0" name="Dryads" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5c5f-490c-579c-2b03" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="74bc-b67e-d46f-3737" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="79c4-f358-bc28-752c" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="8273-b85e-e788-9ff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4db-42f2-8f93-4674" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9c46-ee56-4969-cca5" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+        <infoLink id="ad96-3870-80dd-1351" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f4ad-1675-4348-01bc" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a41b-80df-107d-6c89" name="Dryad" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="26.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0809-726b-c0e7-17d0" type="max"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4926-ae51-f6a2-1e6e" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="0195-3253-36fe-b93c" name="Dryad Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cc68-e619-0540-b1fc" name="Dryad Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f5e6-bd81-4a33-892a" name="Dryad Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="caac-55a7-fe81-fe71" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f9fc-e348-28f3-9f2e" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c4db-42f2-8f93-4674" name="Skirmisher" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="8273-b85e-e788-9ff0" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a41b-80df-107d-6c89" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="8273-b85e-e788-9ff0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a41b-80df-107d-6c89" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="671b-0478-e685-b5ca" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="13c7-a67e-74ea-abed" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1752-884a-82f0-a713" name="Forest Rangers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="964f-771e-3d0a-1891" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="faa9-b8d8-86c8-5f65" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="abc2-3d4e-4437-e5b4" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="0c0a-5853-e206-2a09" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="0900-e95a-7b70-2601" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="5a06-7778-8571-1995" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="9f56-5392-f6a8-c973" name="Elven Cloak" hidden="false" targetId="653d-57ee-da4b-ee00" type="profile"/>
+        <infoLink id="4373-07e0-4e5f-1c10" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3a0b-dd48-1e6e-ff02" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="13f8-0ad7-db4c-74ac" name="Forest Ranger" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8661-2822-ae7b-e834" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0023-a5a8-a818-7115" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b7b6-a9a1-c66d-9ebc" name="Forest Ranger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d265-220b-5bea-e4dc" name="Forest Ranger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="198b-04ce-d4ea-1d6f" name="Forest Ranger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e857-f973-97b9-7fdd" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6bd-5ba0-6333-958b" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8301-c631-c996-5984" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cd8d-99dd-5a2d-f31e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="36b6-8bdd-b900-12c2" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="49d1-5229-1f31-7c4f" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3678-427c-136f-a3dd" name="Vanguard &amp; +1 Advance Rate" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="1752-884a-82f0-a713" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="13f8-0ad7-db4c-74ac" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2315-d4f7-c2f8-71d8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fc81-e68e-d014-7d4a" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="effb-bd7d-e157-5fde" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="978a-7acc-601c-fef9" name="Thicket Beasts" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f5ee-2d3b-f89d-4ba8" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="57aa-a7de-2926-870d" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Thicket Shepherd)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d6c5-c91a-4c1d-cab6" name="Emboldening Boughs" hidden="false" targetId="b76c-3fbe-5461-6570" type="rule"/>
+        <infoLink id="62b3-feaa-e6f2-f8a8" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="4f0c-0e94-2815-966d" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4113-2a36-a034-32b2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9ed4-6bb3-e343-a34b" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule"/>
+        <infoLink id="7be7-5215-ef83-2270" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9ce1-9ddc-3924-5b92" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7ece-3031-d99a-ef23" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e462-4bd6-4a5b-09a7" name="Thicket Beast" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b2b0-eaae-ba09-c4c0" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1476-cca9-642b-db97" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1b0c-f7f0-c232-c5f7" name="Thicket Beast Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="97f0-2ada-a067-f2c4" name="Thicket Beast Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e7df-c4e3-4a7b-5b93" name="Thicket Beast Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="set" field="4d4a-2100-804f-99e5" value="5">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4113-2a36-a034-32b2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="7a8c-adb0-d1b8-a1b6" value="3">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4113-2a36-a034-32b2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="55c8-c908-5c8d-44be" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bade-230f-0d10-134c" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4113-2a36-a034-32b2" name="Entwined Roots Upgrade" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f5e5-c1c6-3ea6-9d8f" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+              <repeats>
+                <repeat field="selections" scope="978a-7acc-601c-fef9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e462-4bd6-4a5b-09a7" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dded-38ab-9ec5-74c9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c56a-2412-1c17-83bc" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ede0-34ee-bdca-d03f" name="Forest Eagle" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2325-2e5d-3f7f-f2ff" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="addb-96f3-90dd-77e8" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="7244-e996-ad87-50ca" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="87b3-abcd-0b70-bb97" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9c41-c14a-fbf0-3a1c" name="Forest Eagle" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7b0-4502-8cef-6495" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="20ca-fe3d-03dd-430d" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="cb8b-8219-152b-0523" name="Forest Eagle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c7d5-d88d-e605-0938" name="Forest Eagle Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d4da-aa24-9c55-4e13" name="Forest Eagle Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="434c-5d0f-6521-b61e" name="Blade Dancers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0303-d349-d091-a354" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="5205-15f1-1060-0644" name="Dances of Cenyrn" hidden="false">
+          <description>At the start of each Round of Combat, units consisting entirely of models with this rule must gain one of the effects listed below. No model may use the same effect in two consecutive Rounds of Combat. All models in the same unit must choose the same effect. The effects last until the end of the Round of Combat.
+
+Dance of Whirling Blades: +1 Attack Value.
+Dance of Biting Wind: +1 Armour Penetration and Lethal Strike.
+Dance of the Parting Mists: Aegis (3+), -1 Strength, and -1 Armour Penetration.
+Dance of Bedevilments: Fear, and enemy units in base contact with the model do not receive any Rank Bonus to their Combat Score.
+
+</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e5d3-110c-24d0-7afe" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="fa56-9ec2-1e0d-d508" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="f938-a79d-3f60-6c0e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="c07b-3132-d0fa-80d8" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="ccf1-de65-a063-4c90" name="Magic Resistance" hidden="false" targetId="3fbc-ceb2-b812-0e88" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5c4a-c249-7a6c-6f58" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="19a0-f5bf-5682-3890" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="908e-f0bd-1da7-652f" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0095-513a-ecad-e2af" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3657-1397-9807-40ec" name="Blade Dancer" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1d0-653e-d161-6f40" type="max"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="271c-1854-f292-383b" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="e707-88cc-ce84-4f58" name="Blade Dancer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="781a-adb0-75b8-740b" name="Blade Dancer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="aafc-6979-d212-fa8e" name="Blade Dancer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="32.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="790c-a1ee-e1ef-3e82" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3bff-984f-fbfd-019d" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7a74-1c9d-5834-1f97" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="48b3-5bce-e1bf-85b5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c83b-d827-2718-4d3c" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="6392-2377-dd8e-38fd" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="0707-c829-fda5-a733" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8be2-bb6b-fc85-e32a" name="Wild Huntsmen" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efb6-9b5c-97f6-275c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2d4c-73c5-1670-724f" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="c929-4ff0-df43-21db" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="57d5-f116-ed93-c6f4" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="2b64-99be-88a2-0f8e" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="ee5a-7db9-27ff-253f" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c8b0-5583-0344-a57f" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="a44d-de69-fb02-f098" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="65b4-44f6-7495-efad" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="a527-1f69-836c-74c8" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bc3d-8e14-f84c-50f1" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4496-4353-02e0-4cd8" name="Wild Huntsman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c15-bf5f-2151-fa93" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bc8a-e2c2-ae57-b057" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="f111-bd37-bf1b-8373" name="Wild Huntsman Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="64f0-6ab0-ca36-d2bc" name="Wild Huntsman Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3401-3832-20d2-4239" name="Wild Huntsman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="79f6-3cca-9af6-fe13" name="Elven Deer" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f99f-470c-086e-c043" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+              <repeats>
+                <repeat field="selections" scope="8be2-bb6b-fc85-e32a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4496-4353-02e0-4cd8" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a442-2822-d0bf-a7f4" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="367b-7903-762a-c218" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a9c0-fd81-dce3-8030" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c877-1125-5258-bb18" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1333-7522-d6dc-9d5c" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b472-8a6a-e80d-118d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="708d-ef9c-ab0a-12c0" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="57f6-44ab-a40b-02e6" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="245c-7e81-18d8-f334" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="a879-6f06-1b55-628c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c44-6caa-70e4-30d8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="214b-91a1-a2b5-07f9" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5897-ccbd-6463-f93c" name="Sylvan Blades" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="8be2-bb6b-fc85-e32a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4496-4353-02e0-4cd8" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="69b2-e604-c18e-ea93" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6a98-fe0c-488a-ed16" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a879-6f06-1b55-628c" name="Sylvan Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd93-7990-0c79-a131" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="236e-9b1e-d0ea-acb9" name="Sylvan Lance" hidden="false" targetId="eace-9ec6-ad08-1b91" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="74e7-73a4-850c-11cc" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9f07-3a57-f7bf-86b4" name="Kestrel Knights" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2394-c340-3bc5-c921" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="3b5d-ed97-c252-f125" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="24a5-c00c-8c43-4069" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="9380-fcd6-4502-beaf" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="a84f-522a-40af-7ced" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="5387-1279-e596-7e73" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="d78c-467a-4872-8acb" name="Sylvan Lance" hidden="false" targetId="eace-9ec6-ad08-1b91" type="profile"/>
+        <infoLink id="abea-e0a7-9a0c-52b2" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="ed63-a859-45e4-8a4b" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0c2a-1de9-18ca-6d81" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5750-fd16-7c1f-abad" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f2fb-466f-0a6a-19cb" name="Kestrel Knight" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d2b0-a5e5-2441-24e2" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9069-e136-55e0-3698" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="4f8b-042f-03e0-5ef0" name="Kestrel Knight Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9a4c-3374-4f9b-5c14" name="Kestrel Knight Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f284-adfc-04f9-3a90" name="Kestrel Knight Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5589-d21e-57ed-ce4c" name="Kestrel Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1954-9595-f1b1-2bd7" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="91e6-af84-7c83-26d9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3f7e-5aa8-b9e2-4adb" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4c9-7836-7a95-1919" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ed26-cdbc-b593-9e79" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="e7ef-c040-8dd6-f5b5" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cd31-04b8-27cd-cf8c" name="Options" hidden="false" collective="false" defaultSelectionEntryId="8774-ca51-b423-90e7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0312-3737-cbf9-edba" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f28-2d1b-dd2c-cb14" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0fe7-15c3-b832-9c4d" name="Skirmisher + Sylvan Longbow (3+)" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="9f07-3a57-f7bf-86b4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f2fb-466f-0a6a-19cb" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c03-84af-a720-4be9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c0a2-6f5b-933d-9dcf" name="Sylvan Longbow" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+                <infoLink id="f741-7dbb-b764-71cd" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8774-ca51-b423-90e7" name="Hard Target + Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d3a1-79aa-e84f-f81d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d109-c9f8-9212-3a37" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+                <infoLink id="a285-07f8-4535-e9c8" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="47e8-269a-9527-e98a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2d7-261f-377a-f7eb" name="Briar Maidens" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="103a-d6a0-e2e5-08e9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b44c-cadf-154d-ea9c" name="Poisoned Thorn (2+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2ee2-4554-6baf-8e02" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="d4e6-5c50-af6c-c4c0" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="d73a-5c54-d6e3-bfdb" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="72a8-1cbc-f99d-8236" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1662-559f-1fd2-8c5b" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="b3c8-096b-4e29-1bbc" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="4c06-861d-e82f-7e82" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9e91-85a1-9586-925d" name="New CategoryLink" hidden="false" targetId="456a-ede0-3f5f-0c44" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2383-25aa-f751-ffd7" name="Briar Maiden" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c66e-6f23-c27e-412e" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7cf1-52a0-7b28-784b" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="e389-3a09-bf27-acf1" name="Briar Maiden Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="04f7-958b-af16-8213" name="Briar Maiden Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9ef3-e464-5e77-4ec4" name="Briar Maiden Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2628-cff2-1866-81a2" name="Elven Deer" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1962-9276-3c8d-3701" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="493c-c5e7-1257-b113" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7de0-ec38-ab2d-b406" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="dca4-4a13-65a2-06e7" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfcb-627e-e245-96c5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="324f-210c-61f1-eab5" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="f3ae-619e-62de-d694" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7bd7-0a72-0c8c-50cc" name="Command Group" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="2d80-0205-32d7-f3ee" name="Champion" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7b5-bcac-2199-cf7e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8d7e-b9de-c6b0-4945" name="Wizard Conclave" hidden="false" targetId="7455-f914-028b-3359" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (Master of Earth -  Druidism, Break the Spirit - Shamanism, Truth of Time - Cosmology, Forest Embrace - Hereditary Spell)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="27b7-6ccb-dbb5-e472" name="Musician" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="990b-d784-2839-733e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="493c-c5e7-1257-b113" name="Standard Bearer" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e7e-d528-e3ef-0f49" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02a1-6ad3-2685-3591" name="Sylvan Sentinels" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="5658-7fc6-5686-25b8" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cd1-1dae-57c3-fc81" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5658-7fc6-5686-25b8" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2d72-122a-5b50-7e0a" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="0246-815e-203a-04b7" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="9c8b-0b32-1d02-e46a" name="Sylvan Longbow (3+)" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+        <infoLink id="0ec1-77b0-8451-f99a" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="dc9a-8348-b76f-f05e" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="90e9-63eb-963c-b1d7" name="New CategoryLink" hidden="false" targetId="456a-ede0-3f5f-0c44" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1a66-b1e0-6b6c-e35a" name="Sylvan Sentinel" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="14a4-37c5-9f3f-ac8c" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ea7-373b-b087-21e0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ded4-8cb7-7eb3-e6f3" name="Sylvan Sentinel Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a70d-4b52-2c30-acb3" name="Sylvan Sentinel Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1bdc-7e8f-f1b2-ee43" name="Sylvan Sentinel Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d51-0529-21ed-2592" name="Sylvan Blades" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="02a1-6ad3-2685-3591" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a66-b1e0-6b6c-e35a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f32-cd28-363c-6f75" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3c89-7dba-9b8a-18b3" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="53d3-ca5e-b9e3-e98d" name="Scout" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="02a1-6ad3-2685-3591" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a66-b1e0-6b6c-e35a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2368-df74-241c-dca4" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99f0-dc45-f6d0-c330" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9215-f847-e72c-ee17" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="298c-e54c-db3f-4539" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5958-cd0b-b52c-10c8" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cd1-1dae-57c3-fc81" name="Pathfinders" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57f2-c700-5084-2e95" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="444e-2422-9a8c-adef" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="74a4-2dd1-89b3-e356" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="e361-0208-aa0b-6333" name="Sylvan Longbow (2+)" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile"/>
+        <infoLink id="e822-aee3-2858-3295" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="5e09-15f3-0a1f-c3e5" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="ccfc-1feb-3551-6f35" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+        <infoLink id="9fb8-40d7-6cb5-089e" name="Sylvan Blades" hidden="false" targetId="16d2-a28e-d542-301d" type="profile"/>
+        <infoLink id="69cc-01ba-bc73-c2dc" name="Master Archer" hidden="false" targetId="4294-399a-b2be-7480" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1e72-424a-9f13-d308" name="Unseen Arrows (local)" hidden="false" targetId="456a-ede0-3f5f-0c44" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e15f-0019-824c-14b1" name="Pathfinder" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1da-954c-156c-7403" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce3f-faff-dcd3-42d8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7e37-762c-ed15-81d3" name="Pathfinder Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b068-bd56-bce1-162a" name="Pathfinder Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8242-9088-7b23-a333" name="Pathfinder Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="99e6-ab5b-cd02-d7f3" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11e3-d762-f707-e28f" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0fa-3a8f-9243-0040" name="Treefather" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="cc0e-1a2e-d38d-dda8" value="1">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="953d-22cd-7ee1-36dc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a735-b492-9f88-9bd7" type="equalTo"/>
+                <condition field="selections" scope="953d-22cd-7ee1-36dc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a24-2eb3-7301-f9fe" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="142b-2963-33de-cf84" type="atLeast"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc0e-1a2e-d38d-dda8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9d8a-02b3-85e5-a2fe" name="Treefather Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="354a-9637-14b5-336f" name="Treefather Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9d24-fd18-4ca1-33a1" name="Treefather Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e9ea-f969-50b4-4a43" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="841f-fdb9-d21c-c751" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="f81a-02cc-8f06-690f" name="Tree Singing" hidden="false" targetId="838c-8a27-8500-a2d8" type="rule"/>
+        <infoLink id="010e-0b0e-3fe2-9158" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule"/>
+        <infoLink id="a3f6-3e3a-a48d-7b03" name="Impaling Roots" hidden="false" targetId="e86f-9c35-81dc-f09d" type="profile"/>
+        <infoLink id="7f4a-6c41-31cb-96dc" name="Crush Attack" hidden="false" targetId="9371-5924-2a39-1652" type="rule"/>
+        <infoLink id="9762-3b6a-acf6-849e" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1adc-7dd9-3062-a4fb" name="Sylvan Spirit" hidden="false" targetId="75be-0f1b-f68d-f925" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="317a-95bf-c2db-9b46" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="450.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ca3-5e76-0aa4-c22f" name="Heath Hunters" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="4c35-4d3a-0e4b-c7fb" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e18-ac0c-d5db-4c8e" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c35-4d3a-0e4b-c7fb" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="18dc-8428-b173-c497" name="Forest Walker" hidden="false" targetId="097a-0004-b452-0158" type="rule"/>
+        <infoLink id="e877-9966-0351-070b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="04eb-81b4-3052-1e99" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="79d9-8ef1-65c5-888a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="9934-b3d9-6ad4-816e" name="Feigned Flight" hidden="false" targetId="06e4-3c2b-0e6d-e48f" type="rule"/>
+        <infoLink id="02b9-1b2d-6b17-21ff" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="17c5-468c-efdb-d8b6" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="4a2c-e91e-bde7-13bb" name="Sylvan Longbow" hidden="false" targetId="c53e-d709-b88e-c4ce" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f34a-554c-6f29-1d68" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="b6cc-d202-c645-62db" name="Unseen Arrows (local)" hidden="false" targetId="456a-ede0-3f5f-0c44" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8e69-502f-677d-1360" name="Heath Rider" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d7e-bc55-11c2-501a" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23e8-9c64-951d-3e64" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7c15-1c6c-9141-f4f5" name="Heath Rider Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cca4-a650-6d7c-ea5a" name="Heath Rider Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="776e-8e1e-a43e-6081" name="Heath Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0ea8-6c2e-18f5-d620" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="37.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="37b3-b8e9-098a-f670" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f73e-df4c-f35b-87a3" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2c9e-497c-a93f-bcfc" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a44-0342-cc34-9861" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f866-4d94-191c-01ac" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="f6bb-1b24-f5ce-fcb3" name="SE Banner Enchantment" hidden="false" collective="false" targetId="dc62-5ac0-76ab-33d5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e3c6-5368-2d19-2516" name="Ambush" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+              <repeats>
+                <repeat field="selections" scope="6ca3-5e76-0aa4-c22f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e69-502f-677d-1360" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="899f-0ff2-9103-213d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5ef8-59f9-84e4-f143" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="d942-7a11-5c93-74a9" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="5390-209a-e46b-7d79" name="Forest Guardian" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ed-5a3e-57a1-c373" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4105-79c6-b27e-ccd3" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3895-4d7e-7b33-7e92" name="Wild Hunter" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac8-2a8e-d0eb-4767" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e71d-651d-e7bc-19b0" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f5e5-c1c6-3ea6-9d8f" name="Entwined Roots" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8793-c8cb-0970-04dd" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5054-0ec5-02e2-a646" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="687e-a0ed-dd89-9b6d" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="142b-2963-33de-cf84" name="Dragon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e847-0cb5-5b13-b741" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7326-9815-7311-cd19" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c43-d393-a8c5-1248" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f4a9-5a82-edf8-b3fd" name="Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f150-8868-73f1-1d1c" name="Dragon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f1ff-8342-3054-14f1" name="Dragon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1b08-b9e7-4f1e-67c5" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="2823-e63a-dc20-d381" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1ab3-bdd8-7ee2-9712" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="f5f8-7e96-fe9a-1040" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP 1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6dcf-a7ad-4ffe-45fd" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d83-6c19-ad1b-9e7b" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c57-34fd-d9bd-354e" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="75e5-6fbd-68f3-1c9b" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="eac0-c58a-c16d-baf9" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="41ed-f7f4-df23-2ae5" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a72-ac2c-3b79-2c38" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe3c-93ec-f075-ffbd" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d150-062b-8112-f287" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d0dd-69bf-46ad-a9d6" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3f56-ff92-d185-1325" name="Elven Horse" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aa9-733b-eca0-d019" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b4-40f3-0f6d-20e4" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="0467-3375-74c4-0979" name="Elven Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d88a-08b5-2894-6f94" name="Elven Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="baf1-31e8-83cc-a9b7" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="28b0-3688-0447-ed48" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a39-e6e4-6f61-f4ba" name="Great Elk" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85c1-9206-e683-b4ab" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="439d-e511-9155-ae9e" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="a7ef-d581-0e01-0ba7" name="Great Elk Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ea42-da8c-26f2-3349" name="Great Elk Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5db0-4477-03a4-3ea9" name="Great Elk Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="76d2-a1b6-440e-b479" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9bca-545c-0ae2-665f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="62ed-ad30-adba-b070" name="Eagle King" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc98-9e3b-9885-7010" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9092-5e3f-169f-7155" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="15aa-6a53-9468-ba42" name="Eagle King Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8219-017b-ec8a-cb85" name="Eagle King Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7a06-1da4-efcf-d48d" name="Eagle King Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c665-66c8-2e57-bd36" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="3ed3-e6ed-71ab-942c" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="8da0-2ddb-3eaa-f56f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="ceeb-9bd6-c122-5d0d" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e48b-318c-1daf-3318" name="Sylvan Unicorn" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="50fe-abc4-1ff8-c7f2" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3045-f92d-ee07-81b4" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="fcfb-b7db-b10a-626b" name="Sylvan Unicorn Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">10&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">20&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="73dd-64e7-8c5f-e398" name="Sylvan Unicorn Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="34cd-9ba6-d2ea-ab10" name="Sylvan Unicorn Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6771-c591-3042-24fd" name="Strider" hidden="false" targetId="df36-dc35-ead5-1719" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Forest)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8921-c4f1-3835-1ac9" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="51d1-d66f-6f5c-56d2" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2f10-b80e-7023-2d0b" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="96bc-fc9b-4257-751d" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1, max 4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="ac3f-6d36-5a49-1439" name="Kindreds" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da54-f745-497d-cbf8" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b806-93a1-72c4-6b28" name="Wild Hunter" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb4e-97b2-14e0-ebcf" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="cb95-90fd-fc27-5804" name="Wild Hunter" hidden="false">
+              <description>The bearer’s model gains Frenzy, Battle Focus, Devastating Charge (+1 Att, Fear) , Light Troops, +1 Attack Value, and -2 Defensive Skill .</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="74ab-c402-94f0-fe6f" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+            <infoLink id="b5b7-26bc-9521-67dd" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+            <infoLink id="2378-ea9f-1205-76eb" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+            <infoLink id="1b37-0b48-79cf-1cc4" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+            <infoLink id="bda9-3618-c825-a6c1" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (+1 Att, Fear)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="9c8e-b19c-bc39-3696" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="347f-fba6-85fc-590b" name="Wild Hunter" hidden="false" collective="false" targetId="3895-4d7e-7b33-7e92" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1390-62d4-20c6-f1b2" name="Forest Guardian" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5871-79b0-9d41-35c4" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="f788-b6ad-c914-a2cd" name="Forest Guardian" hidden="false">
+              <description>The model gains +1 Attack Value and +1 Armour. The only Melee Weapons the model can be equipped with are Spears, Great Weapons, Sylvan Blades, or Hand Weapons.</description>
+            </rule>
+          </rules>
+          <categoryLinks>
+            <categoryLink id="e1fb-bc07-9067-07df" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="66f1-0c58-70bf-bc9a" name="Forest Guardian" hidden="false" collective="false" targetId="5390-209a-e46b-7d79" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="11a3-90ac-1a4b-68b2" name="Blade Dancer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e241-6d6a-d046-3e56" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="7487-c136-dc1d-91b0" name="Blade Dancer" hidden="false">
+              <description>The model gains Aegis (6+), Fearless, and Dances of Cenyrn (see Blade Dancers unit). The bearer’s unit gains Swiftstride. The model may only join or be joined by other Blade Dancer Kindred Characters and units of Blade Dancers. It cannot use any Shooting Weapons or Armour.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="287e-2172-216e-5676" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="df67-0204-8601-be78" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="7cae-9570-5e3d-6ba9" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="37ec-99ea-0b68-7135" name="Shapeshifter - On foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d5d-e1d2-60a6-40a7" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="0a0f-bedb-4ed0-bbe4" name="Shapeshifter" hidden="false">
+              <description>The Model has its Advance Rate set to 6&quot; and its March Rate set to 18&quot;. It gains +1 Attack, +1 Resilience, Hard Target, Vanguard, Fear, and Swiftstride. The model may never join units or be joined by other characters. </description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="cac2-fd15-561f-7e6c" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+            <infoLink id="2538-9043-7a95-7700" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+            <infoLink id="caf6-9217-5c2c-2643" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+            <infoLink id="2517-c075-f26e-0265" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="c44b-12eb-8446-2e44" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8bbe-d6a2-d463-c24c" name="Pathfinder - On foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7b3-6cae-55dd-c64f" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a78b-3b37-9932-12b9" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="6e66-3bcf-3ef7-b6c9" name="Pathfinder" hidden="false">
+              <description>Cannot be taken by the BSB. The model gains Scout and Master Archer. A Sylvan Longbow Wielded by the model gains has its Shots set to 3. If wielded by a Forest Prince, its Shots are set to 4 instead.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="6783-3876-baa0-f600" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+            <infoLink id="1e2f-736c-4399-7264" name="Master Archer" hidden="false" targetId="4294-399a-b2be-7480" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="6e83-f46e-b625-3fe4" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f998-cb94-e4fd-75e7" name="Aspects of Nature" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e7c-7638-cd5c-d120" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="e81f-b421-7ce2-7b89" name="Entangling Vines" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a97-0356-022f-f6de" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbb5-a72a-2273-0b4d" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a8f3-fcc4-b4a6-a80f" name="Entangling Vines" hidden="false">
+              <description>In a Duel, opponents must reroll successful rolls to hit against the model.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4520-b954-2aab-b307" name="Scarred Bark" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a31-1217-82a8-f748" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aaaf-e73b-8bd6-31af" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="dc8a-f750-2b21-c9ad" name="Scarred Bark" hidden="false">
+              <description>All Dryads in the bearer’s unit gain Hatred.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0676-5a56-17a2-e752" name="Toxic Spores" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9e6-85bb-43ee-e081" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b1b-8b79-9c1a-c348" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="bd04-ce61-1f67-c508" name="Toxic Spores" hidden="false">
+              <description>Every model in the bearer’s unit gains Lethal Strike.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="40b7-3b2d-e893-c67d" name="Oaken Crown" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e845-6fb5-7a9b-9cbe" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fed7-14b8-5f7b-64eb" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="61a4-cdfe-3edc-1c2d" name="Oaken Crown" hidden="false">
+              <description>The bearer&apos;s unit may perform Swift Reforms as if it had a Musician.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8dce-f531-6766-23bb" name="SE Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="adbc-2c60-a74e-4e12" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="52b3-155f-ad21-7b0e" name="Bough of Wyscan" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36dc-3c6f-1393-67c9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a5a4-9eeb-37a5-b463" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e680-afa2-27b5-1362" name="Bough of Wyscan" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Sylvan Longbow Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this Sylvan Longbow gain +1 to wound when shooting from Short Range, and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="86c5-ba2c-3221-fb1d" name="Lifeseed Feathers" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="01e7-9615-cfb3-9a5d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d961-7f0c-e83a-5063" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9622-da01-4e98-a293" name="Lifeseed Feathers" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Sylvan Longbow Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Shots always 1. Attacks made with this weapon gain Magical Attacks. Instead of firing this Sylvan Longbow as usual, the wielder may apply the following rules instead: - When fired at a target within 10&quot; of the bearer, this Shooting Attack&apos;s Strength is set to 4 and Armour Penetration to 1. - When fired at a target more than 10&quot; and up to 20&quot; away from the bearer, its Strength is set to 5 and Armour Penetration to 2. - When fired at a target more than 20&quot; and up to 30&quot; away from the bearer, its Strength is set to 6 and Armour Penetration to 3 and it gains Multiple Wounds (2).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bd91-4bac-a681-d23b" name="Hunter&apos;s Honour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aef5-1d7b-e527-5ca5" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc16-9968-1da8-7a37" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6849-f0b3-cb2a-945c" name="Hunter&apos;s Honour" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Spear Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain +1 Strength, +1 Armour Penetration, and Magical Attacks. If the bearer causes at least one unsaved wound with this weapon, the bearer and all R&amp;F models in the bearer&apos;s unit gain Distracting until the end of the Melee Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f3ce-e615-39d2-94f5" name="Spirit of the Whirlwind" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f67-1fdf-2876-bea4" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0b3d-7726-0b2f-a084" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2c65-aafc-4fef-c8da" name="Spirit of the Whirlwind" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Sylvan Blades Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +1 Attack Value, and Attacks made with this weapon gain +1 Strength, Lethal Strike, and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="fc23-2fbf-fbeb-58ae" name="SE Armour Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="766b-e9e7-fb2b-7d78" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="3f47-8373-73ed-c47c" name="Shielding Bark - Infantry models only." hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b51a-b92e-7291-399a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0ff-a391-d04e-c877" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="16be-908a-dfc5-9fa0" name="Shielding Bark" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour, Aegis (5+), Fearless, Flammable, and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e814-6a1d-97a3-8836" name="Curse of the Black Stag" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d58a-1bf7-ca61-3153" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4552-a077-4c5f-40d1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0273-a12c-4735-58b5" name="Curse of the Black Stag" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Devastating Charge (+1 Str, +1 Att).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="cdf6-5704-7840-27c9" name="SE Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a908-17c7-0d40-f69d" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6a98-de72-44df-df3b" name="Hail Shot - Cannot be taken by Druids" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ea6-89a5-33a7-8c5c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cf8-448b-1996-8c65" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="86a2-e0c0-e2c1-d087" name="Hail Shot - Cannot be taken by Druids" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. When this Artefact is used, it is a Shooting Weapon with the following profile:  Range 30&quot;, Shots 3D6, Str 4, AP 1, Magical Attacks. Aim is set to 2+.  When fired from Short Range it gains +1 Armour Penetration. Master Archer cannot be used in conjunction with Hail Shot.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c5c7-efce-f5c0-2da2" name="Mist Walker&apos;s Mirror - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e786-059a-0bdf-832c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e62-1edf-4bbc-1413" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="71b3-7de1-d295-6db8" name="Mist Walker&apos;s Mirror" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. If the bearer’s unit consists entirely of Standard Size Infantry models, is unengaged, and is entirely within a Forest Terrain Feature that doesn’t contain any enemy models, the unit may teleport to any other Forest Terrain Feature on the Battlefield. This special movement is resolved at the end of the player’s Movement Phase. When teleporting, the unit must be placed entirely within the target Forest. It may appear in any legal formation but must follow the Unit Spacing rule. The unit counts as having performed a March Move.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="85fe-cb1c-7fea-f0de" name="Sacred Seeds - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53d6-b862-8576-0061" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc8f-374f-6978-bf20" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c398-4fd9-fbd6-4777" name="Sacred Seeds" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The player may activate this Artefact at the end of any friendly Movement Phase and place a Forest Terrain Feature in contact with the bearer and at least 1&quot; away from any enemy units and other Terrain Features. The Forest may not be larger than 6&quot; in diameter.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e7ec-4cbf-0e8a-6013" name="Drums of Cenyrn - Models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1430-aeec-b656-c808" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2781-394a-aec3-e09b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="06dc-54cd-2499-7c86" name="Drums of Cenryn" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated when the bearer’s unit Declares a Charge. The target of the charge may only declare Hold as its Charge Reaction unless it is already fleeing. The enemy unit may still declare Charge Reactions as normal if it is subsequently charged by other units.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a343-9eee-716d-ebc9" name="Horn of the Wild Hunt" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35f1-3dea-a5ac-eb3e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc09-e60f-0ec1-d360" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8a0a-511d-21ac-96ed" name="Horn of the Wild Hunt" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated when a friendly unit within 8&quot; fails a roll for Charge Range. The roll may be rerolled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="75f2-9fd2-305d-3511" name="Glyph of Amryl - Cannot be taken by models with Sylvan Spirit" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b203-2eb5-fd15-8348" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff23-1880-85ce-808e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="06e6-ddf4-c204-fddb" name="Glyph of Amryl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Cannot be Stomped. When fighting in a Duel, the bearer gains +3 Defensive Skill.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="dc62-5ac0-76ab-33d5" name="SE Banner Enchantment" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d535-a18a-3a84-d717" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fd75-6526-ff68-7a04" name="Banner of Silent Mist" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2fc-ea12-d014-3c54" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03a4-46be-4e8d-07a1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="03ef-108c-05c1-36be" name="Banner of Silent Mist" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer&apos;s unit gains Soft Cover. Enemy units within 3&quot; of the bearer&apos;s unit may not gain any benefit from a Musician.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a4ab-253c-dcbe-73cc" name="Banner of Deception" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d03-7d3b-5b36-aab0" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a03-54ab-8a90-54be" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ef9a-afff-5207-6edb" name="Banner of Deception" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the end of step 4 of the Deployment Phase Sequence (before deploying Scouts), the owning player may remove the bearer&apos;s unit from the Battlefield and deploy it again elsewhere (any Characters joined to the unit must remain in the unit; this does not affect the number of Undeployed Units for calculating the starting roll-off bonus).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da22-0278-0bf6-1e9c" name="Predator Pennant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4b7-3ae7-b339-4836" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="613f-3fb8-9bcb-7367" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="91ee-0460-2289-1a89" name="Predator Pennant" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer&apos;s unit gains Devastating Charge (Distracting).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="951f-097e-8974-65ba" name="The Forest Follows" hidden="false">
+      <description>Right after determining who deploys first (after step 1 of the Deployment Phase Sequence), you must place a single Forest Terrain Feature entirely within your half of the battlefield, not in contact with any other Terrain Feature and more than 6&quot; away from any Objective. If both players are fielding Sylvan Elves, the player that selected their deployment zone places their forest first. This Terrain Feature may not be larger than 27 cm in length and 19cm in width. All Forests on the Battlefield are considered Dangerous Terrain (1) for all units except those with Strider or Strider (Forest).</description>
+    </rule>
+    <rule id="b76c-3fbe-5461-6570" name="Emboldening Boughs" hidden="false">
+      <description>A unit with more than half of its models with Emboldening Boughs gains Stubborn while more than half of the unit’s Footprint is within a Forest.</description>
+    </rule>
+    <rule id="097a-0004-b452-0158" name="Forest Walker" hidden="false">
+      <description>The model gains Strider (Forest). If a unit comprised entirely of models with Forest Walker starts the Melee Phase with more than half of its Footprint inside a Forest, then all model parts with Forest Walker and without Harnessed must reroll to-wound rolls of ‘1’ with their Close Combat Attacks for the duration of that phase.</description>
+    </rule>
+    <rule id="838c-8a27-8500-a2d8" name="Tree Singing" hidden="false">
+      <description>Each model with Tree Singing may discard 1 Veil Token once per friendly Magic Phase, right after Siphon the Veil. If so, choose a Forest Terrain Feature within 24” of the model with Tree Singing that is not in contact with any unit. Move this Forest up to 6&quot; in a straight line. This movement stops just before moving into contact with any units or other Terrain Features. Each Forest may only be moved with Tree Singing once per Magic Phase.</description>
+    </rule>
+    <rule id="4294-399a-b2be-7480" name="Master Archer" hidden="false">
+      <description>When shooting with a Sylvan Longbow, all models of a unit with Master Archer may choose to gain either +2 Armour Penetration or +2 to hit.</description>
+    </rule>
+    <rule id="75be-0f1b-f68d-f925" name="Sylvan Spirit" hidden="false">
+      <description>The model gains Fearless and Magical Attacks. Models with Sylvan Spirit can only join or be joined by models with Sylvan Spirit.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="e86f-9c35-81dc-f09d" name="Impaling Roots" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6+1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, may March and Shoot, ignores to-hit modifiers from Cover. If its target is in contact with a forest, the strength is set to 5 and AP to 2.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c53e-d709-b88e-c4ce" name="Sylvan Longbow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">30&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire. When shooting from Short Range, the Strength is set to 4.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="16d2-a28e-d542-301d" name="Sylvan Blades" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">As User</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Follows the rules for Paired Weapons . In addition, attacks made with Sylvan Blades gain +1 Armour Penetration.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="eace-9ec6-ad08-1b91" name="Sylvan Lance" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Follows the rules for Light Lance . In addition, attacks made with a Sylvan Lance gain +1 Armour Penetration.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="653d-57ee-da4b-ee00" name="Elven Cloak" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">None</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+1</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">When combined with Light Armour, the wearer gains +1 Armour. Elven Cloak cannot be enchanted.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/theNinthAge-FantasyBattles.gst
+++ b/theNinthAge-FantasyBattles.gst
@@ -66,7 +66,7 @@
     <categoryEntry id="953d-22cd-7ee1-36dc" name="Characters" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="16e8-e66f-0b41-756b" name="Dummy" hidden="true"/>
+    <forceEntry id="16e8-e66f-0b41-756b" name="~ Dummy ~" hidden="true"/>
   </forceEntries>
   <sharedSelectionEntries>
     <selectionEntry id="312f-8f87-7840-0442" name="Shield Enchantement" hidden="false" collective="false" type="upgrade">

--- a/theNinthAge-FantasyBattles.gst
+++ b/theNinthAge-FantasyBattles.gst
@@ -1,0 +1,1339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gameSystem id="aa64-1e8e-66fc-9abf" name="The 9th Age: Fantasy Battles 2.0" revision="24" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+  <costTypes>
+    <costType id="24fd-8af8-0c78-001c" name="pts" defaultCostLimit="-1.0"/>
+  </costTypes>
+  <profileTypes>
+    <profileType id="8292-1fb8-8251-29a9" name="1 Global">
+      <characteristicTypes>
+        <characteristicType id="b0d9-2dab-f10b-9b13" name="Adv"/>
+        <characteristicType id="db10-a838-f72f-3ed6" name="Mar"/>
+        <characteristicType id="be28-67a6-2280-9eaf" name="Dis"/>
+        <characteristicType id="2e17-9c12-bfb4-59b0" name="Size"/>
+        <characteristicType id="3145-83b1-14d6-8023" name="Type"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="154c-6605-1486-e1da" name="3 Offensive">
+      <characteristicTypes>
+        <characteristicType id="8265-800f-bc87-d00a" name="Att"/>
+        <characteristicType id="7d3b-bb95-3d29-26f7" name="Off"/>
+        <characteristicType id="4d4a-2100-804f-99e5" name="Str"/>
+        <characteristicType id="7a8c-adb0-d1b8-a1b6" name="AP"/>
+        <characteristicType id="2a23-367f-8828-c297" name="Agi"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="e7d3-5099-e669-c365" name="2 Defensive">
+      <characteristicTypes>
+        <characteristicType id="f381-7850-7fa8-3440" name="HP"/>
+        <characteristicType id="160d-4624-273f-2114" name="Def"/>
+        <characteristicType id="ec15-bc66-645e-db5d" name="Res"/>
+        <characteristicType id="597b-8735-3dd1-0e70" name="Arm"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="a00c-d586-ee68-ed21" name="6 Ranged Weapon">
+      <characteristicTypes>
+        <characteristicType id="c2a8-bc01-360c-6aca" name="Range"/>
+        <characteristicType id="6867-dcc2-7874-e3b4" name="Shots"/>
+        <characteristicType id="f166-13ff-9227-4525" name="Str"/>
+        <characteristicType id="857a-4ce1-d134-8701" name="AP"/>
+        <characteristicType id="d988-3828-5f00-7582" name="Attributes"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="658e-7f7b-4e4f-162a" name="4 Armour">
+      <characteristicTypes>
+        <characteristicType id="017b-143b-0520-bdc1" name="Type"/>
+        <characteristicType id="4ca3-2498-f356-f056" name="Save"/>
+        <characteristicType id="f269-16dd-a614-0f90" name="Rules"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="5bba-441c-01cb-6187" name="7 Artefact">
+      <characteristicTypes>
+        <characteristicType id="d779-a728-a38c-8340" name="Type"/>
+        <characteristicType id="9f42-950f-d2ed-9247" name="Effect"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="a32f-208a-be3d-ad8d" name="5 Melee Weapon">
+      <characteristicTypes>
+        <characteristicType id="7d4e-b182-dd11-52a0" name="Str"/>
+        <characteristicType id="646b-1e72-1589-5083" name="AP"/>
+        <characteristicType id="048a-df92-bb5b-6de9" name="Attributes"/>
+      </characteristicTypes>
+    </profileType>
+  </profileTypes>
+  <categoryEntries>
+    <categoryEntry id="4bcd-01c8-ce5e-7108" name="Core" hidden="false"/>
+    <categoryEntry id="f8f1-3d4f-12bf-73cd" name="Special" hidden="false"/>
+    <categoryEntry id="953d-22cd-7ee1-36dc" name="Characters" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="16e8-e66f-0b41-756b" name="Dummy" hidden="true"/>
+  </forceEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="312f-8f87-7840-0442" name="Shield Enchantement" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="91df-2c4d-5874-4126" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c43-11cb-de62-e40b" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="f853-d3c3-4165-d5ab" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2f2-85bc-ce11-c49d" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2f88-9ecd-8c12-0dcb" name="Titanic Might" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="676b-52a1-7bb8-3a71" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7155-2463-ebaa-8001" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2d3d-c4fc-c6f2-23a2" name="Titanic Might" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this enchanted weapon gain +3 Strength and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="311e-5a0b-83f2-9069" name="Blessed Inscriptions" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9369-51e8-a408-1876" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5ae-726c-f925-b6b3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c829-3241-7dd4-d4b0" name="Blessed Inscriptions" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this enchanted weapon gain Divine Attacks and failed to-wound rolls must be rerolled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3eeb-4d3a-ca9b-17e5" name="King Slayer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f07-c141-0acb-6f38" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6056-7200-eae6-1b0a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="42bb-c25a-0a67-996e" name="King Slayer" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder of the enchanted weapon gains +X Strength, +X Armour Penetration, +X Attack Value and Magical Attacks when attacking with it, where X is equal to the number of enemy Characters in base contact with the wielder&apos;s unit. This bonus is calculated and effective at the Initiative Step when such attacks are made.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="51f1-66e8-4022-9d8b" name="Shield Breaker" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44af-7e51-e210-1f4a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd3d-4ce1-4c98-08d4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9a7c-9b63-6b74-8be6" name="Shield Breaker" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this enchanted weapon gain +6 Armour Penetration, Magical Attacks ,and can never wound on to-wound rolls better than 3+.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eedf-4585-d0c1-f613" name="Hero&apos;s Heart" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5942-d176-8677-4fd2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e9c8-cacb-f16c-ea7f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3d1e-95aa-7268-83fe" name="Hero&apos;s Heart" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon and Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder of this enchanted weapon gains +1 Attack Value when using it. Attacks made with this enchanted weapon gain Magical Attacks and always have at least Strength 5 and at least Armour Penetration 3.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="315a-5ef6-a1b7-336b" name="Touch of Greatness" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eba2-9f45-2ded-d180" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bdfd-aea5-96d4-e00e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3dae-893d-ab4b-a760" name="Touch of Greatness" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this enchanted weapon gain +1 Strength, +1 Armour Penetration and Magical Attacks. Strength modifiers from this weapon (combining both mundane and Weapon Enchantment modifiers) cannot exceed +2 (but can exceed +2 through modifiers from other sources, such as spells).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dd35-7a49-6952-982e" name="Supernatural Dexterity" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24dd-3eb3-0842-70c8" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3957-a352-00de-cdb4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6b28-248c-7f19-1ca9" name="Supernatural Dexterity" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder of this enchanted weapon gains +2 Offensive Skill and +2 Agility while using it, and attacks made with it gain Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="81c6-6663-7fd4-18f7" name="Cleansing Light" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6425-23f8-e630-3237" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f1d-9ac8-6dfe-3129" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="72e2-3e89-1f4a-9ee7" name="Cleansing Light" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Melee Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of each Round of Combat, the wielder may choose to give attacks made with this enchanted weapon Flaming Attacks and Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4c4e-146b-a165-a891" name="Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="757a-d5c1-6cf9-bd2f" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="757a-d5c1-6cf9-bd2f" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="9e1c-64e0-ee91-9065" name="Death Cheater" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cba1-99f6-8291-b0e2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f35-b562-da41-9760" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7c15-67c1-c277-8e10" name="Death Cheater" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains Fortitude (4+) and +1 Armour.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f961-86c2-9c05-26b8" name="Destiny&apos;s Call - Standard Size only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c632-7ea5-0f1b-e5f7" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e2b-9907-9ea4-d178" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a13e-d783-fe7e-a520" name="Destiny&apos;s Call" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains Aegis (4+) and its Armour is set to 3 and cannot be improved beyond this. Standard Size Models only.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8595-7314-30db-51da" name="Essence of Mithril - Standard Size only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0926-d6fb-be47-6bd2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fa2-0f38-156f-ee4a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c829-9786-d674-d45b" name="Essence of Mithril" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +5 Armour, to a maximum of 5. Standard Sized models only.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7826-dc11-ac6b-51c3" name="Dusk Forged" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cb5-506c-6234-6e46" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1921-ec96-a8dc-4557" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7b4e-d308-4ef4-94b8" name="Dusk Forged" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer may choose to reroll its failed Armour Saves while using this Shield. If it does, it automatically fails all special saves.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="6a8b-1ded-cff0-9a28" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="16c0-7108-a6a7-f2b6" name="Ghostly Guard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b89-fcea-fb74-4fae" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9249-4aac-5dfe-3aed" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c2e1-b4dc-de38-780d" name="Ghostly Guard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Heavy Armour and Plate Armour enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +2 Armour against non-Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="38fa-9d02-70a4-fd41" name="Basalt Infusion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d267-e48c-526c-bae3" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b69-16ab-2e7a-30e2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cfba-2d26-2f91-cef7" name="Basalt Infusion" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and Aegis (3+, against Flaming Attacks). The wearer automatically fails all Fortitude saves.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7661-e05d-8c3d-4b60" name="Willow&apos;s Ward - Models on Foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbf3-c384-bcb9-1787" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="61e7-82cc-cd4c-25ca" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b6f2-047a-b02a-955f" name="Willow&apos;s Ward" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer cannot use Parry and gains +1 Armour. Impact Hits distributed towards the bearer suffer -2 Armour Penetration.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="f2a6-8c8c-d8b1-852f" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a341-4e62-97af-a426" name="Alchemist&apos;s Alloy" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b56-9d49-7c24-8daf" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbdf-bd24-eaaf-5e18" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ae69-9a05-d1bd-4aec" name="Alchemist&apos;s Alloy" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and suffers -2 Offensive Skill.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a755-929f-7067-ae6e" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e675-85da-422d-e83d" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="28c9-d1c6-a0c8-d695" name="Crown of the Wizard King - Cannot be taken by Wizards" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0cd2-7a34-9c70-fcef" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1aa6-7e20-0164-c612" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a6dd-7059-e971-9d29" name="Crown of the Wizard King" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">During Spell Selection, randomise a magic Path (from all Paths in The 9th Age: Fantasy Battles - Paths of Magic). The bearer is a Wizard Apprentice using the randomised Path. It cannot select the Hereditary Spell.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="02ee-20af-e439-e56f" name="Book of Arcane Mastery - Dominant. Cannot be taken by Wizard Master." hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8b6-bd94-7030-04dc" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="18ac-5821-ca08-dd8f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1fda-2a73-aee7-500b" name="Book of Arcane Power" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The Bearer&apos;s first casting attempt in each magic phase gains +2 to cast. When using a single magic dice for this casting attempt, a natural roll of 1 or 2 on the magic dice is always a failed casting attempt, regardless of any modifiers.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f996-0dd2-7d1f-17fe" name="Crown of Autocracy" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="346d-2d02-3ad1-fa6a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5125-775d-b84e-6817" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7543-e866-afe8-638b" name="Crown of Autocracy" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +1 Discipline. If taken by the General, the opponent doubles the Victory Points bonus for killing this General (normally +400 instead of +200).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="717c-cdd1-f368-649a" name="Obsidian Rock" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c136-48fb-10d1-af14" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5080-ee94-c94e-0aa7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4ddc-e339-1a1d-5a53" name="Obsidian Rock" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Magic Resistance (2).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2078-81dc-eac0-b856" name="Rod of Battle" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a580-173e-542f-c205" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af3a-1b52-6284-4d23" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e46d-4704-b518-21c0" name="Rod of Battle" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer can cast a Bound Spell, Power Level (4/9): Type: Augment. Range 12&quot;. Duration: Lasts One Turn. The target gains +1 to hit with its Close Combat Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3f7d-5a54-b1ca-550f" name="Binding Scroll" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c83-b58e-1f17-6ad6" type="max"/>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d25c-e7c0-d71c-3dce" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fba1-ac53-2f35-b932" name="Binding Scroll" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated after siphon the veil. When activated, pick an enemy model and select one of its spells (including Attribute and Bound Spells). The chosen model cannot cast the selected spell during this Magic Phase. Only a single Binding Scroll may be activated during the same Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3db5-8d52-cfe9-fbfa" name="Essence of a Free Mind - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8378-ef9c-921c-fea8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b34f-2059-16a0-6fd3" name="Essence of a Free Mind" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A Wizard with this Artefact may select up to two Paths on its Army List instead of one (from the ones normally available to it). Select which of the two Paths to use during Spell Selection.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="589f-da5c-20ba-5f1a" name="Potion of Strength - Cannot be taken by Towering Presence" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2073-cb07-2b27-ebf2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2703-475f-873e-b2f1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dd94-8d4f-6397-58b3" name="Potion of Strength" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Cannot be taken by models with Towering Presence. One use only. May be activated at the start of any Phase or Round of Combat. Until the end of the Player Turn the bearer gains Crush Attack.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3d77-9d65-58c3-9e7d" name="Lightning Vambraces" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="00cd-e544-918b-a19a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="11b8-e8e5-75ac-cc04" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="32bd-cf16-0584-92c6" name="Lightning Vambraces" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer can cast a Bound Spell, Power Level (4/8): Type: Hex, Missile, Damage. Range 24&quot;. Duration: Instant. The target suffers 2D6 hits with Strength 3 and Armour Penetration 0.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8cca-6eee-ecd5-1620" name="Talisman of Shielding" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d0f-cb2b-a4f7-78e2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c45-575d-827d-5f11" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="47a8-7f16-d5aa-59a6" name="Talisman of Shielding" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (5+).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="538d-5665-58a8-281d" name="Ranger&apos;s Boots - Standard Size models on foot only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed0c-4ab2-0724-619c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7249-1714-fbf6-bb29" name="Ranger&apos;s Boots" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Standard size models on foot only. The bearer gains Strider and, unless using Flying Movement, gains +2 Advance Rate up to a maximum of 10, and +4 March Rate up to a maximum of 20.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1a15-8ac5-586b-1b94" name="Magical Heirloom - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e66b-513a-2178-62dd" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="193f-1692-0888-0fff" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3497-5e1f-9856-0786" name="Magical Heirloom" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A Wizard with this Artefact knows the Hereditary Spell in addition to its other spells.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="52aa-545b-5fc8-64fe" name="Scepter of Power" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3294-ac54-84bc-d29c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f4a8-989f-6404-cbf3" name="Scepter of Power" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. A Wizard with this Artefact may add a single Magic Dice from its Dice Pool to one of its casting rolls or dispel rolls, after seeing the casting or dispel froll. (Note that casting rolls cannot exceed the limit of max 5 Magic Dice.)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bc10-9582-1642-6f0e" name="Talisman of the Void" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cf3-fbc4-bfb4-b266" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f2d-8ddc-0968-d37d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d25b-ed80-d5be-3c6c" name="Talisman of the Void" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Channel (+1)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b996-d7ae-e854-2601" name="Dragon Staff" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d841-22a8-95d7-d0b3" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2913-1a61-649c-7864" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="24d8-2a7f-1927-2789" name="Dragon Staff" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Breath Attack (Strength 3, Armour Penetration 0, Flaming Attacks).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef67-0a29-6d5c-687c" name="Crystal Ball" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="96ec-66a7-2069-fc16" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99e1-e740-4f1a-e979" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="65cc-2129-2fd3-d85d" name="Crystal Ball" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">After Spell Selection (at the end of step 7 of the Pre-Game Sequence), mark a single enemy model in the opponent’s Army List. All dispelling attempts of spells cast by that model gain a +1 dispelling modifier, provided the bearer is on the battlefield.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="57fe-c8e7-f786-132c" name="Dragonfire Gem" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b06d-57b2-7d61-c148" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d924-778a-9d6c-8f3a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1aa2-6132-c8f1-0550" name="Dragonfire Gem" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (2+, against Flaming Attacks). The bearer automatically fails all Fortitude Saves.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fc3e-7023-b3ce-8579" name="Potion of Swiftness" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d945-451b-7fc4-4571" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9973-8d34-ffe4-a7d6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2e95-0bf0-8e9a-2173" name="Potion of Swiftness" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any Phase or Round of Combat. Until the end of the Player Turn, the bearer gains +3 Agility.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ebd9-2cee-402a-4ff4" name="Lucky Charm" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0600-edd1-77df-ed4f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45b9-6475-d8be-2fd2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="703e-dc0f-bc53-0e7e" name="Lucky Charm" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated when the bearer&apos;s model fails an Armour Save. This failed Armour Save may be rerolled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="37cb-10cd-3c37-56dd" name="Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0fb8-361b-f433-cc9e" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="1695-cfaf-06fb-fe34" name="Rending Banner" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0350-9e05-ca07-ed9c" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f86-7262-dd94-d986" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6dcd-6b2e-3175-42ef" name="Rending Banner" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of a Round of Combat. Close Combat Attacks from R&amp;F models in the bearer&apos;s unit gain +1 Armour Penetration until they are no longer engaged in combat. A model can only be affected by a single Rending Banner at the same time.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c7f0-afd2-df8b-2008" name="Banner of Speed" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="50fe-79c3-0999-f3d2" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ab92-8898-f49d-2e42" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b298-db20-e285-f084" name="Banner of Speed" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A unit with one or more Banners of Speed gains +1 Advance Rate and +2 March Rate.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bcfc-01a2-69fe-e5e7" name="Stalker&apos;s Standard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="97b9-5262-fc24-0608" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a988-bc77-7669-58f0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="88fb-50d8-970f-65b2" name="Stalker&apos;s Standard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer&apos;s unit gains Strider</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="719b-6dee-2a2a-8e74" name="Banner of Discipline" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dbb-f9a9-a6bf-f7df" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ac8-5d6c-8439-7620" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c5ed-8a31-f738-9f2b" name="Banner of Discipline" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer&apos;s unit may reroll failed Panic Tests and Decimated Tests. If the Battle Standard Bearer or the General is part of the bearer’s unit, it automatically passes all its Panic Tests and Decimated Tests instead.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c287-b3cd-82d4-ba3d" name="Aether Icon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3c7-a190-7c17-3f30" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b09f-a35b-70d7-2b9f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ef17-6448-332f-a446" name="Aether Icon" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Magic Resistance (1). If the unit already had Magic Resistance, it instead increases the Magic Resistance value by 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5bf4-2476-8235-9323" name="Banner of the Relentless Company" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9245-eb29-5a53-326c" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4902-c868-a2e0-52a8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e2f3-7783-39bd-d955" name="Banner of the Relentless Company" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated during the controlling player’s Movement Phase. All Infantry models in thebearer’s unit always have March Rate 15”, until the end of the Player Turn. Only a single Banner of the Relentless Company may be activated during the same Phase.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="59ec-00bd-1953-e80a" name="Flaming Standard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee51-134a-e6b2-13c8" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e072-9a53-d5c8-39ad" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0456-5897-1a62-1bca" name="Fire Banner" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of a Round of Combat or before shooting with the bearer’s unit. The bearer&apos;s unit gains Flaming Attacks. If activated when Engaged in Combat, effects lasts until the bearer’s unit is no longer Engaged in Combat. If activated before Shooting with the bearer’s unit, this effect lasts until end of the Phase. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef5a-692b-1b30-d5d5" name="Legion Standard" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e800-e25e-5784-8e38" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c5f-5d36-da6c-3028" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a3f3-727b-5877-7be7" name="Legion Standard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">A unit with one Legion Standard increases the maximum of its Rank Bonus by +1 (normally this means the unit can add up to 4 Full Ranks to its Combat Score). A unit with two Legion Standards increases the maximum of its Rank Bonus by +2 instead.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b4c3-e840-1bd5-b746" name="Command Group" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="c3e7-8c28-0d42-6aa8" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9621-5b4f-503d-1501" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="10fe-ce12-d662-ae02" name="Musician" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b76f-c463-b6d8-4fed" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8f82-6955-3d8a-01ea" name="Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8d1-795e-f3af-3b02" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="2dda-ee2f-cfce-7f16" name="Ambush" hidden="false">
+      <description>You may choose to not deploy units with Ambush, but instead let them Ambush by bringing them into play later on.
+Declare which units will be Ambushing during step 8 of the Pre-Game Sequence
+(after Spell Selection), starting with the player that picked the Deployment Zone. Deploy your army as usual, but without the Ambushing units. Starting with your Player Turn 2, at the end of step 2 of the Movement Phase Sequence (after moving units with Random Movement), roll a dice for each Ambushing unit. After rolling for all Ambushing units, all units that rolled 3+ enter the Battlefield from any Board Edge. Place the arriving units with their entire rear ranks touching the Board Edge.
+- Ambushing models can neither March Move during the Movement Phase in which they arrive, nor can they voluntarily end that Movement Phase further away from the Board Edge than their March Rate.
+- If an Ambushing unit has not entered the Battlefield before the end of the game (e.g. due to failing all its 3+ rolls), the unit counts as destroyed.
+- An Ambushing unit that enters the Battlefield on Game Turn 4 or later loses Scoring.
+- An Ambushing Character may be deployed within an Ambushing unit that it is allowed to join (declare this when declaring which units are Ambushing). Roll only one dice for the combined unit.
+- Until arriving on the Battlefield, Ambushing units follow the rules for units that have Pursued off the Table.</description>
+    </rule>
+    <rule id="3ef6-167b-7d0f-b484" name="Battle Standard Bearer" hidden="false">
+      <description>An army may only include a single Battle Standard Bearer. The model gains Rally Around the Flag and Not a Leader. If the model has the option to buy Special Equipment, it is allowed to purchase up to two Banner Enchantments.</description>
+    </rule>
+    <rule id="1d4a-2ada-4edb-0363" name="Bodyguard" hidden="false">
+      <description>When a Character is joined to a unit in which at least one model has Bodyguard, that Character gains Stubborn. When Characters or Character types are stated in brackets, Bodyguard only works for the specified Characters or Character types.</description>
+    </rule>
+    <rule id="5a46-f1e8-f840-a1de" name="Channel" hidden="false">
+      <description>During step 3 of the Magic Phase Sequence, each of the Active Player’s models with Channel may add X Veil Tokens to the Veil Token Pool. If X is given as a modifier (e.g. Channel (+1)), the model gains this as a modifier to its Channel value (the value in brackets).</description>
+    </rule>
+    <rule id="8583-d413-d1ef-ec61" name="Chariot" hidden="false">
+      <description>The model must roll an additional D6 when taking Dangerous Terrain Tests. A model with Chariot can only be part of a unit consisting entirely of models with Chariot, unless noted otherwise.</description>
+    </rule>
+    <rule id="4d9a-1dea-1661-4083" name="Supernal" hidden="false">
+      <description>The model gains Unstable. When a unit consisting entirely of models with Supernal loses a combat, the unit must take a Break Test (Stubborn or Steadfast units ignore modifiers from Combat Score difference as normal). If the Break Test is passed, ignore all Health Points that would be lost due to Unstable. If the Break Test is failed, follow the rules for Unstable as normal.</description>
+    </rule>
+    <rule id="c16c-8e9f-3d9c-7a2a" name="Engineer" hidden="false">
+      <description>Once per Shooting Phase, an unengaged Engineer may select a single War Machine
+within 6″ that has not fired yet to gain the following effects:
+- Replace the Aim of one of the War Machine’s Artillery Weapons with the value given in brackets (X+).
+- You may reroll the roll on the Misfire Table .
+- You may reroll the dice (all of them or none) for determining the number of hits of a Flamethrower Artillery Weapon.</description>
+    </rule>
+    <rule id="06e4-3c2b-0e6d-e48f" name="Feigned Flight" hidden="false">
+      <description>Models in a unit consisting solely of models with Feigned Flight do not become Shaken
+if their unit voluntarily chooses Flee as Charge Reaction and passes its Rally Test in its next Player Turn. The Reform after Rallying in this case does not prevent the unit from moving nor from shooting (but it still counts as having moved). This rule does not apply if a unit fails to rally on the next friendly Player Turn or involuntarily Flees (e.g. as a result of a failed Panic Test or if it was already Fleeing when being charged).</description>
+    </rule>
+    <rule id="229b-fa84-b9fe-b1ff" name="Tall" hidden="false">
+      <description>Line of Sight drawn to or from a model with Tall is not blocked by models of the same size (as the model with Tall), unless the intervening model also has Tall. Remember that this also affects Cover (if a model blocks Line of Sight it contributes to Hard Cover, otherwise only to Soft Cover).</description>
+    </rule>
+    <rule id="ed2a-e8b3-cc1a-cce0" name="Fear" hidden="false">
+      <description>Models in units in base contact with one or more enemy models with Fear suffer -1 Discipline. At the start of each Round of Combat, such units must take a Discipline Test
+, called a Fear Test. If this test is failed, the models in the unit are Shaken and Close Combat Attacks made by the models in the unit suffer -1 to hit, while Close Combat Attacks allocated against the models in the unit gain +1 to hit. These effects apply until the end of the Round of Combat.
+Models that have Fear themselves are immune to the effects of Fear.</description>
+    </rule>
+    <rule id="4a5a-48a4-b2f9-f6ed" name="Fly" hidden="false">
+      <description>The model gains Light Troops and Swiftstride. Units composed entirely of models with Fly may use Flying Movement during Move Chargers moves, Advance Moves
+, and March Moves. When a unit uses Flying Movement, substitute its
+models’ Advance Rate with the first value given in brackets (X), and their March Rate with the second value given in brackets (Y). A unit using Flying Movement ignores all Terrain Features and units during the Flying Movement. Note that:
+- It must abide by the Unit Spacing rule at the end of the move (unless charging, when the normal exceptions to the Unit Spacing rule apply).
+- It is affected by the Terrain Features from which it takes off and in which it lands.
+- All modifiers to ground movement values also apply to a model’s Fly values (unless specified otherwise).
+- When Declaring a Charge with a unit with Fly, you must declare if the unit will use Flying Movement for the Charge Move.</description>
+    </rule>
+    <rule id="d3a1-728e-7e9f-992d" name="Front Rank" hidden="false">
+      <description>The model must always be placed as far forward as possible in its unit. Normally this means that it must be placed in the first rank, but if the first rank is full of other models with Front Rank, it is placed in the second rank instead. If this rank is also full of models with the Front Rank rule, it is placed in the 3rd rank, and so on. When moving a unit that includes models with Front Rank, these models can be reorganised into a new position (still as far forward as possible) as part of the move. This can be done as a part of an Advance move, March, or Reform move, and counts
+towards the distance moved by the unit (measure this from the starting position to the ending position of the centre of the model with Front Rank to determine how far it has moved).
+
+If a model with Front Rank leaves a unit or is removed as a casualty, the gap it leaves must be filled with models from other ranks, possibly moving up models with the Front Rank rule, if this means they are moved to positions further forward. If more than one model with Front Rank could move forward, the owner of the models decides which model is moved forward. If all models with the Front Rank rule already are as far forward as possible, fill any empty gaps with R&amp;F models from the back ranks. Sometimes Front Rank models must be redistributed in order for all such models to be as far forward as possible. When this happens, move as few models as possible in order to always have all models with the Front Rank rule as far forward as possible</description>
+    </rule>
+    <rule id="ccc1-4db1-6ef8-8bc7" name="Stand Behind" hidden="false">
+      <description>The model can be placed anywhere in its unit, it doesn’t have to be placed as far forward as possible, even if it has Front Rank. Among models with Front Rank, models without Stand Behind have priority over Stand Behind models to be placed as far forward as possible.</description>
+    </rule>
+    <rule id="bf56-e3dc-41ca-292b" name="Rally Around the Flag" hidden="false">
+      <description>All units within 12&quot; of a friendly non-Fleeing model with Rally Around the Flag may reroll failed Discipline Tests.</description>
+    </rule>
+    <rule id="0ab3-2e1b-8c2b-a7fe" name="Fearless" hidden="false">
+      <description>If more than half of a unit&apos;s models are Fearless, the unit automatically passes Panic Tests and cannot declare a Flee Charge Reaction (unless already Fleeing). Models that are Fearless are also immune to the effects of Fear.</description>
+    </rule>
+    <rule id="10f4-4cf9-f713-7351" name="Insignificant" hidden="false">
+      <description>Units consisting entirely of models with Insignificant do not cause Panic Tests on friendly units without
+Insignificant. Only Insignificant Characters can join units with Insignificant R&amp;F models.</description>
+    </rule>
+    <rule id="2304-d0e4-f97b-c4e5" name="Commanding Presence" hidden="false">
+      <description>All Generals have the Commanding Presence Universal Rule. All units within 12&quot; of a friendly non-Fleeing model with Commanding Presence may borrow the Discipline of the model with Commanding Presence, instead of using their own Discipline (t his ability follows all the normal rules for using a Borrowed Characteristic, meaning that effects modifying the Discipline of the model with Commanding Presence are applied before borrowing the model’s Discipline ; this borrowed Discipline may then be further modified ) .</description>
+    </rule>
+    <rule id="8b75-3cd5-bd70-6210" name="Light Troops" hidden="false">
+      <description>A unit composed entirely of models with Light Troops may shoot even after March Moving or Reforming earlier that Player Turn, and it may Reform any number of times during Advance Moves and March Moves. No model can end its movement with its centre further away from its starting position than its March Rate.
+- For measuring the distance travelled by a model, check the path the model would have taken if it was alone and measure the movement around any obstructions (abiding by the Unit Spacing rule). Note that the unit nevertheless must abide by the Unit Spacing rule (including all Reforms).
+- If a model performed any action during the movement (such as a Sweeping Attack), the distance moved is measured from its starting position to the point on the Battlefield where it performed that action and then to its final position.
+- Units with more than half of their models with Light Troops always count as having 0 Full Rank.
+- Characters lose Light Troops while joined to units with one or more models without Light Troops (if they had it).
+- Infantry Characters gain Light Troops while joined to Infantry units of the same Size with Light Troops.</description>
+    </rule>
+    <rule id="f611-6165-ada9-0d7d" name="Not a Leader" hidden="false">
+      <description>The model cannot be the General	</description>
+    </rule>
+    <rule id="3fbc-ceb2-b812-0e88" name="Magic Resistance" hidden="false">
+      <description>Learned Spells and Bound Spells that are targeting at least one enemy unit with one or more models with Magic Resistance suffers a -X modifier to their casting roll (where X is given in brackets). This is an exception to the Casting and Dispelling Modifier rule. If there are different X values that could be used, use the highest value.</description>
+    </rule>
+    <rule id="7a94-4a81-745e-66d1" name="Pathmaster" hidden="false">
+      <description>The Wizard may swap any of its Learned Spells for any other Learned Spell in the same Path and/or the Hereditary Spell. This rule overrides the Spell Selection rules connected to being Wizard Apprentice, Apprentice or Master.</description>
+    </rule>
+    <rule id="9c73-bbca-fd62-c017" name="Protean Magic" hidden="false">
+      <description>During Spell Selection, the Wizard must select its spells between the Learned Spell
+1 of the Paths it has access to and the Hereditary Spell of its army. This rule overrides the Spell Selection rules connected to being Wizard Apprentice, Adept or Master.</description>
+    </rule>
+    <rule id="0d8a-3fd8-a61d-5b74" name="Wizard Apprentice" hidden="false">
+      <description>The Wizard selects its spells as described in Spell Selection.</description>
+    </rule>
+    <rule id="c0a6-6da5-98d6-f051" name="Wizard Adept" hidden="false">
+      <description>The Wizard gains Channel (1) and selects its spells as described in Spell Selection</description>
+    </rule>
+    <rule id="fa5b-1bdc-8550-50c7" name="Wizard Master" hidden="false">
+      <description>The Wizard gains Channel (1) and a +1 modifier to its casting rolls, and selects its spells as described in Spell Selection.</description>
+    </rule>
+    <rule id="b6f2-241f-8379-3327" name="Frenzy" hidden="false">
+      <description>The model gains Fearless. At the start of the Charge Phase, each of your units with at least one model with Frenzy that could Declare a Charge against an enemy unit within the unit’s Advance Rate +7″ must take a Discipline Test, called a Frenzy Test. If the test is failed, the whole unit must Declare a Charge this Player Turn if possible. When a unit with at least one model with Frenzy takes a Frenzy Test or Discipline Test to restrain from Pursuing, the test is subject to Maximised Roll.
+- When measuring if a unit must take a Frenzy Test, use the lowest available Advance Rate among the unit’s models.
+- If the unit has Fly and there is more than one Advance Rate available, you must use the type of movement (ground or Fly) that has the highest chance of completing the charge.
+- When a unit is forced to Declare a Charge due to a failed Frenzy Test, it is not forced to charge the enemy unit that triggered the Frenzy Test.
+- Characters are never forced to charge out of their units due to failed Frenzy Tests.</description>
+    </rule>
+    <rule id="33ac-93f2-47f5-d0f0" name="Massive Bulk" hidden="false">
+      <description>If a model with Massive Bulk is mounted by a Character, ignore the rider’s Armour Equipment (including Armour Enchantments) and Personal Protections, unless specifically stated otherwise (such as Armour Enchantments that affect the bearer’s model).</description>
+    </rule>
+    <rule id="6e49-e056-5845-4b66" name="Random Movement" hidden="false">
+      <description>At the end of step 2 of the Movement Phase sequence (after Rally Fleeing Units), the unit moves using the rules for Pursuing units, with the following exceptions:
+- It moves the distance stated in brackets (X), which is also used for Flee Distance and Pursue Distance (including Overruns).
+- It can choose which direction to rotate towards before rolling the Pursuit Distance.
+- It cannot move off the Board Edge.
+- It only takes Dangerous Terrain Tests if it charges (it still tests as normal when Fleeing, Pursuing, and Overrunning).
+- For units with several instances of Random Movement, use the one with the lowest average (choose in case of a tie).
+There are several restrictions connected with Random Movement:
+- The unit cannot move normally in the Movement Phase (Advance, March, Reform) and cannot Declare Charges. Whenever it needs a March Rate (e.g. when Post-Combat Reforming), use the potential maximum value of X as its March Rate.
+- The unit cannot perform Magical Moves.
+- The unit loses Swiftstride and can never gain it.
+- Characters with Random Movement can only join units with Random Movement (by moving into contact with them during the Movement Phase or by being deployed inside), and units with Random Movement can only be joined by Characters with Random Movement.
+- Units with Random Movement cannot enter Buildings .
+- A unit with Random Movement cannot move in the same phase as it arrives on the Battlefield as Reinforcement (Dawn Assault) or Ambusher.</description>
+    </rule>
+    <rule id="188e-05fb-8a95-60c8" name="Scoring" hidden="false">
+      <description>Units with at least one model with Scoring are considered to be Scoring Units, which are used for winning Secondary Objectives. Every army needs a few Scoring units to be able to complete Secondary Objectives, which is why units with Scoring are marked in the Army Books with a special pennant icon. 
+Scoring can be lost during the game:
+● A unit that is Fleeing loses Scoring for as long as it if Fleeing.
+● An Ambushing unit that enters the Battlefield on Game Turn 4 or later loses Scoring.
+● A unit that has performed a Post-Combat Reform loses Scoring until the end of the current Player Turn.</description>
+    </rule>
+    <rule id="1c9f-ec16-529b-e3ca" name="Scout" hidden="false">
+      <description>At step 8 of the Pre- Game Sequence (after Spell Selection) an army that includes units with Scout must state which of its units with Scout will use it, starting with the player that picked the Deployment Zone. Deploy your army as usual, but without deploying any of the Scouting units. These units are placed after all other non-Scouting units have been deployed. They can either be deployed in your Deployment Zone, using the normal rules, or they can be deployed outside the Deployment Zone, but must be more than 18&quot; away from any enemy units. This is decreased to 12&quot; if the Scouting unit is deployed entirely within a Forest, Ruins, Field, Building or Water Terrain Feature. Scouting units that are deployed outside their player’s Deployment Zone may not Declare Charges in the first Player Turn (if their side has the first turn). If both players have Scouting units, alternate deploying one unit at a time, starting with the player that finished deploying first.</description>
+    </rule>
+    <rule id="2ce4-ece5-068c-4d20" name="Skirmisher" hidden="false">
+      <description>A model with Skirmisher can always use Shooting Attacks from any rank (they are not limited to shooting from first and second rank).
+Units with at least one R&amp;F model with Skirmisher are formed into a skirmish formation. They are not placed in base to base contact with each other. Instead, models are placed with a 12.5mm distance between them. This gap is considered part of the unit for Cover purposes, and will have the same Size as the models in the unit. Other than this gap between models, units with Skirmisher follow the normal rules for forming units and therefore have a Front, two Flanks, a Rear, can perform Supporting Attacks, and so on. Units in skirmish formation gain Light Troops and Hard Target, never block Line of Sight (remember that this also affects Cover and that they can never contribute to Hard Cover.
+
+Units in skirmish formation can only be joined by Characters that have both the same Type and the same Size as the unit. Unless a Character has the exact same base size as all R&amp;F models in the unit, it is considered Mismatched for the purpose of placement within the unit. The unit ceases to be in skirmish formation when all R&amp;F models with Skirmisher are wiped out: immediately contract their skirmish formation into a normal formation, without moving the centre of the front rank. Nudge any unit as normal to maintain base contact if possible.</description>
+    </rule>
+    <rule id="36f9-836f-d687-5d43" name="Ghost Step" hidden="false">
+      <description>The model treats all Terrain Features as Open Terrain for movement purposes, but must abide by the Unit Spacing rule upon the completion of its moves.</description>
+    </rule>
+    <rule id="df36-dc35-ead5-1719" name="Strider" hidden="false">
+      <description>The model automatically passes Dangerous Terrain Tests taken due to Terrain. If more than half of a unit&apos;s models have Strider, the unit never loses their Steadfast or Rank Bonus due to Terrain. Sometimes Strider is linked to a specific type of Terrain, stated in brackets. In this case, models with Strider are considered Striders only when interacting with such type of Terrain.</description>
+    </rule>
+    <rule id="51bf-5c8d-5b95-e33c" name="Stubborn" hidden="false">
+      <description>A unit with at least one model with Stubborn ignores any Combat Score penalties to its Discipline when taking Break Tests or Combat Reform Discipline Tests.</description>
+    </rule>
+    <rule id="d15d-3c8e-23db-ab7b" name="Swiftstride" hidden="false">
+      <description>If a unit is composed entirely of models with Swiftstride, its rolls for Charge Range, Flee Distance, Pursuit Distance, and Overrun Distance are subject to Maximised Roll</description>
+    </rule>
+    <rule id="0b48-87f9-1467-7ef2" name="Terror" hidden="false">
+      <description>The model gains Fear and is immune to the effects of Terror. When a unit with one or more models with Terror Declares a Charge, its target must take a Panic Test. If the test is failed, the target of the charge must declare a Flee Charge Reaction , if able to do so.</description>
+    </rule>
+    <rule id="9ca4-65be-33fc-5d47" name="Towering Presence" hidden="false">
+      <description>The model gains Tall and can never be joined or join a unit (unless it is a War Platform). A model with Towering Presence increases its Rally Around the Flag and Commanding Presence ranges by 6&quot;.</description>
+    </rule>
+    <rule id="99ef-69e8-164b-3335" name="Unbreakable" hidden="false">
+      <description>The model gains Fearless and its unit automatically passes all Break Tests. Characters with Unbreakable can only join units consisting entirely of models with Unbreakable. Units with one or more Unbreakable models can only be joined by Unbreakable Characters .</description>
+    </rule>
+    <rule id="b558-1cce-fbc9-afe6" name="Undead" hidden="false">
+      <description>The model gains Unstable. Undead models cannot perform March Moves, unless their unit starts the March Move within the range of a friendly model’s Commanding Presence. The only Charge Reaction a unit with one or more Undead models can make is Hold .
+When units consisting entirely of models with Undead lose Health Points due to Unstable, the number of lost Health Points can be reduced in some situations. Apply the modifiers in the following order:
+1. If the unit is Stubborn, halve the number of lost Health Points (round fractions up).
+2. If the unit is Steadfast, reduce all lost Health Points above 12 to 12.
+3. If the unit receives Rally Around the Flag, reduce the number of lost Health Points with the unit’s current Rank Bonus. Units with no Rank Bonus reduce the number of Health Points lost by 1 instead.
+4. Apply all other modifiers (from Artefacts, Model Rules, spells, etc.) afterward.</description>
+    </rule>
+    <rule id="b642-5b33-158d-421b" name="Unstable" hidden="false">
+      <description>The model gains Fearless. Units with one or more models with Unstable automatically pass all Break Tests. When a unit consisting entirely of models with Unstable loses a combat, it loses one Health Point (without any saves allowed) for each point of Combat Score by which it lost the combat.
+The Health Points l osses are distributed in the following order:
+1. R&amp;F models, excluding Champions.
+2. Champion.
+3. Characters. Distributed by the owner of the unit, as evenly as possible.
+Only Characters with Unstable can join units with one or more models with Unstable, and Characters with Unstable cannot join units with models without Unstable .</description>
+    </rule>
+    <rule id="e4e4-ef11-f62f-59b6" name="Vanguard" hidden="false">
+      <description>After Deployment (including units with Scout), models with Vanguard may perform a 12&quot; move. The move is performed as an Advance Move in the Movement Phase, including any actions and restrictions the unit would normally have (such as Wheeling, Reforming, joining units, leaving units and so on). The 12&quot; distance is used instead of the unit&apos;s Advance Rate and March Rate. This move cannot be used to move within 12&quot; of enemy units. This is decreased to 6&quot; for enemy units which have either Scouted or Vanguarded. Units that have moved in this way may not Declare Charges in the first Player Turn (if their side has the first turn). If both players have units with Vanguard,
+alternate moving units one at a time, starting with the player that finished deploying last. Instead of moving a unit, a player may declare to not move any more Vanguarding units.</description>
+    </rule>
+    <rule id="610e-d71e-0439-9e7f" name="War Machine" hidden="false">
+      <description>The Model gains Move or Fire. The model cannot Pursue, Declare Charges or Declare Flee as Charge Reaction. Characters can never join units with one or more War Machines.
+When a War Machine fails a Panic Test, instead of Fleeing it is Shaken until the end of the next Player Turn. War Machines that fail a Break Test are automatically destroyed. War Machines and units Engaged in Combat with them cannot make Combat Reforms.
+When a unit charges a War Machine, it can move into base contact by having its Front Facing contact any point of the War Machine’s base (it must still maximise the number of models in base contact, see Bases and Base Contact). No Align Move is allowed. Ignore the War Machine’s Facing, as it does not have any due to its round base.</description>
+    </rule>
+    <rule id="ccef-5d47-fa0a-8bdf" name="War Platform" hidden="false">
+      <description>Unless selected as a mount for a Character, a model with War Platform gains Not a Leader and Character, with the following exceptions:
+- It does not count as Characters when Deploying Units (It may still be deployed inside Units)
+- It cannot Issue Duels, Accept Duels or Make Way.
+- It can perform Swirling Melee.
+- It does not count as Character regarding Bodyguard and Multiple Wounds.
+The model can join units even if it has Towering Presence, and having Chariot does not prevent it from joining units without Chariot. Additionally, it does not prevent Characters without Chariot from joining a unit containing a model with War Platform and Chariot. When joined to a unit, it must always be placed in the centre of the front rank, possibly pushing back other models with Front Rank, and must keep its position in the centre of the front rank at all times (as long as it is joined to the unit). If two positions are equally central (this may e.g. be the case in a unit with an even number of models in the first rank and a War Platform replacing an uneven number of models per rank), the War Platform can
+be placed in either of these positions. If the War Platform cannot be placed in the centre of the the front rank (e.g. due to Mismatching bases or the front rank being too narrow), the model cannot join the unit. This means that a War Platform can never join a unit with Mismatching bases and that only a single War Platform can normally be in the same unit .</description>
+    </rule>
+    <rule id="7455-f914-028b-3359" name="Wizard Conclave" hidden="false">
+      <description>The Champion of a unit with Wizard Conclave gains +1 Health Point in addition to the normal Characteristics increases associated with being a Champion, and is a Wizard Adept . This Champion may select up to two spells from predetermined spells given in brackets after Wizard Conclave. This overrides the Spell Selection rules connected to being a Wizard Adept.</description>
+    </rule>
+    <rule id="0919-4c3c-87d8-78a8" name="Cannot be Stomped" hidden="false">
+      <description>For the purposes of Stomp Attacks from enemy model, a model with Cannot be Stomped is never considered Standard Size.</description>
+    </rule>
+    <rule id="056f-73ea-194b-1b49" name="Distracting" hidden="false">
+      <description>Close Combat Attacks allocated towards a model with Distracting suffer a -1 to-hit modifier. This to-hit modifier cannot be combined with any other negative to-hit modifiers.</description>
+    </rule>
+    <rule id="5df5-1a68-27be-1ad6" name="Flammable" hidden="false">
+      <description>The attacks ignores Regeneration saves and must reroll failed to-wound rolls against models with Flammable.</description>
+    </rule>
+    <rule id="69d6-4d15-1fc4-13d3" name="Hard Target" hidden="false">
+      <description>Shooting Attacks targeting a unit that has more than half of its models with Hard Target suffer a -1 to-hit modifier. This rule is cumulative, allowing an additional -1 to-hit modifier for each instance of Hard Target.</description>
+    </rule>
+    <rule id="b828-8719-4807-b047" name="Parry" hidden="false">
+      <description>Parry can only be used against Close Combat Attacks from the Front Facing. The model gains +1 Defensive Skill, or its Defensive Skill is always equal to the Offensive Skill of the attacker, whichever is higher.</description>
+    </rule>
+    <rule id="faef-6f9d-ae02-d420" name="Fortitude" hidden="false">
+      <description>Fortitude is a Special Save. Fortitude Saves cannot be taken against attacks with Lethal Strike that rolled a natural 6+ to wound, or against attacks with Flaming Attacks.</description>
+    </rule>
+    <rule id="4966-e452-f252-6176" name="Aegis" hidden="false">
+      <description>Aegis is a Special Save. A model must reroll successful Aegis saves against attacks with Divine Attacks.</description>
+    </rule>
+    <rule id="68aa-b60b-ae0b-158b" name="Accurate" hidden="false">
+      <description>The attack doesn&apos;t suffer the -1 to-hit modifier for shooting at Long Range.</description>
+    </rule>
+    <rule id="542e-121d-e448-b51e" name="Area Attack" hidden="false">
+      <description>When the attack hits a unit, chose up to X different ranks of this unit; these must be the ranks resulting in the maximum amount of hits. For each rank selected this way: the unit suffers X hits, to a maximum equal to the number of models in this rank. A single Area Attack can never cause more hits than there are models in the unit.
+Some Area Attacks have a higher Strength and/or additional Attack Attributes stated in square brackets (such as Strength 3 [7], [Multiple Wounds (D3)]). If so, a single hit from this attack, chosen by the attacker, uses the Strength value and Attack Attributes in brackets. The bracketed values and Attack Attributes are not applied to any other hits.</description>
+    </rule>
+    <rule id="9371-5924-2a39-1652" name="Crush Attack" hidden="false">
+      <description>At the end of step 4 of the Round of Combat Sequence (just after Issue and Accept Duels), the model part may announce that it will use its Crush Attack this Round of Combat. It performs a single Close Combat Attack, which cannot be made as a Supporting Attack , is resolved at Initiative Step 0, has Strength 10, Armour Penetration 10 (regardless of user’s Agility, Strength, and Armour Penetration), and Multiple Wounds (D3+1). Crush Attacks never benefit from any Weapons or other Attack Attributes the model part may have. The model part cannot make any other Close Combat Attacks during this Round of Combat (but can still use its Special Attacks such as Stomp Attacks or Impact Hits).</description>
+    </rule>
+    <rule id="030a-8283-3ebb-93f1" name="Divine Attacks" hidden="false">
+      <description>Successful Aegis Saves taken against the attack must be rerolled .</description>
+    </rule>
+    <rule id="f07b-fa49-1de5-8a2b" name="Fight in Extra Rank" hidden="false">
+      <description>Model parts with Fight in Extra Rank, or using a Weapon with Fight in Extra Rank, can make Supporting Attacks from an additional Rank (normally, this means that models with Fight in Extra Rank will be able to make Supporting Attacks from the third rank). This rule is cumulative, allowing an additional rank to make Supporting Attacks for each instance of Fight in Extra Rank.</description>
+    </rule>
+    <rule id="49e5-2d9a-1ecc-101f" name="Flaming Attacks" hidden="false">
+      <description>The attack doesn’t have any special effect. However, it interacts with other rules, such as Flammable and Regeneration.</description>
+    </rule>
+    <rule id="13c5-ce89-60ad-c572" name="Hatred" hidden="false">
+      <description>During the first Round of Combat, failed to-hit rolls from attacks with Hatred must be rerolled.</description>
+    </rule>
+    <rule id="cc29-65f2-796b-52e2" name="Battle Focus" hidden="false">
+      <description>If the attack hits with a natural to-hit roll of ‘6’, the attack causes two hits instead of one.</description>
+    </rule>
+    <rule id="f433-7645-0332-97a4" name="Lethal Strike" hidden="false">
+      <description>An attack with Lethal Strike that wounds with a natural to-wound roll of ‘6’ has its Armour Penetration set to 10 and ignores Regeneration saves.</description>
+    </rule>
+    <rule id="f17a-c7f9-af34-a039" name="Lightning Reflexes" hidden="false">
+      <description>The attack gains a +1 to-hit modifier if it is a Close Combat Attack. Model parts with this Attack Attribute wielding Great Weapons do not gain this +1 to-hit modifier, but strike with the Great Weapon at the Initiative Step corresponding to their normal Agility instead of always striking at Initiative Step 0.</description>
+    </rule>
+    <rule id="97c6-651e-d93d-a61e" name="Magical Attacks" hidden="false">
+      <description>The attack doesn’t have any special effects. However, it interacts with other rules, such as Aegis (X, against Magical Attacks). Model parts with Magical Attacks apply it also to their Special Attacks (such as Stomp Attacks , Impact Hits and Breath Attack).</description>
+    </rule>
+    <rule id="6475-e063-0070-f6cc" name="Move or Fire" hidden="false">
+      <description>The attack may not be used if the attacking model moved during the current Player Turn .</description>
+    </rule>
+    <rule id="2ea2-3a42-de1e-bc0a" name="Multiple Wounds" hidden="false">
+      <description>Unsaved wounds caused by the attacks are multiplied into the value given in brackets (X). If the value is a dice (e.g. Multiple Wounds (D3)), roll one dice for each unsaved wound with Multiple Wounds. The amount of wounds that the attack is multiplied into can never be higher than the Health Points Characteristic of the target (excluding Health Points lost previously in the battle). For example, if a Multiple Wounds (D6) attack wounds a unit of Trolls (HP 3) and rolls a ‘5&apos; for the multiplier, the number of unsaved wounds is reduced to 3, even if the Troll unit has already lost
+one or two Health Points previously in battle .
+If Clipped Wings is stated after the X value in brackets, any unsaved wound caused by the attack against a model with Fly is multiplied into X+1 instead of X.</description>
+    </rule>
+    <rule id="64e2-a7c4-41ba-fbf9" name="Penetrating" hidden="false">
+      <description>When the attack hits, check in which Arc of the target half or more of the attacker’s base is in (randomise in case of a tie). The attack causes a number of hits equal to the number of ranks of its target if the attacker is in the Front or the Rear Arc, or a number hits equal to the number of files of its target if the attacker is in either Flank Arc. In either case, the number of affected ranks or files cannot exceed 5, and no model can suffer more than one hit from a single attack with Penetrating.
+Some Penetrating attacks have a higher Strength and/or additional Attack Attributes stated in square brackets (e.g. Strength 3 [6], [Multiple Wounds (D3)]). If so, a single hit from this attack, chosen by the attacker, uses the Strength value and Attack Attributes in brackets. The bracketed values and Attack Attributes are not applied to any other hits.</description>
+    </rule>
+    <rule id="f2fe-a751-2161-8c76" name="Poison Attacks" hidden="false">
+      <description>If the attack successfully hits with a natural to-hit roll of ‘6’, it automatically wounds with no to-wound roll needed. Shooting Attacks using the Hopeless Shot can only automatically wound if the first to-hit roll is a natural ‘6’. Note that the second to-hit roll must still be successful in order to hit the target. If the Attack can be turned into more than one hit (e.g. a hit with Penetrating, Area Attack or Battle Focus) , only a single hit, chosen by the attacker, automatically wounds. All other hits must roll to wound as normal.</description>
+    </rule>
+    <rule id="5a08-d3bf-06f9-3034" name="Quick to Fire" hidden="false">
+      <description>The attack doesn&apos;t suffer the -1 to-hit modifier for Moving and Shooting.</description>
+    </rule>
+    <rule id="1b31-4a58-d332-33f2" name="Reload!" hidden="false">
+      <description>The attack cannot be used for a Stand and Shoot Charge Reaction.</description>
+    </rule>
+    <rule id="3d09-e862-b7b5-fc26" name="Harnessed" hidden="false">
+      <description>Model parts with Harnessed cannot make Supporting Attacks and cannot use Weapons. Shooting Weapons carried by model parts with Harnessed can be used by other model parts of the same model (as long as they do not have Harnessed or Inanimate). A model with with at least one model part with Harnessed is considered to be mounted. </description>
+    </rule>
+    <rule id="ca83-2dad-d908-5f4c" name="Inanimate" hidden="false">
+      <description>Model parts with Inanimate cannot make Close Combat Attacks and cannot use Shooting Weapons. Shooting Weapons carried by model parts with Inanimate can be used by other model parts of the same model (and do not have Restraints or Inanimate).</description>
+    </rule>
+    <rule id="c66c-e69e-a4f1-0351" name="Devastating Charge" hidden="false">
+      <description>A charging model part with Devastating Charge, or using a weapon with Devastating Charge, gains the Model Rules and Characteristic modifiers stated in brackets. For example, a charging model part with Devastating Charge (+1 Strength, Poison Attacks) gains +1 Strength and Poison Attacks when it is charging. This rule is cumulative: a model part with several instances of Devastating Charge applies all Attack Attributes and Characteristics modifiers from all of them when charging.</description>
+    </rule>
+    <rule id="3472-76a4-0c76-5d27" name="Toxic Attacks" hidden="false">
+      <description>The attack has its Strength always set to 3 and its Armour Penetration always set to 10 .</description>
+    </rule>
+    <rule id="c545-6ef2-4618-4d0f" name="Unwieldy" hidden="false">
+      <description>The attack suffers an additional -1 to-hit modifier for Moving and Shooting (for a total of -2). When combined with Quick to Fire, the attack can only ignore the normal -1 to-hit modifier from Moving and Shooting, not the additional -1 to-hit modifier from Unwieldy.</description>
+    </rule>
+    <rule id="1582-2a6f-e73c-889c" name="Volley Fire" hidden="false">
+      <description>If at least one model in a unit can draw Line of Sight to the target, then all model parts using Volley Fire in the same unit ignore all intervening models of their own size or smaller for Line of Sight and Cover purposes.
+In addition, unless making a Stand and Shoot Charge Reaction, models in a unit in Line Formation that has not moved during this Player Turn may shoot from one additional rank (usually this means that they can shoot from the first three ranks).</description>
+    </rule>
+    <rule id="a9a1-31b4-37a3-4138" name="Weapon Master" hidden="false">
+      <description>At the beginning of each Round of Combat, model parts with Weapon Master may choose which weapon they fight with. This includes selecting to use a Hand Weapon even if they have other weapons. If armed with a weapon with a Weapon Enchantment , the model part must still use it.</description>
+    </rule>
+    <rule id="3be7-d693-e8e8-6b1e" name="Breath Attack" hidden="false">
+      <description>A model part with Breath Attack can use it only once during the game. If a model has more than one Breath Attack, it can only use one Breath Attack in a single phase. It can be used either as a Shooting Attack or as a Melee Attack .
+● As a Shooting Attack (normally in the Shooting Phase): choose a target using the normal rules for Shooting Attacks (it is allowed for a Stand and Shoot Charge Reaction), except it can be used even if the model Marched previously in this Player Turn. A model with both a Breath Attack and a Shooting Weapon can use both in the same Shooting Phase, however only against the same target . The attack has a range of 6&quot;.
+● As a Melee Attack (normally in the Melee Phase) : the attack is made at the model part&apos;s Agility. Declare that you are using the Breath Attack when allocating attacks, and choose a unit in base contact to attack with it. 
+No matter if it is used as a Shooting or Melee Attack, the target of the Breath Attack suffers 2D6 hits. The Strength, Armour Penetration and Attack Attributes (if any) of these hits are given within brackets, such as in Breath Attack (Strength 4, Armour Penetration 1, Flaming Attacks). When several model parts in the same unit have this Special Attack , roll for the number of hits separately for each model part .</description>
+    </rule>
+    <rule id="1728-908f-7383-29d6" name="Grind Attacks" hidden="false">
+      <description>At the Agility of the model part with Grind Attacks Agility, it must choose an enemy unit in base contact with it. The chosen enemy unit suffers a number of hits equal to the value stated in brackets (X). These hits are resolved with the model part &apos;s own Strength and Armour Penetration .
+If a model has both Grind Attacks and Impact Hits, it may only use one of these rules in the same Round of Combat (its controlling player may choose which). When several model parts in the same unit have Grind Attacks and when X is a random number (e.g. Grind Attacks (2D3)), roll for the number of hits separately for each model part .</description>
+    </rule>
+    <rule id="197f-58cf-73ad-ac42" name="Impact Hits" hidden="false">
+      <description>At Initiative Step 10, a Charging model part with Impact Hits must choose an enemy unit that is in base contact with the attacking model&apos;s Front Facing. This unit suffers a number of hits equal to the value stated in brackets (X). These hits are resolved with the attacking model part&apos;s Strength and Armour Penetration.
+If a model has both Grind Attacks and Impact Hits, it may only use one of these rules in the same Round of Combat (its controlling player may choose which). In multipart models, only model parts that also have Restraints or Inanimate can use their Impact Hits. When several models in the same unit have Impact Hits, and when X is a random number (e.g. Impact Hits (D6)), roll for the number of hits separately for each model part.</description>
+    </rule>
+    <rule id="4810-6726-807b-e78e" name="Stomp Attacks" hidden="false">
+      <description>At Initiative Step 0 a model part with Stomp Attacks must choose an enemy model of Standard Size in base contact with it. The chosen model’s unit suffers a number of hits equal to the value stated in brackets (X). These hits can only be distributed onto models of Standard Size (ignore models of a different Size when distributing hits). They are resolved with the model part’s own Strength and Armour Penetration.
+In multipart models, only model parts that also have Restraints can use Stomp Attacks. When several models in the same unit have this Special Attack, and when X is a random number (e.g. Stomp Attacks (D6)), roll for the number of hits separately.</description>
+    </rule>
+    <rule id="3fff-f85c-3747-6634" name="Sweeping Attack" hidden="false">
+      <description>This attack may be used by units consisting of models with Sweeping Attack. When the unit Advance Moves or March Moves, you may nominate a single unengaged enemy unit that the unit with Sweeping Attack moved through or over during this move (meaning their Bases were Overlapping, even partially). The whole unit makes the Sweeping Attack against the nominated enemy unit, which is resolved when the March or Advance Move is completed. Follow the description in the unit profile. These attacks hit automatically and count as Ranged Attacks. When a model performs a Sweeping At tack, the distance moved is counted from its starting position to the point on the Battlefield where it performed the attack, and then to its final position. Each Sweeping Attack can only be performed once per Player Turn.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="1da1-0128-4bf2-cf8d" name="Shield" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Shield</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+1</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">Parry</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ceb4-e216-c1ec-56a4" name="Light Armour" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Suit of Armour</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+1</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">A model part can only wear a single Suit of Armour.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="37ab-dde5-6b99-7c67" name="Heavy Armour" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Suit of Armour</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+2</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">A model part can only wear a single Suit of Armour.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="85fa-68ac-214d-2f4b" name="Plate Armour" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="Armour">
+      <characteristics>
+        <characteristic name="Type" typeId="017b-143b-0520-bdc1">Suit of Armour</characteristic>
+        <characteristic name="Save" typeId="4ca3-2498-f356-f056">+3</characteristic>
+        <characteristic name="Rules" typeId="f269-16dd-a614-0f90">A model part can only wear a single Suit of Armour.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2d01-b358-db9b-3b99" name="Hand Weapon" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">As User</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">As User</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">If a model has any Melee Weapon other than a Hand Weapon, it cannot choose to use the Hand Weapon (unless specifically stated). Hand Weapons wielded by models on foot can be used alongside a Shield, then giving the Parry Personal Protection .</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ce6c-6fd5-c795-da76" name="Great Weapon" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Always strike at Initiative Step 0 (regardless of the wielder’s Agility ). A model using this weapon cannot simultaneously use a Shield against Melee Attacks.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="680b-8e56-dff9-240c" name="Halberd" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">A model using this weapon cannot simultaneously use a Shield against Melee Attacks .</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="06d7-e62c-0123-95ec" name="Paired Weapons" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">As User</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">As User</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">The wielder gains +1 Attack Value when using this weapon. Attacks made with Paired Weapons gain +1 Offensive Skill and ignore Parry. A model using this weapon cannot simultaneously use a Shield against Melee Attacks .</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f1a1-62ad-69ea-9d18" name="Lance" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Attacks made with a Lance and allocated toward models in the wielders’ Front Facing gain Devastating Charge (+ 2 Strength, +2 Armour Penetration). Infantry cannot use Lances.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8460-7bb5-aa92-d6ee" name="Light Lance" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+1</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Attacks made with a Lance and allocated toward models in the wielders’ Front Facing gain Devastating Charge (+1 Strength, +1 Armour Penetration). Infantry cannot use Lances.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c18a-75bb-fa2f-f7cf" name="Spear" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">As User</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+1</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Attacks made with a Spear gain Fight in Extra Rank and +1 Armour Penetration. Close Combat Attacks from model parts wielding a Spear gain +2 Agility and an additional +1 Armour Penetration in the first Round of Combat provided their unit is not Charging and is not Engaged either in their Flank or Rear Facing. Cavalry, Beasts and Constructs cannot use Spears.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a564-30bf-f33f-f20d" name="Bow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Fire</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="245b-baaf-f5ec-e168" name="Longbow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">30&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Fire</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="fdf6-3c15-644b-1ced" name="Crossbow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">30&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Unwieldy</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b092-dbc5-4c60-9a80" name="Handgun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Unwieldy</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="12c1-3184-6230-c142" name="Pistol" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8c83-06ff-024f-a235" name="Throwing Weapons" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">8&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">As User</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">As User</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Accurate</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</gameSystem>

--- a/theVerminSwarm.cat
+++ b/theVerminSwarm.cat
@@ -1,0 +1,3721 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="cb95-d0ac-2627-c23e" name="The Vermin Swarm 2.0" revision="18" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="1c57-fa6c-295c-c49c" name="Tunnel Gunners (local)" hidden="false"/>
+    <categoryEntry id="a4b6-d53f-821c-9216" name="Built and Bred (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="035e-617b-127a-22fd" name="The Vermin Swarm (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="041d-188e-83f8-5c2f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="eab9-2582-4acd-eeee" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5645-cc62-911e-9601" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="c59f-122d-a5ac-a4c1" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="afd0-2f07-c34a-5de7" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="9d24-8e49-a3a9-a035" name="Tunnel Gunners (local)" hidden="false" targetId="1c57-fa6c-295c-c49c" primary="false">
+          <modifiers>
+            <modifier type="decrement" field="1d90-e4ae-83b4-c09e" value="5">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="187a-c2bf-67dd-6ccb" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="1d90-e4ae-83b4-c09e" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2c1b-d63d-1994-8e6d" name="Built and Bred (local)" hidden="false" targetId="a4b6-d53f-821c-9216" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="890c-04f7-789a-9d94" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="187a-c2bf-67dd-6ccb" name="Vermin Daemon" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c923-a291-e316-5126" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d6e6-06a6-9e1f-a685" name="Vermin Daemon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b59b-a924-1709-d8a2" name="Vermin Daemon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">8</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="639b-d6d4-54b9-28de" name="Vermin Daemon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">8</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">10</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">9</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6da4-5ed5-68ab-19f3" name="Schemer" hidden="false">
+          <description>Spells cast by the model gain +3&quot; Range. The model knows an additional spell, and must select spells from Divination. If a Vermin Daemon is included in the Army, the Tunnel Gunners category is reduced to 25%.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="26e7-f650-0aa9-13f0" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
+        <infoLink id="0357-53bc-7601-4085" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="7424-f2cb-2b31-5115" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+        <infoLink id="3765-3730-bbff-1e45" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+, against Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2313-87c7-c2ea-4804" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="eec4-6cd5-4110-34e2" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="ab3d-c6bf-8fac-8da7" name="Built and Bred (local)" hidden="false" targetId="a4b6-d53f-821c-9216" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1319-afbc-74e4-fcff" name="Army General" hidden="false" collective="false" targetId="335b-c901-c159-fbed" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="820.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c78-3f78-630a-1645" name="Tyrant" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="0574-f87a-7fc1-2fb4" name="Tyrant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7d93-a749-e52c-8bd3" name="Tyrant Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f284-5fc6-8a7c-b61a" name="Tyrant Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9238-ce47-7b04-e132" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="be3f-e688-9948-f143" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="053d-f60f-ed85-6a32" name="Honourless" hidden="false" targetId="3016-0b06-30a7-7484" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="baab-a8eb-eee0-356c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="27e6-ea0f-7676-e82a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78d1-300d-f802-18d6" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8fe3-2724-eaa3-c934" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1972-8e9b-ea1c-8bbd" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="421c-8442-9f07-ea7c" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="421a-c099-37dc-2191" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="d02a-9bd2-d895-e505" name="VS Weapon Enchantments" hidden="false" collective="false" targetId="d50e-23be-2e5d-6f0a" type="selectionEntryGroup"/>
+                    <entryLink id="2eb3-0d08-7e58-0f60" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1de1-f23d-ccda-71ae" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="ecd0-f407-e2dd-050b" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecd0-f407-e2dd-050b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="057e-bb62-6495-b97a" name="VS Armour Enchantments" hidden="false" collective="false" targetId="60c3-91ea-5312-75f9" type="selectionEntryGroup"/>
+                    <entryLink id="6c6f-9968-03e6-4dd9" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="da72-5f6d-6e1b-a953" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a72f-7fce-149e-be04" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="328a-243a-a88c-09d8" name="VS Artefacts" hidden="false" collective="false" targetId="b06c-6498-74d7-74b3" type="selectionEntryGroup"/>
+                    <entryLink id="2479-8046-905f-d914" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cba9-ca15-fae9-8fb4" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="a3a8-ac23-81ed-4a13">
+          <selectionEntries>
+            <selectionEntry id="a3a8-ac23-81ed-4a13" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="3408-4aa2-6416-281f" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d444-4d45-e7c9-f426" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3408-4aa2-6416-281f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c372-91c1-b25b-87d8" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d444-4d45-e7c9-f426" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="3bbd-c156-e14d-5c13" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3a8-ac23-81ed-4a13" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3bbd-c156-e14d-5c13" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1ddc-6f05-ec27-f8eb" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2d4b-0d22-9b6c-54a0" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f75f-bb2f-69f4-3df5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c700-8a79-551d-c58d" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d46e-4004-cbf2-c100" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ce9-b2ba-e07f-22e7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f29b-db98-6dc1-a43b" name="Ratlock Pistols" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87b3-c47e-6f8b-1b5a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="53f6-40a4-7703-9ecd" name="Ratlock Pistol" hidden="false" targetId="4d6d-8823-9da6-486f" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5391-d8b7-6419-eda2" name="Paired Weapons and Tail Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb6a-65b0-3092-5fde" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7c23-6f08-750e-2063" name="Tail Weapon" hidden="false" targetId="a30f-462e-8f23-2766" type="profile"/>
+                <infoLink id="8e8f-b41e-9e55-488e" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0ff2-46b4-fd3f-c698" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be48-ad5e-c454-3579" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ace2-dd7b-cdde-7fef" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6c0a-1454-4753-676c" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03aa-a8d8-e044-59bd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="92f9-d1b8-4807-249f" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6214-5cb7-ee4d-b8d9" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b57-9638-09dc-38fa" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="285a-7e89-3819-a8f3" name="Vermin Guard Litter" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2818-94d6-f71b-d9d6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0898-45bf-4fc4-6161" name="Vermin Guard Litter" hidden="false" collective="false" targetId="7cfd-df04-3e1b-e2be" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="18de-060b-79f8-054a" name="Vermin Hulk Bodyguard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e9a6-2fd3-ea29-ebcb" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d976-f2d0-0192-82cc" name="Vermin Hulk Bodyguard" hidden="false" collective="false" targetId="3d1e-7361-8963-e157" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f9e4-c732-0b86-d19e" name="Monstrous Rat" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf63-4f9c-eed9-4b59" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="9e28-0247-95ae-6887" name="Built and Bred (local)" hidden="false" targetId="a4b6-d53f-821c-9216" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="d509-b8d4-e718-2211" name="Monstrous Rat" hidden="false" collective="false" targetId="6998-b2ad-5bd8-255b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="185.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="adf3-9b63-b77d-541d" name="Army General" hidden="false" collective="false" targetId="335b-c901-c159-fbed" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7e18-69c5-daac-8d07" name="Chief" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2269-051b-87b8-5c9b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="89f7-904c-79c8-f1d2" name="Chief Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <modifiers>
+            <modifier type="set" field="b0d9-2dab-f10b-9b13" value="7&quot;">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="40ca-8aeb-e952-116e" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="db10-a838-f72f-3ed6" value="14&quot;">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="40ca-8aeb-e952-116e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="97a7-e180-876d-31e4" name="Chief Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7410-e8d9-f966-79ee" name="Chief Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="03b4-d4ba-1e40-9243" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="8dc4-c3c2-e80a-7ca7" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="d47b-f95f-bab8-df52" name="Honourless" hidden="false" targetId="3016-0b06-30a7-7484" type="rule"/>
+        <infoLink id="9f4d-ece3-f199-99b7" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="40ca-8aeb-e952-116e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="90e6-ff6f-69df-94ea" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="03c6-4395-855c-ee9e" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34c6-bd77-5dca-b9f5" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6901-c686-7ee6-8846" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1227-df8b-1993-f785" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7cb1-7b86-b6c5-5472" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d97-8cfc-f346-324b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="1b7b-f6b3-c880-39ad" name="VS Weapon Enchantments" hidden="false" collective="false" targetId="d50e-23be-2e5d-6f0a" type="selectionEntryGroup"/>
+                    <entryLink id="cea6-906a-0136-2ce2" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c963-a2ce-667a-ccff" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="be78-1ee7-02c0-446d" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be78-1ee7-02c0-446d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="529a-f143-1c31-91fc" name="VS Armour Enchantments" hidden="false" collective="false" targetId="60c3-91ea-5312-75f9" type="selectionEntryGroup"/>
+                    <entryLink id="3d07-864e-20b6-dd51" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3672-f3e2-e0c5-6b01" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="07b5-be4c-173a-eae3" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7482-2aa3-2227-e993" name="VS Artefacts" hidden="false" collective="false" targetId="b06c-6498-74d7-74b3" type="selectionEntryGroup"/>
+                    <entryLink id="b06e-ef46-b985-e0ff" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e75c-7bda-c405-96be" name="Banner Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="7e18-69c5-daac-8d07" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="007c-ee51-6e60-97bc" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e2f-77f5-89c2-6abc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="366a-4665-159a-d56d" name="VS Banner Enchantments" hidden="false" collective="false" targetId="96e5-b65b-1c87-1acd" type="selectionEntryGroup">
+                      <modifiers>
+                        <modifier type="set" field="4f85-2a46-f0d1-c6f3" value="2">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="03c6-4395-855c-ee9e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7cb1-7b86-b6c5-5472" type="equalTo"/>
+                                <condition field="selections" scope="03c6-4395-855c-ee9e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c963-a2ce-667a-ccff" type="equalTo"/>
+                                <condition field="selections" scope="03c6-4395-855c-ee9e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3672-f3e2-e0c5-6b01" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink id="a6d8-7906-403b-5d92" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+                      <modifiers>
+                        <modifier type="set" field="0fb8-361b-f433-cc9e" value="2">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="03c6-4395-855c-ee9e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7cb1-7b86-b6c5-5472" type="equalTo"/>
+                                <condition field="selections" scope="03c6-4395-855c-ee9e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c963-a2ce-667a-ccff" type="equalTo"/>
+                                <condition field="selections" scope="03c6-4395-855c-ee9e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3672-f3e2-e0c5-6b01" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="40ca-8aeb-e952-116e" name="Fetthis Broodmaster" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5450-fb63-1163-f031" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="3158-8f84-4376-e3c8" name="Fetthis Broodmaster" hidden="false">
+              <description>Fetthis Broodmaster: Universal Rule.
+The Chief has its Advance Rate set to 7”, its March Rate set to 14”, and gains Swiftstride.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9cdc-3faf-e5f7-7a73" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="fd3d-2088-d0ee-9e5f" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="7540-c616-94ee-0705" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f22e-c4f4-d6db-4258" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7540-c616-94ee-0705" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0198-8797-143e-d96f" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f22e-c4f4-d6db-4258" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="6ecb-5b5e-03f6-7839" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd3d-2088-d0ee-9e5f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ecb-5b5e-03f6-7839" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="eacd-0efe-edc1-32e5" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c310-fc5e-aa02-ec71" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f8a-3a5e-850a-785a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="912f-4562-c959-2d93" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6837-6e8d-f904-795f" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b88-9267-898e-58a8" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a6ab-51df-3f01-64d1" name="Ratlock Pistols" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ea6-c48a-8d56-95ec" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="506a-0117-fc2c-f974" name="Ratlock Pistol" hidden="false" targetId="4d6d-8823-9da6-486f" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0c2a-82b8-252b-2dc0" name="Paired Weapons and Tail Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b2c3-e8bd-8fbf-37d4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d1f6-0a84-a3a6-b887" name="Tail Weapon" hidden="false" targetId="a30f-462e-8f23-2766" type="profile"/>
+                <infoLink id="e26c-f04c-5a13-5a08" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b416-747d-c212-7863" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f50-39fa-e27e-3dbe" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a625-bcaf-ba2e-fe59" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a5c6-c3f2-500a-7837" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7366-5d9d-fedd-5a08" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7045-89e0-d3fd-555e" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2c73-18dc-6073-8b0b" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="871c-3b3b-4332-1526" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7dab-04f9-d808-4a7a" name="Vermin Hulk Bodyguard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80d6-80ab-7bcc-aa87" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ab30-bd39-0bd7-2f6f" name="Vermin Hulk Bodyguard" hidden="false" collective="false" targetId="3d1e-7361-8963-e157" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6755-5054-4bdb-a610" name="Monstrous Rat" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbb8-7bae-062a-7eb3" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="8716-8277-ce67-45af" name="Built and Bred (local)" hidden="false" targetId="a4b6-d53f-821c-9216" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="63d3-f6e5-0ffe-ffcd" name="Monstrous Rat" hidden="false" collective="false" targetId="6998-b2ad-5bd8-255b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="210.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="704b-dc3a-7f08-f930" name="Army General" hidden="false" collective="false" targetId="335b-c901-c159-fbed" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="007c-ee51-6e60-97bc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="7fd5-385c-291a-3aed" name="Battle Standard Bearer" hidden="false" collective="false" targetId="007c-ee51-6e60-97bc" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="335b-c901-c159-fbed" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dd9e-4c79-bce8-f708" name="Magister" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="fab7-c9f3-2fc8-8017" name="Magister Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f18d-28f1-20d8-7856" name="Magister Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9665-bb3b-ce2d-b7f0" name="Magister Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="30de-26d3-ba4f-5fc4" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="b0de-8db1-9b87-9cca" name="Honourless" hidden="false" targetId="3016-0b06-30a7-7484" type="rule"/>
+        <infoLink id="5dd3-ef04-9c5f-354b" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8a0e-d10d-f65a-5aea" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d741-a9e5-2571-39ae" name="3 Dark Shards" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfef-65f5-9939-0661" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fbef-ad85-66bf-97d8" name="Dark Shards" hidden="false" targetId="ac84-f13f-40fc-c2d6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="562d-b4fd-7ed7-7486" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7284-d16f-0955-3f81" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7eb2-0dff-6ab3-fc8b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d28c-cd06-10f7-e79c" name="Doom Bell" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d16-21e9-736c-48c6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d2aa-6b25-68cb-f287" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="8313-a726-9fad-a59b" name="Built and Bred (local)" hidden="false" targetId="a4b6-d53f-821c-9216" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="9bdd-1c86-d2c8-9301" name="Doom Bell" hidden="false" collective="false" targetId="6cf6-15eb-e6b0-fde1" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="360.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cc9d-b3f4-5ea8-a6de" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cec7-2496-0d23-25f2" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="76d2-94a4-056f-12ea" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="fc66-5f96-2f0b-67fa" value="200">
+                  <conditions>
+                    <condition field="selections" scope="dd9e-4c79-bce8-f708" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d16-21e9-736c-48c6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc66-5f96-2f0b-67fa" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7530-19b4-f4ab-0d7b" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb2c-7eae-2d6a-32b8" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="35c5-5666-07f9-df7a" name="VS Weapon Enchantments" hidden="false" collective="false" targetId="d50e-23be-2e5d-6f0a" type="selectionEntryGroup"/>
+                    <entryLink id="e530-b063-0c8d-72d4" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8125-7f0b-cb57-f8f4" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="dd9e-4c79-bce8-f708" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="562d-b4fd-7ed7-7486" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="5b3e-fb5b-8e05-7599" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5b3e-fb5b-8e05-7599" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4caa-d376-707b-1c79" name="VS Armour Enchantments" hidden="false" collective="false" targetId="60c3-91ea-5312-75f9" type="selectionEntryGroup"/>
+                    <entryLink id="5fb7-8cfa-f72c-8075" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1182-f061-7b4d-93a2" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c3a9-3885-56cd-31ae" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="86c3-ac45-b84f-9ce1" name="VS Artefacts" hidden="false" collective="false" targetId="b06c-6498-74d7-74b3" type="selectionEntryGroup"/>
+                    <entryLink id="7d52-d8b1-6791-8dac" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="70fa-8e26-075b-25cd" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="02ab-fcb7-0553-ed82">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="167f-b2a1-0f28-d146" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ea9-5b1e-bd3c-9cc8" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="02ab-fcb7-0553-ed82" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0853-b8fe-a6fe-2724" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="26a4-3c88-b5ed-d546" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8d16-21e9-736c-48c6" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f1e0-f21a-3d61-0679" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5488-4ae7-ed88-f99c" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d320-0f49-30af-6628" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="f655-194f-ee6a-3860" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f655-194f-ee6a-3860" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="725b-4002-1b09-e373" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="27c8-2690-22e4-5363" name="Witchcraft" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="623e-0392-8ede-cb74" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0d50-b53d-c5f0-52a6" name="Thaumaturgy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="869a-5d96-5c5c-ce10" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6571-7b0a-e58b-7ff4" name="Army General" hidden="false" collective="false" targetId="335b-c901-c159-fbed" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="427b-2845-8698-7818" name="Rakachit Machinist" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f5c-7ecf-c3e4-135e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5506-24e8-0507-08ad" name="Rakachit Machinist Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bb23-cb68-062c-3dbc" name="Rakachit Machinist Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6631-fd41-ac72-9f98" name="Rakachit Machinist Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1824-43d6-8542-e7ff" name="Mechanical Limbs" hidden="false">
+          <description>Mechanical Limbs: Special Attack.
+A Rakachit Machinist may use a single of the following attacks once per Player Turn. If used as a Shooting Attack, the attack may be used in addition to using a Shooting Weapon, provided both Shooting Attacks target the same unit.
+⦁	Lightning Coil: Shooting Attack. Range 18”, Shots D6, Str 2, AP 3. This attack hits automatically. 
+⦁	Naphtha Thrower: Breath Attack (Str 3, AP 0, Flaming Attacks). This Breath Attack is not limited to being used only once per game.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d145-2a82-bbae-ad5d" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="346e-d2d0-04a7-2609" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="c606-09a0-9ea4-a882" name="Honourless" hidden="false" targetId="3016-0b06-30a7-7484" type="rule"/>
+        <infoLink id="ddda-ebe7-d3e1-3b3e" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="d451-82b0-1e03-38bd" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4f35-015b-2c00-578b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ec0a-d6a2-2243-467d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="452b-7e38-c40d-4a7e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8934-43d7-428b-4940" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84bd-be4e-87ad-8c89" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="f175-3f56-81bf-fb02" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd5a-d74a-0c7b-f59b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="77eb-2e46-10b2-dfe6" name="VS Weapon Enchantments" hidden="false" collective="false" targetId="d50e-23be-2e5d-6f0a" type="selectionEntryGroup"/>
+                    <entryLink id="ffe7-d21d-b958-f9e2" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="62d5-a698-e756-8f00" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="bb2c-1feb-c804-dc8d" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb2c-1feb-c804-dc8d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="fc16-e497-bb9c-87d6" name="VS Armour Enchantments" hidden="false" collective="false" targetId="60c3-91ea-5312-75f9" type="selectionEntryGroup"/>
+                    <entryLink id="5b25-718b-0e9c-b579" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="9c04-0731-db9a-3291" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7746-49fa-071a-acc7" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8d94-5eb7-cc5f-1d6b" name="VS Artefacts" hidden="false" collective="false" targetId="b06c-6498-74d7-74b3" type="selectionEntryGroup"/>
+                    <entryLink id="b9ce-52f1-7601-b336" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3bdb-9b11-8c83-c2b1" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4957-edc9-6b21-3b62" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b4c5-d44c-3575-0d9f" name="Gas Globes" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="append" field="name" value=" (3+)"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa6f-416f-70f5-c4a2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6a28-e0b5-2b9e-378a" name="Gas Globes" hidden="false" targetId="5741-4795-0156-40ef" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="abea-eacc-527a-0477" name="Ratlock Pistols" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="07f0-da1b-c9bf-50ff" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1d35-448e-c73e-f2a3" name="Ratlock Pistol" hidden="false" targetId="4d6d-8823-9da6-486f" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e1d4-79f7-6567-c40a" name="Jezzail" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="396a-a0d1-2f77-f58a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9a2f-3456-964b-1aa6" name="Jezzail" hidden="false" targetId="6c76-ea2d-66f3-1a62" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="dac5-0311-8eda-37e1" name="Army General" hidden="false" collective="false" targetId="335b-c901-c159-fbed" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e67-3b5e-52ae-e4f6" name="Sicarra Assassin" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="3724-4020-c6c6-7f60" name="Sicarra Assassin Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="21a8-07ee-6e62-63f0" name="Sicarra Assassin Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fa9a-3a86-7d56-4104" name="Sicarra Assassin Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">8</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6638-6a42-3416-a696" name="Professional Courtesy" hidden="false">
+          <description>Sicarra Assassins cannot join (or be deployed in) units that contain another Sicarra Assassin. Sicarra Assassins may perform Make Way moves even when they are in base contact with an enemy model.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b03e-5426-b106-c531" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="febf-f054-7f2b-43c3" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="3382-f638-7ec6-3488" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="a448-5e64-1d72-1dbe" name="Honourless" hidden="false" targetId="3016-0b06-30a7-7484" type="rule"/>
+        <infoLink id="f49b-0b0c-f85e-2bc0" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ab79-5f35-d20c-1a53" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+        <infoLink id="da27-9860-fbdb-57de" name="Tail Weapon" hidden="false" targetId="a30f-462e-8f23-2766" type="profile"/>
+        <infoLink id="a103-0ab6-4d18-0886" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+        <infoLink id="4c5b-54c2-df94-6ff3" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="a2ec-8717-e307-e223" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(D3, against Characters)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e4ad-9c97-1e45-a98b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e6e3-7cf6-d242-6fbd" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="528f-dbbf-83fc-23e7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e905-bdd6-c3fe-f49c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8208-4e1d-e859-3df3" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a25c-6476-34d8-16de" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e5c-0681-064f-3fe7" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9ba5-de73-9258-b898" name="VS Weapon Enchantments" hidden="false" collective="false" targetId="d50e-23be-2e5d-6f0a" type="selectionEntryGroup"/>
+                    <entryLink id="3094-1cd9-c31f-3faa" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="74f6-5645-dbdd-9560" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36d5-6e62-a3a4-1f68" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="01bb-4355-582a-8833" name="VS Artefacts" hidden="false" collective="false" targetId="b06c-6498-74d7-74b3" type="selectionEntryGroup"/>
+                    <entryLink id="544e-6b2e-b4c5-60ed" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c6c9-27d7-6c14-4f2f" name="Upgrades" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="177a-6b7d-fcfd-f60a" name="Lethal Strike" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8104-0f01-c04f-4839" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dbbf-ff8e-6e4f-e1e3" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="311d-3c5b-5549-f0b0" name="Scout, Ambush, and Vanguard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c97e-e82a-8581-2bd6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="41e3-2fb0-710a-57e0" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+                <infoLink id="00d7-4632-07bd-7539" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+                <infoLink id="1df8-a66e-a734-321b" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="79a2-2b94-4ebd-8c01" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="ec6f-a9e1-e213-d818">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a07c-f427-d361-5b60" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa7f-f662-3390-ee88" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c86b-5b9d-5859-8b49" name="Sling" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1350-7097-d7d9-9a46" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c0a5-b4a9-2321-6e67" name="Sling" hidden="false" targetId="29ea-f62f-5c78-773d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (2+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ec6f-a9e1-e213-d818" name="Throwing Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2da-e1ca-6745-7249" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e5bd-9c9a-bc74-cc93" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="280.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3a4b-d72e-d5aa-8a70" name="Plague Patriarch" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="8e73-6bbd-b830-dc3b" name="Plague Patriarch Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2c21-6dad-dfee-c36e" name="Plague Patriarch Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e363-2a51-a313-52ae" name="Plague Patriarch Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="d12d-dbda-0da4-c8ca" name="Putrid Scholar" hidden="false">
+          <description>The model can select its spells from the Learned Spells 1, 2, 3, 4, 5, and 6 of its chosen Path and the Hereditary Spell of its army. This overrides the normal Spell Selection rules connected to being a Wizard Apprentice/Adept.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8352-d1ac-31c8-3c31" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="7e7c-4ea6-51d1-1b4d" name="Honourless" hidden="false" targetId="3016-0b06-30a7-7484" type="rule"/>
+        <infoLink id="3c3f-b78f-571a-3d77" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="745a-b88b-c49a-afb8" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="441b-08c7-7f14-7867" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+        <infoLink id="9e33-40e7-9935-158b" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d603-7876-912e-8ee8" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="994e-3fbb-8a4d-3851" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1aaf-252a-8862-aa1b" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="97fe-e099-5a59-bc95" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="66bd-1e3d-8719-c669" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2157-ab93-b3c8-f5a6" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3e6f-cf6a-7b83-692c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f6c-6901-b1fc-03da" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="deb3-f9fc-b4f0-74e6" name="Weapon Enchantments" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a34b-a0eb-d8e5-8e1b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5a79-b2eb-aa35-3960" name="VS Weapon Enchantments" hidden="false" collective="false" targetId="d50e-23be-2e5d-6f0a" type="selectionEntryGroup"/>
+                    <entryLink id="acdf-4e5c-6fa9-9d1b" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="2fb4-0b10-4739-0f7c" name="Armour Enchantments" hidden="false" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="3a4b-d72e-d5aa-8a70" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="994e-3fbb-8a4d-3851" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="03bc-12bd-6793-8d36" value="2">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03bc-12bd-6793-8d36" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="564c-4350-5916-a485" name="VS Armour Enchantments" hidden="false" collective="false" targetId="60c3-91ea-5312-75f9" type="selectionEntryGroup"/>
+                    <entryLink id="cda0-4c6c-32dd-d3b1" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="ced4-221d-96ce-ff06" name="Artefacts" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d8f-2328-ea80-a63a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6c3e-caa1-5250-fb18" name="VS Artefacts" hidden="false" collective="false" targetId="b06c-6498-74d7-74b3" type="selectionEntryGroup"/>
+                    <entryLink id="3d33-dfee-b0d6-209c" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ec83-23e7-1bea-5d34" name="Plague Pendulum" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68bb-ee3f-1e9d-0fee" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="725a-30ff-51f5-1bb7" name="Built and Bred (local)" hidden="false" targetId="a4b6-d53f-821c-9216" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="b19e-d583-df08-2c57" name="Plague Pendulum" hidden="false" collective="false" targetId="d182-dccc-9a50-44b6" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="410.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1a03-d661-1ae8-04aa" name="3 Dark Shards" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="694b-8745-ad46-f7b8" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d6d3-ad45-8b77-dc06" name="Dark Shards" hidden="false" targetId="ac84-f13f-40fc-c2d6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8eba-1917-b7db-df00" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="3216-f787-ba4b-32e6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ba5-5238-2c4d-437a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a587-683d-89b1-5830" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3216-f787-ba4b-32e6" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee6c-cc1b-2b29-1e86" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7eb9-e135-ceb6-4372" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c9b8-11e4-165c-dddc" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="52c5-0d4f-934a-8e1a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5efe-29f6-7635-3028" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b387-78ad-5dfe-f890" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="87dc-4f60-5d8c-2061" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5897-d591-6366-b990" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b0e-385e-f898-afba" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ca74-3ecd-1a4b-2416" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1270-9f0a-0165-ea96" name="Plague Flail" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d72-1a67-63ce-41c8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d6d3-0804-3442-8bad" name="Plague Flail" hidden="false" targetId="0791-f981-6d52-b2ef" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="155.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24fc-8fe6-8240-5165" name="Rats-at-Arms" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="cd8b-9d97-a946-c408" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="c4e2-d207-1cea-a138" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="4e71-921e-7a7b-9fc8" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="1c3f-d663-211b-c3a0" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="be97-2cef-8447-1f28" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="791e-5620-5bbf-9389" name="Rat-at-Arms" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ace7-3976-1216-0322" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a14-e54b-37c1-56f7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d60a-4ded-a1ee-4991" name="Rat-at-Arms Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="483a-7773-2c27-7292" name="Rat-at-Arms Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8d90-3800-7d9c-59f3" name="Rat-at-Arms Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9b0d-a042-5d79-da05" name="Spears" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="24fc-8fe6-8240-5165" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="791e-5620-5bbf-9389" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6799-13e1-5864-5e88" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d4cc-ec7f-f4d3-001d" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="33b6-4e67-55e9-437b" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9990-0647-6a85-6d2e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="934e-d3f8-ed3f-116c" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a4c-ef9b-af1a-6b70" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="dd70-a8eb-2cf2-fc6a" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="6056-5294-e573-ee9f" name="VS Banner Enchantments" hidden="false" collective="false" targetId="96e5-b65b-1c87-1acd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8edf-89ff-ccae-81bc" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="91f2-ee87-22d6-6c13" name="Vermin Guard" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="13a0-cb3b-8c14-c50b" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="1dd7-6007-1bfc-342a" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3968-5cb1-2727-2a1c" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="c544-2bf7-afd4-36b0" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="da5b-33bd-efb3-cbb5" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="9c20-b5e2-589a-57da" name="Fight in Extra Rank" hidden="false" targetId="f07b-fa49-1de5-8a2b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e168-ff99-ecb2-4bde" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3055-4435-c7c9-e4b0" name="Vermin Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b517-19b4-ec72-3447" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec41-c06b-60ff-3ad3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b17c-abe0-9bf6-a9b1" name="Vermin Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="fe23-8024-a1e9-319f" name="Vermin Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5a71-48a1-4e7d-cc05" name="Vermin Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0fe7-46b9-08aa-c6e7" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ed7-1812-b144-ebe9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5192-a087-96be-88d1" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13ce-f860-c5ec-5afa" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="950d-9312-0439-c639" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="7f44-4f06-a543-7973" name="VS Banner Enchantments" hidden="false" collective="false" targetId="96e5-b65b-1c87-1acd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="c5d7-4bab-deee-0908" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bb60-f7d0-c451-f365" name="Plague Brotherhood" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="0dc2-4340-def2-806b" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="4891-3bae-ef78-7eaa" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="9c34-454c-acc9-3ebe" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="27b9-9244-843c-8237" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="2a5b-b3ce-62e1-c297" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+        <infoLink id="16c5-9345-0303-d325" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="1950-b7af-5418-80ca" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2a47-7733-b3de-c9cc" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6e4b-1edd-93df-6e72" name="Plague Brotherhood" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ba5-0919-3ba6-e2df" type="min"/>
+            <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c509-84c2-22b6-884e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f30a-8de6-e185-435b" name="Plague Brotherhood Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="98c1-ab8e-0862-abd3" name="Plague Brotherhood Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0335-5a7f-e638-2d34" name="Plague Brotherhood Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7d6a-3795-f2b9-6c40" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cb3-d79b-043e-0b04" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="bc3e-6b4f-8991-f88a" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f9d0-5a99-ed0c-b61e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="bdf1-8cae-073d-b970" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="67c9-ec3f-07a2-8fcd" name="VS Banner Enchantments" hidden="false" collective="false" targetId="96e5-b65b-1c87-1acd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="ba5c-dc17-6e6e-e046" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5341-a7a2-4985-b217" name="Slaves" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="493d-b7b8-9dad-eb78" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="70b3-02b2-3a44-029c" name="Disposable" hidden="false">
+          <description>Units with this rule that Break from combat are immediately destroyed. 
+When checking if an enemy unit is Steadfast, your Slave units count as having 0 Full Ranks, unless the Slave unit is Engaged in the enemy unit’s Flank or Rear Facing. 
+When shooting into combat where the only Engaged friendly models are Slaves, the Shooting Attack gains +2 to hit and -1 to rolls for randomising which unit is hit with Callous.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d897-d278-ee46-8986" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="8b4b-f738-c1df-3b8d" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="479d-1bff-b1ab-4255" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7c46-3bf8-337b-f090" name="Slave" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="294a-a5fc-1b0e-8869" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5777-aef7-1da0-dc79" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2f1c-5f2e-ac83-8f6f" name="Slave Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">2</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b515-2b21-854e-f0f4" name="Slave Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a37f-a58d-e080-de19" name="Slave Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="4.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="28f7-659f-a264-a214" name="Musician" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f602-a054-2dae-762b" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1ab-8952-0c83-fe01" name="Footpads" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f00c-cab8-b4f6-211c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d0e2-06b7-88f4-3f49" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="67e2-c875-d8d3-2eac" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="67c6-e7b9-f9f3-087c" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="7c7b-7ed2-a7cf-d89f" name="Sling" hidden="false" targetId="29ea-f62f-5c78-773d" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9b4c-b041-cb49-d41e" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c240-3a8c-b155-fdf1" name="Footpads" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b77a-a675-3451-6300" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a3a-0c4e-95de-f5ee" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f43b-ee30-b313-bc7b" name="Footpad Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2c08-07cb-5bbd-eaf4" name="Footpad Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8765-0f50-fbaa-1e69" name="Footpad Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="9.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c053-bd42-17f2-d85a" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d485-2630-8547-be8a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3640-dc92-2bbd-6184" name="Banner Enchantment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c74c-1233-5ae8-7215" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="36bc-0d63-6092-a72c" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="23c5-4f99-0b89-b60b" name="VS Banner Enchantments" hidden="false" collective="false" targetId="96e5-b65b-1c87-1acd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="df41-31ad-462c-3872" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="a1ab-8952-0c83-fe01" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c240-3a8c-b155-fdf1" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c66a-22f1-d594-5068" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b26e-153a-64f4-9882" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f36a-a850-5f57-49ab" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="a1ab-8952-0c83-fe01" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c240-3a8c-b155-fdf1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cda2-1fdc-2275-9087" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7240-9a32-6d33-6a85" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="ee33-6353-494a-5d0a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="49d2-07c5-c497-6551" name="Giant Rats - Special" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="c074-e226-b650-4f49" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd9a-316f-53f8-ab8f" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c074-e226-b650-4f49" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6fb0-109c-b3ab-ae38" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="c612-94a0-14f9-6650" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="949f-161e-fc47-234b" name="Handlers" hidden="false" targetId="e80d-b5e4-232d-c90e" type="rule"/>
+        <infoLink id="1626-20a4-37c6-095d" name="Fight in Extra Rank" hidden="false" targetId="f07b-fa49-1de5-8a2b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="df1c-362f-0c8c-3d8f" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1191-671f-0054-1333" name="Giant Rat" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22f4-8618-2a65-959c" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3917-583a-70b8-d6fe" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="3faf-00c7-eb3f-46e2" name="Giant Rat Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d809-39dd-9105-8cc4" name="Giant Rat Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="17e8-1b51-fe97-33da" name="Giant Rat Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="6.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd9a-316f-53f8-ab8f" name="Giant Rats - Core" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="2e10-ab73-af52-a615" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49d2-07c5-c497-6551" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e10-ab73-af52-a615" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bce6-487c-05a9-6c72" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="5e9e-7a6a-b5af-4737" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="0e3a-5987-12d2-c6ed" name="Handlers" hidden="false" targetId="e80d-b5e4-232d-c90e" type="rule"/>
+        <infoLink id="c8ce-b251-4146-ae93" name="Fight in Extra Rank" hidden="false" targetId="f07b-fa49-1de5-8a2b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ac80-37b7-cd55-9e57" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fa6d-a7a5-6b6d-7bc0" name="Giant Rat" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2262-eabb-9cc7-f4ee" type="max"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8325-428d-df7a-2d58" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="a87b-12be-9a32-54d3" name="Giant Rat Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5891-26b5-2ecc-980e" name="Giant Rat Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8186-8b04-b57e-a150" name="Giant Rat Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="6.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0379-9ea3-c9d3-8001" name="Plague Disciples" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39fc-e18f-998b-11f2" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="002e-a01a-3116-6578" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="aec5-040c-dd8f-0481" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="d200-287b-06ab-bb93" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="77f4-990e-bb37-6818" name="Brood&apos;s Courage" hidden="false" targetId="62a1-714b-7654-f77a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Plague Brotherhood)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="775a-4ba4-350f-a421" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule"/>
+        <infoLink id="ba64-ca79-e0d7-c743" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+        <infoLink id="e3f6-24f5-7458-73ed" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="9688-dd27-0da6-9f89" name="Plague Flail" hidden="false" targetId="0791-f981-6d52-b2ef" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c0ac-cd55-1742-2e74" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f375-cfc4-c5b5-c92b" name="Plague Disciple" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68d5-4c70-2278-ede9" type="max"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f4b-7f76-1843-3eb4" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="d667-e752-ad5a-9f41" name="Plague Disciple Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="aa67-f9f3-d9f6-812f" name="Plague Disciple Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b91f-69b4-a2af-2787" name="Plague Disciple Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b478-fbe4-57ca-3e15" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f6d-0b08-6b5d-fc14" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="34.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="096b-b5d8-54c5-a100" name="Vermin Hulks" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="42db-6ecc-f6ee-9cf5" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9ffc-c388-e39f-a5d2" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="35eb-3c9a-8993-b2f6" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="b221-4ffe-64b6-209a" name="Handlers" hidden="false" targetId="e80d-b5e4-232d-c90e" type="rule"/>
+        <infoLink id="8823-33b6-413c-f736" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="f41c-db7d-a9ac-a515" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="03f1-6d7c-fe38-72d8" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7f0c-fca6-ec75-6de8" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="aa5b-dacc-7107-d4f6" name="Vermin Hulk" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd92-14e3-0250-76d8" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="848a-3c1e-208b-ef97" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eb33-8a0b-e560-fed8" name="Vermin Hulk Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="edf5-a4d8-b023-3e31" name="Vermin Hulk Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d7ac-6c6a-b974-3ea2" name="Vermin Hulk Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="92dd-4dfc-fcb9-8bb1" name="Become Thunder Hulks" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+              <repeats>
+                <repeat field="selections" scope="096b-b5d8-54c5-a100" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aa5b-dacc-7107-d4f6" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89ae-f414-332d-b360" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8cf0-3eff-bdd5-cdcf" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="32ba-6ea6-cefd-cfaa" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f22-b615-0df5-59a4" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="319e-c92b-ea7f-547c" name="Weapon" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f34f-b755-f503-0212" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="460c-3688-baf1-2012" name="Naptha Launcher" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23a1-9f6c-c406-5863" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="facd-b7f8-7ba3-a6e1" name="Naphtha Launcher" hidden="false" targetId="d95d-6b0a-ea8c-6373" type="profile">
+                      <modifiers>
+                        <modifier type="append" field="name" value=" (4+)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="140.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="12b1-3693-bea2-05f4" name="Rotary Gun" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f45-3a7f-850f-ca15" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="dd0e-cc6d-486d-10dc" name="Rotary Gun" hidden="false" targetId="0e9b-e00b-8065-4135" type="profile">
+                      <modifiers>
+                        <modifier type="append" field="name" value=" (4+)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4000-6dba-3dfa-c25d" name="Globe Launcher" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee66-d478-7bf7-79b2" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3884-e3e3-b56a-2653" name="Globe Launcher" hidden="false" targetId="646e-d162-7990-7ba2" type="profile">
+                      <modifiers>
+                        <modifier type="append" field="name" value=" (4+)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1ae0-6e3b-04a1-ac42" name="Meat Grinder" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8579-3153-4492-ec2d" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="52cd-bce9-bbb0-79c8" name="Meat Grinder" hidden="false" targetId="dc1a-c483-9ce1-9929" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bb83-2b19-f017-618f" name="Rat Swarms" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e107-e09b-6f03-2e45" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="a39f-423c-fc2f-fe46" name="Tiny" hidden="false">
+          <description>The model ignores friendly units when moving in the Charge and Movement Phase, but must follow the Unit Spacing rule at the end of the move, unless charging, when the normal exceptions to the Unit Spacing rule apply.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f14f-ed9d-9441-1927" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="cfff-2546-84c3-fe62" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="7b1a-c962-efbe-2dbd" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="2bb6-13b5-0f9d-41a7" name="Unstable" hidden="false" targetId="b642-5b33-158d-421b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e1b5-8477-7854-af97" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f458-21ca-77fe-6ec7" name="Rat Swarm" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40c4-e08d-a085-bb0d" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce98-4e90-b683-c8ff" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7156-90c6-16a7-2c99" name="Rat Swarm Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3d06-2365-b587-672e" name="Rat Swarm Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="50b5-4144-3cfc-1bc4" name="Rat Swarm Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="92b0-b6b8-5ffd-c5df" name="Meat Grinder" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="991a-2c95-83e8-ef6a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f05a-1940-9f24-1607" name="Meat Grinder Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2d8b-c191-88c2-26c9" name="Meat Grinder Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="84fd-182a-c3c3-e4e6" name="Meat Grinder Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="7103-add2-827f-10f0" name="One with the Swarm" hidden="false">
+          <description>The model can only join units of Rats-at-Arms, and loses Insignificant while joined to such units.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9313-3508-9b20-692b" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="5836-7e47-839d-4d2e" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="9436-fe2d-0d0f-94c7" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="c6c0-ba6a-9b45-e8e7" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="0472-48b7-3f8d-ce8d" name="Brood&apos;s Courage" hidden="false" targetId="62a1-714b-7654-f77a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Rats-at-Arms, Vermin Guard)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a92b-f554-ebc1-b21b" name="Tag Along" hidden="false" targetId="03b7-f0a6-aa01-d434" type="rule"/>
+        <infoLink id="7414-e98f-dc29-188c" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="9e99-7606-5aa9-d76e" name="Meat Grinder" hidden="false" targetId="dc1a-c483-9ce1-9929" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e6a6-fe19-5809-6667" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b38b-5dbd-2414-04b9" name="Weapon Team" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d97-5cf5-2a47-0c84" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a13d-8bc0-4a30-8963" name="Weapon Team Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d53f-b711-f27e-e285" name="Weapon Team Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fb0b-6d5c-17ea-dc8e" name="Weapon Team Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="906e-8bca-63a7-19ff" name="Scorched Fur" hidden="false">
+          <description>When the model rolls Breakdown on the Misfire Table it is removed as a casualty.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="fcfb-99b6-0fac-ce5e" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="669c-f26b-cbb2-5daf" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="1304-1507-819c-2ac0" name="Insignificant" hidden="false" targetId="10f4-4cf9-f713-7351" type="rule"/>
+        <infoLink id="3805-dc63-bdce-6990" name="Brood&apos;s Courage" hidden="false" targetId="62a1-714b-7654-f77a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Rats-at-Arms, Vermin Guard)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b365-7f68-2c10-5bd2" name="Tag Along" hidden="false" targetId="03b7-f0a6-aa01-d434" type="rule"/>
+        <infoLink id="e8bf-79ca-dff8-3fff" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="77fb-106c-0971-8f36" name="New CategoryLink" hidden="false" targetId="1c57-fa6c-295c-c49c" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c4d9-b62d-0fbf-a82a" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6dc-5564-08cd-ec84" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9424-c180-d82a-a6af" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c90c-0205-9f18-caec" name="Naphtha Launcher" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f95-4349-12d5-3677" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="15d3-f0f8-77a4-d515" name="Naphtha Launcher" hidden="false" targetId="d95d-6b0a-ea8c-6373" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cebc-9f20-9530-19ff" name="Rotary Gun" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ffa-aa9d-3fbb-5f08" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a6af-9480-4426-ec9b" name="Rotary Gun" hidden="false" targetId="0e9b-e00b-8065-4135" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="81f6-622f-9b7c-52b2" name="Globe Launcher" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac2b-0497-48d9-15cb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ea73-1f12-332d-a2d1" name="Globe Launcher" hidden="false" targetId="646e-d162-7990-7ba2" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8d92-9cac-e1d2-05d7" name="Jezails" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8dc3-4179-57fe-9667" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f8a4-7745-7e15-5d8c" name="Pavise" hidden="false" typeId="658e-7f7b-4e4f-162a" typeName="4 Armour">
+          <characteristics>
+            <characteristic name="Type" typeId="017b-143b-0520-bdc1">Armour</characteristic>
+            <characteristic name="Save" typeId="4ca3-2498-f356-f056">+3</characteristic>
+            <characteristic name="Rules" typeId="f269-16dd-a614-0f90">Only works against Ranged Attacks.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d144-f0b7-e7de-3767" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="30f2-a70b-4931-076a" name="Jezzail" hidden="false" targetId="6c76-ea2d-66f3-1a62" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f2c6-5190-eaf8-c0e0" name="New CategoryLink" hidden="false" targetId="1c57-fa6c-295c-c49c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ecc7-193d-2c5a-f599" name="Jezail" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea0c-6d32-6909-ae2d" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7489-f6ef-815b-e01e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4dda-2c1e-63ae-003e" name="Jezail Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e916-8f38-880e-8a4d" name="Jezail Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9fb1-8a82-e848-01ff" name="Jezail Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ff7-da8b-123a-7606" name="Grenadiers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b65e-b680-96ec-79e5" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d09f-3c7e-ffb0-92c9" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="5734-12ec-5e16-6433" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="6d4a-c37c-8acc-a148" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="0b57-eb21-d8e1-afc0" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="ecd5-524f-618d-3b99" name="Gas Globes" hidden="false" targetId="5741-4795-0156-40ef" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="09fa-88cb-1dfa-d19b" name="Volley Fire" hidden="false" targetId="1582-2a6f-e73c-889c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4e5f-49d1-7232-5dbf" name="New CategoryLink" hidden="false" targetId="1c57-fa6c-295c-c49c" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8d6d-8c7c-f431-2192" name="Grenadier" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9cfb-f012-3b22-ac27" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f497-6b30-de29-66e8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="53a8-4e5e-8476-bc8f" name="Grenadier Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="74f0-93ad-5d16-bcd4" name="Grenadier Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="114e-0591-0c11-24eb" name="Grenadier Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a51-3aff-3a1a-9b3d" name="Gutter Blades" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3298-02de-d477-b95f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9675-2f5d-4ba3-14db" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="5793-0553-d4dd-70f0" name="Callous" hidden="false" targetId="5035-bf89-bca4-3ba0" type="rule"/>
+        <infoLink id="333e-374e-6f73-96da" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="a6f8-e35c-ef34-7d11" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+        <infoLink id="f354-17a6-6bcf-87f3" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="438e-2598-b910-a814" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1c6f-e4fa-06c4-7317" name="Gutter Blade" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="882e-b0fa-e0c6-a489" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f268-057a-9b4c-c5a0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="05c8-cbf9-55c9-62d8" name="Gutter Blade Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e7ed-6372-fbf9-9c23" name="Gutter Blade Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="32c4-d775-0eb7-98e9" name="Gutter Blade Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="8671-abdb-484e-1b6c" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f6ec-673d-7a42-4503" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8786-c47a-8ddc-9f35" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="ecfb-a1b5-0d53-5361" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="debf-8300-5e98-c62a" name="Scout and Ambush" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+              <repeats>
+                <repeat field="selections" scope="0a51-3aff-3a1a-9b3d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c6f-e4fa-06c4-7317" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6f1-01ea-0d98-537f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a519-35ac-245d-0aba" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+            <infoLink id="482b-1eeb-4904-9ed3" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="7fe8-5b26-7b22-e82d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="32df-c6fb-a78a-f7d4" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="ddb6-fa69-3071-4c14">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="90a4-45cb-bbcb-41c8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e44-daa1-55ef-2c1c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d7f7-6807-09ca-2aba" name="Sling" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f35a-7334-4619-8270" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="44d2-9ad3-f4e9-865b" name="Sling" hidden="false" targetId="29ea-f62f-5c78-773d" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (3+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ddb6-fa69-3071-4c14" name="Throwing Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f6e-48ae-dacc-01af" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a660-1e08-e042-220a" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5f35-2893-76e9-ac10" name="Verminous Artillery" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f968-5b6d-743b-36ab" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9bc1-2a8a-4751-fb68" name="Verminous Artillery Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">5&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e721-369f-48e4-e910" name="Verminous Artillery Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="721e-ca56-0ed4-f057" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="4eb8-7d7a-773a-256a" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9b93-2646-679b-04f2" name="New CategoryLink" hidden="false" targetId="1c57-fa6c-295c-c49c" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="262b-0343-c845-6cea" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da31-08db-52f3-7205" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb6c-23c2-ed82-ef32" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c892-3493-9bf6-b748" name="Plague Catapult" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1efd-063e-b10c-8f15" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="84eb-356d-2561-24b1" name="Plague Catapult" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12-48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">-</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">-</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (4x4), Toxic Attacks, Magical Attacks</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="01c6-b8e0-f583-7792" name="Catapult Crew" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="d841-26a5-810b-e539" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+                <infoLink id="2cdb-645b-c0b3-3037" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+                <infoLink id="4892-8b8d-c815-4144" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="170.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6b7c-5ea6-5f44-7de4" name="Lightning Cannon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="19ff-a155-2e51-6e87" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f9b5-0274-72c5-42cb" name="Lightning Cannon" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (4+)"/>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">7</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Cannon, Accurate, Magical Attacks, Lightning Attacks, Multiple Wounds (D3+1, Clipped Wings). Before rolling to hit, the Lightning Cannon may be supercharged. If supercharged, the weapon’s Strength is set to 10 and its Range is set to 18&quot; for the duration of the phase. After the shot has been resolved, roll a D6. On a roll of &apos;1&apos; or ‘2’, the Lightning Cannon cannot be supercharged again this game.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="b8cf-7a30-1bda-7896" name="Cannon Crew" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="3833-bba1-920c-d289" name="Accurate" hidden="false" targetId="68aa-b60b-ae0b-158b" type="rule"/>
+                <infoLink id="89d6-a7ed-a80e-e83e" name="Lightning Attack" hidden="false" targetId="501e-5bc4-8b73-463a" type="rule"/>
+                <infoLink id="68c7-43b4-fdb3-bb6b" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="265.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="782d-f3d3-d092-b05e" name="Dreadmill" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e1f7-1f09-f3a1-8606" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7cb0-b8bd-98ac-a4af" name="Dreadmill Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8eb2-7b3f-1ded-f9bc" name="Dreadmill Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="685f-ec7a-b2ca-0d2d" name="Dreadmill Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f89e-b6df-9a1a-46ea" name="Electric Discharge" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">15&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">6</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Multiple Wounds (D3), Lightning Attacks, Magical Attacks.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5326-0538-0bb0-4065" name="Electric Discharge" hidden="false">
+          <description>Model parts with this Special Attack can use it as a Shooting Attack and as a Special Attack in Close Combat.
+- As a Shooting Attack: Choose a target using the normal rules for Shooting Attacks. The Shooting Attack has Range 18”, Shots 3, Reload!, Accurate, Quick to Fire, and Aim (4+). Before Shooting, the model may Supercharge the Electric Discharge. If so, the Shooting Attack gains +3&quot; Range this phase.
+- As a Special Attack in Close Combat: The attack is made at the model part&apos;s Initiative Step. Choose a single unit in base contact as the target of 3 Melee Attacks. These Melee Attacks always hit on 3+. Hits from Electric Discharge are resolved with Strength 5, Armour Penetration 10, Multiple Wounds (D3), Lightning Attacks, and Magical Attacks.
+Before rolling to hit, the Dreadmill may be supercharged. If supercharged, the attacks from Electric Discharge are set to Strength 6 and their Range is set to 12” for the duration of the phase. After the Electric Discharge has been resolved, roll a D6. On a roll of ‘1’ or ‘2’, the Dreadmill cannot be supercharged again this game</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="17af-9edf-75b2-4f52" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="01b7-dda9-674c-71ca" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="01a0-f1a1-acfe-e1e8" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="c808-b30e-64bb-5919" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7f7a-a8fb-1ce4-7731" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="e41d-8b1d-6159-ad33" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bc2a-d278-fb27-5568" name="New CategoryLink" hidden="false" targetId="1c57-fa6c-295c-c49c" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="305.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a95c-04e9-fe02-665c" name="Abomination" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="986f-a229-a668-bfdd" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="fe80-e024-7360-49bd" name="Abomination Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3D6</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="16a7-3e90-bee1-d6ea" name="Abomination Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="31c2-2598-4b19-9856" name="Abomination Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3D6</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="3270-7de7-db04-d299" name="Safety in Numbers" hidden="false" targetId="f4e0-dc81-e628-dc4a" type="rule"/>
+        <infoLink id="c22d-301f-de48-da86" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="b7b5-989b-46d1-c3e0" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="ea52-ec3f-7215-c195" name="Random Movement" hidden="false" targetId="6e49-e056-5845-4b66" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7f0e-5105-c5d6-176d" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e9ef-699c-17a2-3508" name="New CategoryLink" hidden="false" targetId="a4b6-d53f-821c-9216" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="375.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="335b-c901-c159-fbed" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7823-76b2-c8e8-aa53" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3864-f62f-baa5-988b" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a365-f34a-efce-fc9e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="59cb-7a14-baa3-3813" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="007c-ee51-6e60-97bc" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f481-14ef-5ab6-733e" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f24-c590-46c1-64f4" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1085-0f40-b482-33bf" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7cfd-df04-3e1b-e2be" name="Vermin Guard Litter" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9fdb-dcd1-e3a7-67ec" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa77-1599-438f-98ba" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="7b7b-0be3-b014-9c5d" name="Vermin Guard Litter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="becc-c5df-190f-7c8e" name="Vermin Guard Litter Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7cee-e355-0ee4-f14c" name="Vermin Guard Litter Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="a8fd-a579-5244-934a" name="Herding the Swarm" hidden="false">
+          <description>The model increases the range of its Commanding Presence (if available) by 6&quot;.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b942-c547-78f3-1f87" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3d1e-7361-8963-e157" name="Vermin Hulk Bodyguard" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="954e-c63d-cbcd-4a4c" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e1-2250-3f89-8a68" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="4e9b-5c21-5326-dcbb" name="Vermin Hulk Bodyguard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="11d8-5237-e875-a7d7" name="Vermin Hulk Bodyguard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f98b-2550-8d71-9c43" name="Vermin Hulk Bodyguard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="27a2-c0f1-0803-691f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="6463-10b2-8532-dbe7" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6998-b2ad-5bd8-255b" name="Monstrous Rat" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6c5-cdf6-caef-633b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d939-af4a-95c9-3090" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="bb4f-ca56-e36e-cb7f" name="Monstrous Rat Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5a9b-f575-acf0-e7e6" name="Monstrous Rat Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fccf-bf04-bbd2-0a6d" name="Monstrous Rat Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="eef6-f32f-51e7-0c37" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="a7ab-5bdf-d622-3ac9" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="3781-181c-58cf-5c64" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
+        <infoLink id="fbd0-3703-1aee-7521" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c144-b868-6d18-2a1c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="f344-1e91-8879-c860" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Toxic Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6cf6-15eb-e6b0-fde1" name="Doom Bell" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29fc-3e58-d0d5-1142" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9abd-4d35-3530-f202" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="07f0-59ab-2dad-3a48" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="8689-f7f0-74bb-3be0" name="Doom Bell Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e4e5-f6c8-9748-02d4" name="Doom Bell Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fc4a-710a-82b1-b819" name="Vermin Hulk Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b5b4-7358-8979-a2e7" name="Above the Masses" hidden="false">
+          <description>When a Magister riding the Doom Bell chooses targets for spells with Type Direct, it ignores the restriction of only choosing targets in its Front Arc. When a Magister riding the Doom Bell chooses targets for spells with Type Missile, it can draw Line of Sight in 360 degrees and from any point of the Doom Bell’s base, and may cast Missile spells even when Engaged in Combat. All non-Bound Spells cast by the Magister gain +3” Range.</description>
+        </rule>
+        <rule id="a650-4976-fd48-290f" name="Sounding the Bell" hidden="false">
+          <description>All enemy units within 18” of one or more models with this Universal Rule suffer -1 Offensive Skill and -1 Defensive Skill. At the start of your Magic Phase, you may choose to roll a D6. On a 2+, all enemy units within 18” suffer an additional -1 Offensive Skill and -1 Defensive Skill, until the start of your next Magic Phase. If a &apos;1&apos; is rolled, the Doom Bell temporarily loses this Universal Rule until the end of your next Movement Phase, and all units (friend and foe) in base contact with the Doom Bell suffer D6 hits with Strength 4 and Armour Penetration 2.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7cb9-d5f5-841f-4fd4" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="0fd8-0811-a0c2-21aa" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="2029-9938-285e-23e2" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="0e92-dd88-682a-4755" name="State of Trance" hidden="false" targetId="36d3-27e4-be15-18fe" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Rats-at-Arms, Vermin Guard)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1a3b-8e53-c12c-a3cb" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="48d3-f163-a669-8531" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="87de-9e45-a9f8-a10c" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="380d-172a-c3c9-f368" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d182-dccc-9a50-44b6" name="Plague Pendulum" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0e1-a7f0-10e0-765c" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea4f-2fa1-6c8e-3363" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8dd-983b-fca5-eb18" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9478-43e7-2d06-1758" name="Plague Pendulum Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d3c2-8709-54c5-3dae" name="Plague Pendulum Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">c</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b729-0d30-39b0-3f50" name="Crew (4) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cefb-5a8a-0c4e-eb99" name="Chassis Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2437-dc7d-97c7-61ba" name="Ram Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="682f-3657-c88b-3c88" name="Pendulum" hidden="false">
+          <description>The model part can only use its Grind Attacks against enemy units Engaged in the model’s Front Facing.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="07a0-7054-1d93-60e0" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="1d05-43e5-7189-2265" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule"/>
+        <infoLink id="fcdd-0244-d90f-314b" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="de5f-46cd-33f5-08e3" name="State of Trance" hidden="false" targetId="36d3-27e4-be15-18fe" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Plague Brotherhood)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="dc10-22ce-376b-569b" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="315d-10e5-61e7-051e" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="44d5-a032-0427-fb30" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="635b-ad1b-68ae-bcf4" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="dd11-4060-8380-c985" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+        <infoLink id="c844-5918-2c36-36bc" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+        <infoLink id="61f3-a6e4-0f56-6cef" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="b26f-e6f2-fc2e-d211" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="38f3-a913-f985-c1a7" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="00aa-25e4-28ff-89fd" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="d50e-23be-2e5d-6f0a" name="VS Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4ff-42a4-885d-255a" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="f688-5f8c-a14d-328a" name="Secrets of the Doom Blade" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e109-b763-7c5a-8ca8" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bb8-8402-9083-404c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="218c-8d13-ec24-4257" name="Secrets of the Doom Blade - Standard size Tyrant only" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon have their Strength set to 10 and Armour Penetration set to 10, gain Multiple Wounds (D6), Magical Attacks, and Divine Attacks. At the end of each friendly Player Turn, the wielder suffers 1 hit with Toxic Attacks (which counts as a Melee Attack). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b50a-a17b-0d3b-538b" name="Swarm Master" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e02d-0cdc-e37e-15c2" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9657-5e19-91ad-eaf2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6830-2947-1cb9-64f5" name="Swarm Master" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Paired Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder always has Attack Value 3D6 when using this weapon. Attacks made with this weapon always have Strength 3 and always have Armour Penetration 1 and gain Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b7e0-3e26-8765-146f" name="Darkstone Shot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1cae-44af-72c8-9207" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4e5-3846-9cb0-5bdf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="50cb-9611-568d-d2bd" name="Darkstone Shot" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Jezzail or Ratlock Pistols Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The weapon gains +1 Shots. Attacks made with this weapon that roll a natural &apos;6&apos; to wound gain Multiple Wounds (D3).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="60c3-91ea-5312-75f9" name="VS Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="7ca8-ea3e-255b-92a1" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ca8-ea3e-255b-92a1" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="3993-4ee8-f90f-6512" name="Putrid Protection" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9fe-0c03-96da-38ae" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="215e-5c85-53ef-99ff" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9b77-bc4c-6627-5126" name="Putrid Protection" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Light Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +2 Armour. For each successful Armour Save made by the wearer against Melee Attacks, the Health Pool which the model that caused the wounding hit is part of suffers 1 hit with Toxic Attacks. This is considered a Special Attack.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b029-5d4a-7a4e-a06d" name="Seal of House Underminer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d244-e1b4-1c94-b776" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9985-2dd5-77ca-2d77" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3f23-238f-46c8-d9a7" name="Seal of House Underminer" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Heavy Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The owning player’s Army gains a +1 modifier for the roll for determining who picks the Deployment Zone. Directly after Deployment Zones are picked, choose a Terrain Feature with its center on your half of the Battlefield. Unless the chosen Terrain Feature is Impassable Terrain, it becomes Dangerous Terrain (2). </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7dd3-4628-11c4-bb74" name="Net of Deception" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d5a-10da-1d9e-e0c8" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32ef-bc1c-db2e-eb4d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b66c-bae9-2f9f-47e9" name="Net of Deception" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, the wielder gains Distracting and at the end of step 2 of the Round of Combat Sequence (right after Choose Weapons), nominate one enemy model part in base contact with the user of the Shield. For the duration of this Round of Combat, the nominated model part suffers -1 Attack Value.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="5409-3278-5eda-b90e" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b06c-6498-74d7-74b3" name="VS Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d62-d29f-e1cf-3d42" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6279-76f9-fc90-1b6d" name="Multifocal Eyepiece - Rakachit Machinist only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="42ec-fcae-46d4-6693" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="14f1-2798-2bd5-fd56" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="817c-01bc-0d53-23db" name="Multifocal Eyepiece" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">At the start of each friendly Shooting Phase, you may choose a Weapon Team within 3&quot; of the bearer. For the duration of the phase, Shooting Attacks made by this Weapon Team gain +1 to hit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="098b-b36d-dc3c-3036" name="Second Awakening" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5998-917e-27ae-efcd" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="17ca-3de6-cc98-2f21" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2170-f527-c19b-1ba5" name="Second Awakening" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When the bearer casts a spell of Type Damage for which dice are used to determine the number of hits this spell inflicts, you may choose to reroll these dice. If so, all dice must be rerolled. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2ce0-fba5-71ac-6ace" name="Crown of Succession" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e0f1-a6c8-0bcd-d2ab" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e0b-c9bc-27b4-e062" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7335-4654-6b1f-319d" name="Crown of Succession - Cannot be taken by models with Not a Leader" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Cannot be taken by models with Not a Leader. When the Army’s General is removed as a casualty, the bearer gains Commanding Presence.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d553-f792-20cd-4652" name="Scurrying Veil - Standard Size only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c700-fd0d-b39f-a690" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7a1-6fdf-b5e3-dded" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7a3f-213d-e7e3-549a" name="Scurrying Veil" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Tiny (see Rat Swarms), and its March Rate is set to 20”.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b3ee-bba2-f8e9-0097" name="Sceptre of Vermin Valour - Infantry only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5456-8933-9ce3-859e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0cdf-ef9b-03ee-12e4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2afb-5605-9c45-e315" name="Sceptre of Vermin Valour" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Stand Behind. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7bb0-ca6d-05d9-47a0" name="Focusing Stone - Wizards Only - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f92-9897-a9e5-1c94" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c908-b7ac-5332-ea79" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cf3d-23be-26b4-4574" name="Focusing Stone" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">During a friendly Magic Phase or Shooting Phase, when a friendly model in a unit within 24” of the bearer inflicts a hit, before rolling to wound, the owning player may discard a single Veil Token from its Veil Token pool. If so, the hit gains +1 to wound. If there is more than one hit, declare which hit gains the modifier before rolling any dice.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="96e5-b65b-1c87-1acd" name="VS Banner Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f85-2a46-f0d1-c6f3" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="401f-c16d-8f38-1a3f" name="Lightning Rod" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2513-1872-6d0d-11ba" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2180-bdfd-1e22-87d7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8d80-ce18-7d69-b399" name="Lightning Rod" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Battle Standard Bearer and Vermin Guard only.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of the opponent’s Player Turn. During this Player Turn all friendly units gain Hard Target. No Flying Movement may take place.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0270-f056-6896-a13f" name="Banner of the Endless Swarm" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7181-7823-a2ec-e09c" type="max"/>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a8d0-7313-745b-284b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6832-b2a0-6bb0-8cf9" name="Banner of the Endless Swarm" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If a unit with one or more Banners of the Endless Swarm has more Full Ranks than each of the enemy units Engaged in the same Combat, it gains Fight in Extra Rank. If the unit has more than twice the number of Full Ranks than each of the enemy units Engaged in the same Combat, it gains an additional instance of Fight in Extra Rank. Check how many Full Ranks the units have and apply the effects at each Initiative Step.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e6c0-482d-85e4-f929" name="Aquila of Ruin" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b64d-e49c-3db3-46ca" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="471e-332e-ad5c-41ea" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="471a-2759-9953-2dc0" name="Aquila of Ruin" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247"> Rats-at-Arms only. If the bearer’s unit is composed entirely of Infantry models, it increases the maximum of its Rank Bonus by +2, which cannot be increased by any other means (this means the unit can add up to 5 Full Ranks to its Combat Score).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="f4e0-dc81-e628-dc4a" name="Safety in Numbers" hidden="false">
+      <description>Non-fleeing units comprised entirely of models with Safety in Numbers add their number of Full Ranks after the first one to their Discipline, up to a maximum of +3 and never above 10. Safety in Numbers cannot be used to modify the Discipline that is distributed by models with Commanding Presence (but the received Commanding Presence can be modified by Safety in Numbers). Furthermore, units comprised entirely of models with Safety in Numbers gain +1” to their Flee Distance rolls.</description>
+    </rule>
+    <rule id="5035-bf89-bca4-3ba0" name="Callous" hidden="false">
+      <description>The model is allowed to use Shooting Attacks and The Awakened Swarm (Hereditary Spell) against enemy units that are Engaged in Combat with friendly units, as long as all friendly units Engaged in the Combat are of Standard Size.​ All units Engaged in this Combat are ignored for Cover purposes. When a model with this rule targets an enemy unit Engaged in Combat with a Shooting Attack or with The Awakened Swarm, roll to hit as normal against the intended target. Each hit must then be randomised to see which unit it hits. Roll a D6 for each hit. On 3+ it hits the intended target. Otherwise it hits a friendly unit that is Engaged in that Combat. If there are several friendly units involved in the Combat, randomise which one is hit. </description>
+    </rule>
+    <rule id="36d3-27e4-be15-18fe" name="State of Trance" hidden="false">
+      <description>The model’s unit gains Fearless. The model must be deployed in, and can only join, units that include at least one model from one of the unit entries stated in brackets (X). The model can never voluntarily leave its unit.</description>
+    </rule>
+    <rule id="62a1-714b-7654-f77a" name="Brood&apos;s Courage" hidden="false">
+      <description>When the model is within 6” of a unit that includes at least one model from one of the unit entries stated in brackets (X), it may use the Full Ranks of this unit for the purpose of calculating the Discipline modifier it gains from Safety in Numbers.</description>
+    </rule>
+    <rule id="03b7-f0a6-aa01-d434" name="Tag Along" hidden="false">
+      <description>If the model is within 3&quot; of a non-fleeing unit with at least one Rat-at-Arms or Vermin Guard model, it gains Aegis (4+) against Ranged Attacks.</description>
+    </rule>
+    <rule id="3016-0b06-30a7-7484" name="Honourless" hidden="false">
+      <description>A Character with Honourless cannot be chosen by the enemy as the model that refuses a Duel. </description>
+    </rule>
+    <rule id="ac84-f13f-40fc-c2d6" name="Dark Shards" hidden="false">
+      <description>One use only. A model can use each of its Dark Shards once per game. Declare usage just before the model is rolling a casting roll for a non-Bound Spell. Any Dispel Attempt made against this spell suffers -D3 to its dispel roll (roll this dice directly when using the Dark Shard). If a natural ‘1’ is rolled for this D3, the model using the Dark Shards suffers 1 hit with Toxic Attacks. This is an exception to the Casting and Dispelling Modifier rule (i.e. it is allowed to modify the dispel roll by more than -2). </description>
+    </rule>
+    <rule id="e80d-b5e4-232d-c90e" name="Handlers" hidden="false">
+      <description>The unit may perform Swift Reforms as if it had a Musician.</description>
+    </rule>
+    <rule id="501e-5bc4-8b73-463a" name="Lightning Attack" hidden="false">
+      <description>At the end of a phase in which a unit that consist entirely of models with Fly has suffered one or more hits from attacks with Lightning Attack, the unit suffers an additional D6 hits with Strength 4 and Armour Penetration 1.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="0791-f981-6d52-b2ef" name="Plague Flail" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Unless using another weapon, the wielder of a Plague Flail suffers -1 Defensive Skill.  In addition, the wielder gains Grind Attacks (1). This Grind Attack can be made as a Supporting Attack, is resolved at Initiative Step 10 (regardless of the wielder’s Agility), and has Toxic Attacks. A model using this weapon cannot simultaneously use a Shield against Melee Attacks. This weapon cannot be enchanted with Weapon Enchantments from the Common Special Equipment.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="dc1a-c483-9ce1-9929" name="Meat Grinder" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">4</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">2</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">When using this weapon, the wielder gains Impact Hits (2D6) and Grind Attacks (2D6). </characteristic>
+      </characteristics>
+    </profile>
+    <profile id="29ea-f62f-5c78-773d" name="Sling" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5741-4795-0156-40ef" name="Gas Globes" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">8&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">-</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Accurate, Magical Attacks. Hits from this weapon ignore the target&apos;s Resilience and are instead set to wound on 4+. </characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4d6d-8823-9da6-486f" name="Ratlock Pistol" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">3</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, Magical Attacks, Counts as Paired Weapons</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6c76-ea2d-66f3-1a62" name="Jezail" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">36&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">6</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">4</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Unwieldy, Accurate, Magical Attacks, If rolling a natural ‘1’ to hit, the bearer suffers 1 hit with Toxic Attacks.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0e9b-e00b-8065-4135" name="Rotary Gun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">(2D6)*2 / (3D6*2)</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">4</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Magical Attacks, Quick to Fire.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="646e-d162-7990-7ba2" name="Globe Launcher" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">(2D6)*2</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Toxic Attacks, Magical Attacks, Volley FIre, Quick to Fire. If a Standard Size model equipped with a Globe Launcher is within 3&quot; of a unit with at least one Rat-at-Arms or Vermin Guard model when shooting, it may draw Line of Sight to the target as if this unit was shooting instead of itself (i.e. the unit cannot be Fleeing, Shaken, or Engaged). The target must still be within range and in the Front Arc of the model shooting with the Globe Launcher.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d95d-6b0a-ea8c-6373" name="Naphtha Launcher" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">18&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">2D6</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">1</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Multiple Wounds (D3), Flaming Attacks, Magical Attacks, Quick to Fire. This weapon ignores to-hit modifiers from Cover and Hard Target.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a30f-462e-8f23-2766" name="Tail Weapon" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+      <characteristics>
+        <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">As User</characteristic>
+        <characteristic name="AP" typeId="646b-1e72-1589-5083">As User</characteristic>
+        <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">When attacking with a Paired Weapons, the model part gains +1 Attack Value. </characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/theVerminSwarm.cat
+++ b/theVerminSwarm.cat
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cb95-d0ac-2627-c23e" name="The Vermin Swarm 2.0" revision="18" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cb95-d0ac-2627-c23e" name="The Vermin Swarm 2.0" revision="19" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="1c57-fa6c-295c-c49c" name="Tunnel Gunners (local)" hidden="false"/>
-    <categoryEntry id="a4b6-d53f-821c-9216" name="Built and Bred (local)" hidden="false"/>
+    <categoryEntry id="1c57-fa6c-295c-c49c" name="Tunnel Gunners" hidden="false"/>
+    <categoryEntry id="a4b6-d53f-821c-9216" name="Built and Bred" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="035e-617b-127a-22fd" name="The Vermin Swarm (local)" hidden="false">
+    <forceEntry id="035e-617b-127a-22fd" name="The Vermin Swarm" hidden="false">
       <categoryLinks>
         <categoryLink id="041d-188e-83f8-5c2f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>

--- a/undyingDynasties.cat
+++ b/undyingDynasties.cat
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4079-b3c9-934f-ce79" name="Undying Dynasties 2.0" revision="13" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4079-b3c9-934f-ce79" name="Undying Dynasties 2.0" revision="14" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="d18e-d0ac-d05f-3410" name="Entombed (local)" hidden="false"/>
-    <categoryEntry id="d425-7690-6b20-5848" name="Mason&apos;s Menagerie (local)" hidden="false"/>
-    <categoryEntry id="edea-d85f-5b4e-838d" name="Ancient Ordnance (local)" hidden="false"/>
+    <categoryEntry id="d18e-d0ac-d05f-3410" name="Entombed" hidden="false"/>
+    <categoryEntry id="d425-7690-6b20-5848" name="Mason&apos;s Menagerie" hidden="false"/>
+    <categoryEntry id="edea-d85f-5b4e-838d" name="Ancient Ordnance" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="57c6-1cc2-ed0d-0805" name="Undying Dynasties (local)" hidden="false">
+    <forceEntry id="57c6-1cc2-ed0d-0805" name="Undying Dynasties" hidden="false">
       <categoryLinks>
         <categoryLink id="a3c4-529d-c30d-9f49" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -1179,9 +1179,6 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b61-f88f-04a4-1a33" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="8da7-3bf9-19d7-640e" name="New CategoryLink" hidden="false" targetId="3876-145c-7cb2-a253" primary="false"/>
-              </categoryLinks>
               <entryLinks>
                 <entryLink id="9961-ac53-e240-74e7" name="Amuut" hidden="false" collective="false" targetId="0438-ff7f-841f-535b" type="selectionEntry"/>
               </entryLinks>
@@ -1387,9 +1384,6 @@
               <infoLinks>
                 <infoLink id="27bb-a73c-c93f-3a23" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="0434-aa3e-c417-1aed" name="New CategoryLink" hidden="false" targetId="4abe-83f5-0118-16db" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
@@ -1401,9 +1395,6 @@
               <infoLinks>
                 <infoLink id="93c1-cb18-7a3e-4210" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
               </infoLinks>
-              <categoryLinks>
-                <categoryLink id="4b36-73ae-6b1e-41b6" name="New CategoryLink" hidden="false" targetId="4abe-83f5-0118-16db" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
@@ -1501,7 +1492,6 @@
               </constraints>
               <categoryLinks>
                 <categoryLink id="f1df-97da-962c-7858" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-                <categoryLink id="8f57-f2b2-3f75-029f" name="New CategoryLink" hidden="false" targetId="3876-145c-7cb2-a253" primary="false"/>
               </categoryLinks>
               <entryLinks>
                 <entryLink id="0860-5010-c67e-df44" name="Amuut" hidden="false" collective="false" targetId="0438-ff7f-841f-535b" type="selectionEntry"/>

--- a/undyingDynasties.cat
+++ b/undyingDynasties.cat
@@ -1,0 +1,5885 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="4079-b3c9-934f-ce79" name="Undying Dynasties 2.0" revision="13" battleScribeVersion="2.02" authorName="Karanadon, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="d18e-d0ac-d05f-3410" name="Entombed (local)" hidden="false"/>
+    <categoryEntry id="d425-7690-6b20-5848" name="Mason&apos;s Menagerie (local)" hidden="false"/>
+    <categoryEntry id="edea-d85f-5b4e-838d" name="Ancient Ordnance (local)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="57c6-1cc2-ed0d-0805" name="Undying Dynasties (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="a3c4-529d-c30d-9f49" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="0c46-d789-4286-bdde" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="c85a-e7aa-7103-36b5" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="8d78-8c58-a986-153d" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="addc-126c-4e17-2008" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="e6a1-83d8-dcbf-31bc" name="Ancient Ordnance (local)" hidden="false" targetId="edea-d85f-5b4e-838d" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="de5d-73bf-f408-5ec0" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0108-7b1d-232c-8f11" name="Mason&apos;s Menagerie (local)" hidden="false" targetId="d425-7690-6b20-5848" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="af3e-aedf-2867-bc51" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="900e-c38f-5821-aba8" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="134e-3871-b2b9-3cfc" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="a4cb-cb6a-43f6-f087" name="Pharaoh" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="6872-0fbc-342b-d016" name="Pharaoh Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4751-8a59-68fe-cd45" name="Pharaoh Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ffde-3ecd-2936-3686" name="Pharaoh Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4a3e-c5a5-b3af-bcac" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="5651-c005-f368-c1a7" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="5e05-5220-f304-245c" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="30cc-321b-5025-87bf" name="Undying Will" hidden="false" targetId="3a23-85ab-6fb7-3816" type="rule"/>
+        <infoLink id="70f0-243e-dcca-6f5c" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6f5c-e0bb-f451-73b5" name="Mummy&apos;s Curse" hidden="false" targetId="1aa0-b4b7-d77c-be14" type="rule"/>
+        <infoLink id="ed59-297f-bb71-f036" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6e5b-28b9-ee6b-8734" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c0e1-c855-5a57-c9c7" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bf02-17eb-79e2-255a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="015a-b068-33ce-5fd2" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8a4c-8d3d-97cc-6fb1" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b40b-8451-73eb-fae9" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3e84-21b1-6b71-9943" name="Armour Enchantments" hidden="false" collective="false" targetId="6acc-67ca-6961-c964" type="selectionEntryGroup"/>
+                <entryLink id="78c1-55df-97d8-3019" name="Artefacts" hidden="false" collective="false" targetId="3677-bc9b-b029-4055" type="selectionEntryGroup"/>
+                <entryLink id="cb95-c24f-e177-250b" name="Weapon Enchantments" hidden="false" collective="false" targetId="774e-115b-7473-7c20" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e1fc-5f61-1753-9fcc" name="Great Aspen Bow (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="258c-7c63-e00b-492d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0ee4-0b9e-7756-4ad1" name="Great Aspen Bow" hidden="false" targetId="6509-0400-a54d-c254" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="344e-9a1f-6584-73ed" name="Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e788-a264-f0f6-b791" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b209-f846-7cb8-52dd" name="Commander of the Terracotta Army" hidden="false" collective="false" targetId="f564-93b2-b0d9-a4b7" type="selectionEntry"/>
+            <entryLink id="800d-cf29-abcd-71e3" name="Lord of the Barrow Legion" hidden="false" collective="false" targetId="3a8c-d985-1004-5a32" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="227d-3b08-10a3-1a02" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="7cbd-445a-b7f9-b93a" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="85ad-026b-bc8e-61f7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5802-db17-2cec-ed9b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="287b-8953-3805-5e6e" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7bf9-21f3-14ac-9b2e" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b51e-5a7d-5ffd-4186" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0d3b-ba8c-f1dd-59e3" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7949-13b7-ded1-6da1" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d071-843c-a70d-4d68" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5fd8-adcc-5060-ccc6" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="64ce-4385-315c-e959" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb00-5298-570a-d9bf" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7212-209f-b21f-842a" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9844-9245-89c1-08d3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="28f1-6a57-a2f7-4156" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e0f0-744b-cb05-8277" name="Paired Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d641-b7de-8865-0a1b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b455-792a-5cb8-aa6e" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cee7-d31b-aedd-2071" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92c0-a9a1-09b4-f137" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a02e-1d89-dcd7-1829" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f450-27b1-462e-27d6" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3d8-da50-5a10-4d41" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="31b9-c2c4-cc0d-3f25" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5ed4-dc71-7332-55d7" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4fd-9a43-2b9c-587a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="263d-caa9-531c-d532" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e43-b35a-dec6-dff4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="41ec-4113-b069-2a78" name="Skeletal Horse" hidden="false" collective="false" targetId="4074-39fa-0fcc-6c98" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="83ca-a02a-5d52-c7da" name="Skeleton Chariot" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8fc5-fd3c-ff20-17eb" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5578-9ed4-68b3-e10e" name="Skeleton Chariot" hidden="false" collective="false" targetId="ae95-ec69-39c5-59d4" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cca5-dffc-eb26-4c62" name="Sha Guardian" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13e8-d8e5-add3-7887" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="0445-dbc5-86f8-8e7a" name="Mason&apos;s Menagerie (local)" hidden="false" targetId="d425-7690-6b20-5848" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="094e-a67d-bcf9-7bf4" name="Sha Guardian" hidden="false" collective="false" targetId="8442-66d7-e259-958c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="365.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c5e4-ccc9-ea25-51d1" name="Army General" hidden="false" collective="false" targetId="7135-76a4-e218-b0c4" type="selectionEntry"/>
+        <entryLink id="b7c0-a172-a50f-86b2" name="Hierophant" hidden="false" collective="false" targetId="7718-325c-09da-3e17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="e6ec-925b-ed38-3810" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="295.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15af-b6f6-f9fc-7ad0" name="Nomarch" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="a2f7-5308-2e85-58fe" name="Nomarch Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b8e5-c6b9-ea14-f964" name="Nomarch Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3789-37e6-b5ed-e48d" name="Nomarch Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0673-e72a-f69a-b1eb" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="d78f-38d7-24af-df92" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="bc87-8b55-4810-22f9" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="0f9d-13fd-c4ce-31f4" name="Undying Will" hidden="false" targetId="3a23-85ab-6fb7-3816" type="rule"/>
+        <infoLink id="1dbb-ce33-fe41-5e5b" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6130-95b4-7f58-956f" name="Mummy&apos;s Curse" hidden="false" targetId="1aa0-b4b7-d77c-be14" type="rule"/>
+        <infoLink id="5785-8ef6-6ae5-91bd" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="63a8-469d-469f-d4c8" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6750-ad0d-3e09-0379" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="70d3-3e84-060c-945a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8494-1fb0-4426-7109" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8901-541a-d977-276c" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb47-0f23-9557-6f10" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4a96-792d-cd69-db4f" name="Armour Enchantments" hidden="false" collective="false" targetId="6acc-67ca-6961-c964" type="selectionEntryGroup"/>
+                <entryLink id="b86d-9ee5-569c-1788" name="Artefacts" hidden="false" collective="false" targetId="3677-bc9b-b029-4055" type="selectionEntryGroup"/>
+                <entryLink id="e733-59e9-825c-9821" name="Weapon Enchantments" hidden="false" collective="false" targetId="774e-115b-7473-7c20" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c86c-1340-4302-cf0f" name="Aspen Bow (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e760-d789-2c47-fc91" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0077-c02a-19d5-117f" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="307b-06ec-5d70-a9c6" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="f0a6-0721-26d9-4bcf" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="70c3-9b6b-3f61-06e7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ab7c-a56b-5274-4aea" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="b8e0-d645-e83a-772a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b7c8-0fc1-de66-7905" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5805-2fa5-0efb-2d49" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e0d6-e008-7dd1-bd19" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="64ab-cd25-96d8-4631" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3875-3ac8-340d-2974" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1736-6bd4-900b-7943" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4ad0-d34b-43ec-6a4a" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="991f-5d1a-45da-dd65" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="40f3-eed1-e4c3-ccb4" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cfc7-1bab-7d45-3c93" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f3e8-c2a9-0e76-ccd3" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="129c-6edb-55b3-5ba6" name="Paired Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1fa-46eb-982c-d9b7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c35e-16c9-122d-520d" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9514-e9ca-9eac-2298" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dfb0-fcbd-eea7-0dad" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dd82-93ab-6277-ed91" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ad81-f39b-a34c-2330" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5347-3ae0-50d6-bb60" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2ed0-4ec5-e9e5-c182" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ed3d-0e53-9c75-b452" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b008-e459-5c24-171b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a999-a441-ddb8-bb15" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6d2-a12e-0a0b-f50c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1182-6a5e-fac2-0618" name="Skeletal Horse" hidden="false" collective="false" targetId="4074-39fa-0fcc-6c98" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="679f-2144-c035-68a0" name="Skeleton Chariot" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c903-23ff-b73d-0afc" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2f7f-2b4a-4e02-009e" name="Skeleton Chariot" hidden="false" collective="false" targetId="ae95-ec69-39c5-59d4" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="243e-6233-8d7f-5a51" name="Sha Guardian" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99a3-ba59-70bb-ad6c" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="ccbc-d5e9-0468-ca3b" name="Mason&apos;s Menagerie (local)" hidden="false" targetId="d425-7690-6b20-5848" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="0b54-14cb-41cd-f9ac" name="Sha Guardian" hidden="false" collective="false" targetId="8442-66d7-e259-958c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="360.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9444-fba7-9cd2-f0f9" name="Army General" hidden="false" collective="false" targetId="7135-76a4-e218-b0c4" type="selectionEntry"/>
+        <entryLink id="9280-5112-9e1d-1848" name="Hierophant" hidden="false" collective="false" targetId="7718-325c-09da-3e17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="e6ec-925b-ed38-3810" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="140.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6eec-ddf1-1864-f6e7" name="Death Cult Hierarch" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="5bb1-6889-bbf6-d022" name="Death Cult Hierarch Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2181-6d67-ecca-4d0d" name="Death Cult Hierarch Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e5fe-cb54-ec86-a54a" name="Death Cult Hierarch Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6d05-543d-9ad2-1ceb" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="1aa3-5f28-6a93-7396" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="3339-a5e8-d6cd-b3b4" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ecfa-ac50-579b-d1d8" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e49a-6d65-3547-0cc5" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fdc1-3c6a-08c5-8058" name="Soul Conduit" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e111-6bc9-fbc8-9b78" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6460-f82c-0d21-cb65" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="3164-3237-09e7-f119" name="Soul Conduit" hidden="false">
+              <description>If the model is present on the Battlefield at the beginning of a friendly Magic Phase, you don&apos;t draw a Flux Card. Instead apply the following:
+
+5 Magic Dice 
+(both players)
+
+4+D3 Veil Tokens
+(Active Player)</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4ff7-1d59-f7d9-6aca" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8629-261f-c7fc-5f71" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7c23-cad9-b45c-7aa3" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7e3e-006a-5374-c1f6" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e782-810c-7bb9-e33c" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c421-a20e-5b3f-4af1" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="e7c4-03ae-d4b7-62d6" value="200">
+                  <conditions>
+                    <condition field="selections" scope="6eec-ddf1-1864-f6e7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e111-6bc9-fbc8-9b78" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7c4-03ae-d4b7-62d6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fe37-b49a-8b7d-392e" name="Armour Enchantments" hidden="false" collective="false" targetId="6acc-67ca-6961-c964" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="6eec-ddf1-1864-f6e7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ff7-1d59-f7d9-6aca" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="a884-e3c9-d4d3-7a16" name="Artefacts" hidden="false" collective="false" targetId="3677-bc9b-b029-4055" type="selectionEntryGroup"/>
+                <entryLink id="dbd4-52fc-a55d-408d" name="Weapon Enchantments" hidden="false" collective="false" targetId="774e-115b-7473-7c20" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="658c-1a74-8c52-e571" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="f770-df71-ee54-5141">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="df77-808a-eb0d-1ac1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bec6-dc69-712a-4375" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f770-df71-ee54-5141" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f81-e6c1-ec65-6127" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a97a-bab5-24f1-bedf" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="80af-1bbf-1598-01e2" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f8e-958c-d201-da7f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="01ad-c397-1bca-07af" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e111-6bc9-fbc8-9b78" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="914d-f9d2-efb9-0ca9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8896-b453-4607-d945" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7f59-939a-8954-7d91" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8167-125a-9161-edfa" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="71da-02ee-625a-d7d2" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a78-b977-ebdb-a75e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="953a-38f0-e0a2-acd2" name="Skeletal Horse" hidden="false" collective="false" targetId="4074-39fa-0fcc-6c98" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5cea-dd98-6d8c-6edd" name="Ark of Ages" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="100d-ced9-1a24-9437" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="83dd-9722-a63f-e345" name="Ark of Ages" hidden="false" collective="false" targetId="9e3a-edc6-977b-7a2b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="145.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="686c-557f-78e3-6ba4" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="e8e5-2543-0666-dd1f" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e8e5-2543-0666-dd1f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="66f3-2e87-90f9-9682" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3d91-0711-6c30-6ef6" name="Divination" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3655-9b5b-a4c8-5fad" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a612-3c18-253b-d3ec" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4871-143b-d582-4a2d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="32fa-2850-e4cd-a44c" name="Cosmology" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b2d4-e2eb-19ac-b734" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1352-ff6f-4845-8826" name="Army General" hidden="false" collective="false" targetId="7135-76a4-e218-b0c4" type="selectionEntry"/>
+        <entryLink id="088e-445a-e402-819a" name="Hierophant" hidden="false" collective="false" targetId="7718-325c-09da-3e17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="50">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e111-6bc9-fbc8-9b78" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="20">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e111-6bc9-fbc8-9b78" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ecce-b473-cab9-b80b" name="Tomb Harbinger" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="da38-ec35-dcc3-2103" name="Tomb Harbinger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e9b6-9178-e9e6-c8d8" name="Tomb Harbinger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fae6-e677-6650-538d" name="Tomb Harbinger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="7689-8df2-85d1-4f5d" name="Royal Guard" hidden="false">
+          <description>The model counts as a R&amp;F model for the purpose of Undying Will. If in the same unit as a Pharaoh or a Nomarch, a Tomb Harbinger must issue and accept Duels unless another model does so first.</description>
+        </rule>
+        <rule id="3503-a8ab-06f7-6674" name="Guardian&apos;s Wrath" hidden="false">
+          <description>The model and all model parts without Harnessed in the same unit, except model parts with Harnessed, gain Battle Focus.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="431d-724b-88cd-4ae2" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="8d4f-eb5b-f15d-c7f5" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="10ae-f175-0594-80ef" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b01c-b14c-e81c-bfe1" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="78ab-c56e-cb3b-d1b4" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="97b2-ca84-3a8a-3ecf" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="5f36-6297-987b-69fd" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ff9b-4762-7264-7928" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="101a-a36c-346f-711a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d73-ce5f-3c12-3a92" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ab9e-bed6-4690-8ee7" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1693-2d39-cbc0-3824" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b8b9-ce1b-1ca8-8e49" name="Armour Enchantments" hidden="false" collective="false" targetId="6acc-67ca-6961-c964" type="selectionEntryGroup"/>
+                <entryLink id="2577-f98e-f3b9-c817" name="Artefacts" hidden="false" collective="false" targetId="3677-bc9b-b029-4055" type="selectionEntryGroup"/>
+                <entryLink id="a46b-4d4f-8af8-695a" name="Weapon Enchantments" hidden="false" collective="false" targetId="774e-115b-7473-7c20" type="selectionEntryGroup"/>
+                <entryLink id="633b-1615-974e-0c24" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="ecce-b473-cab9-b80b" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49b4-bf2a-b8d8-ae8d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0efa-d731-7907-aea2" name="Aspen Bow (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3edc-d28a-6b9f-322c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e0ab-eb6b-32b3-44a2" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="49b4-bf2a-b8d8-ae8d" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fdec-df82-7f9f-f4c6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="694b-eb33-1d35-268c" name="Battle Standard Bearer" hidden="false" collective="false" targetId="f20d-a837-3005-83ea" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8381-3a52-ff42-612e" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="09d3-7609-198e-1a20" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="28ab-2543-cef5-5d07" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0333-043e-1a0f-c0a1" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="ab36-39a6-59e1-863d" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6b4e-24a1-d96d-7fe8" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4a8-40b3-b97d-5f51" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cd3a-1d6b-332e-2ead" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="542d-3e0f-db77-cc1d" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc89-334a-6baf-4248" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="02fb-ee9d-b724-4c68" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8c38-2115-067c-9f24" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9bcf-6152-87cb-771b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f008-50c3-941a-4e22" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ee0-07b9-c9d1-7360" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="30e9-ebef-5b50-c264" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cd41-ac89-daf3-73ad" name="Paired Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe61-90bf-dd88-d9b9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d2d7-9edc-5509-d2e9" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="47d1-309d-47d3-0097" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7416-e048-b4f1-1bdd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9bdd-1313-74fe-88ce" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cfa2-8c2d-d045-2def" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9307-6899-e077-3d4f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4747-291a-8731-893e" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ac72-2aca-ec2c-a1fb" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef80-9994-c7d9-2a94" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="21a5-abff-dbcf-9434" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="474c-bfff-59f3-db80" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6c7f-1fb1-e35f-08e1" name="Skeletal Horse" hidden="false" collective="false" targetId="4074-39fa-0fcc-6c98" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="afba-88df-057d-72e6" name="Skeleton Chariot" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c3b6-2c6d-aa42-7022" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6829-5477-1f62-0ffa" name="Skeleton Chariot" hidden="false" collective="false" targetId="ae95-ec69-39c5-59d4" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cd95-e0e4-bca6-9b49" name="Amuut" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b61-f88f-04a4-1a33" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="8da7-3bf9-19d7-640e" name="New CategoryLink" hidden="false" targetId="3876-145c-7cb2-a253" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="9961-ac53-e240-74e7" name="Amuut" hidden="false" collective="false" targetId="0438-ff7f-841f-535b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9ea0-f890-4658-e341" name="Army General" hidden="false" collective="false" targetId="7135-76a4-e218-b0c4" type="selectionEntry"/>
+        <entryLink id="8c17-43a0-ad8b-b7a9" name="Hierophant" hidden="false" collective="false" targetId="7718-325c-09da-3e17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="e6ec-925b-ed38-3810" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3eca-3140-0e69-47e7" name="Tomb Harbinger with Banner of the Entombed" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="1bd1-c37f-4418-98a6" name="Tomb Harbinger Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a12c-c6ef-cc45-3a46" name="Tomb Harbinger Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d3bc-4c4a-0e5d-d059" name="Tomb Harbinger Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8f0f-3155-711c-02af" name="Royal Guard" hidden="false">
+          <description>The model counts as a R&amp;F model for the purpose of Undying Will. If in the same unit as a Pharaoh or a Nomarch, a Tomb Harbinger must issue and accept Duels unless another model does so first.</description>
+        </rule>
+        <rule id="d54e-84a3-55e1-fedf" name="Guardian&apos;s Wrath" hidden="false">
+          <description>The model and all model parts without Harnessed in the same unit, except model parts with Harnessed, gain Battle Focus.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0a87-6b51-c6a8-aa8b" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="5833-398d-4f20-dd05" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="a190-7ba6-3ca7-86b6" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="60c9-c656-9143-6b0c" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7f3b-df84-cbda-1e29" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="fbb0-e784-11b1-3737" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="9a60-766c-6245-061b" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a76e-bc21-a337-0299" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="d15f-49df-9125-a56f" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d1a1-9c67-0e5f-a0f6" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b768-c507-8bb5-196a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8872-1ae3-fee1-ea1a" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c4b3-32b1-604e-8b79" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5974-eb57-e96c-e3d6" name="Armour Enchantments" hidden="false" collective="false" targetId="6acc-67ca-6961-c964" type="selectionEntryGroup"/>
+                <entryLink id="609a-5cc3-264c-4963" name="Artefacts" hidden="false" collective="false" targetId="3677-bc9b-b029-4055" type="selectionEntryGroup"/>
+                <entryLink id="6b06-a393-b184-6692" name="Weapon Enchantments" hidden="false" collective="false" targetId="774e-115b-7473-7c20" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d5a8-b8b1-9b95-bb7e" name="Aspen Bow (4+)" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c33f-7a8b-7411-4737" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="aa1d-7890-6f8f-746e" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cb21-ed2e-4992-3eb2" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cd58-d4c6-723a-7b51" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a600-2a19-de47-4471" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5a55-4fac-78cb-115a" name="Battle Standard Bearer" hidden="false" collective="false" targetId="f20d-a837-3005-83ea" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e002-9bdd-bc7d-124d" name="Armour" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="d6ee-0b9a-4c07-6083" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="056a-21bc-b553-87b7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b849-6e7d-a852-4645" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="694c-b9e1-0f0b-9123" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="496a-0a1c-b06b-c8f1" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d74-c086-1a68-46d9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="27bb-a73c-c93f-3a23" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="0434-aa3e-c417-1aed" name="New CategoryLink" hidden="false" targetId="4abe-83f5-0118-16db" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3d59-07ba-1d08-3dfa" name="Shield" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4fcc-a5e2-2f88-ee82" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="93c1-cb18-7a3e-4210" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="4b36-73ae-6b1e-41b6" name="New CategoryLink" hidden="false" targetId="4abe-83f5-0118-16db" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7cea-f7cc-7bf5-57bc" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ae1-a86c-be8f-8360" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0a88-c27e-d4c5-1abb" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a84-bd06-2c1b-55e3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1b6d-d734-2448-7f6b" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="826e-e6a7-ab09-0f46" name="Paired Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b74f-5fd0-1ca8-d002" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="932b-d2aa-e5b2-1834" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c354-266d-5df3-6717" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aeb1-c883-e896-6669" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6846-a46c-cecd-7c48" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7ff9-da32-5c47-d0d0" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bc0-be83-1f41-9c86" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2190-d37d-c8d1-a705" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="564f-1c9c-cbf3-213f" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f4a3-e5ee-e8eb-0bad" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4da9-2d48-2718-45c3" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8785-d437-7be5-9d8d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8e43-9372-8c86-3195" name="Skeletal Horse" hidden="false" collective="false" targetId="4074-39fa-0fcc-6c98" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0003-f041-675e-2df0" name="Skeleton Chariot" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4373-60df-94ce-ba7d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fc77-099a-505e-f48d" name="Skeleton Chariot" hidden="false" collective="false" targetId="ae95-ec69-39c5-59d4" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ac25-a6a2-a600-e629" name="Amuut" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b32b-3d09-cd76-e27d" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="f1df-97da-962c-7858" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+                <categoryLink id="8f57-f2b2-3f75-029f" name="New CategoryLink" hidden="false" targetId="3876-145c-7cb2-a253" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="0860-5010-c67e-df44" name="Amuut" hidden="false" collective="false" targetId="0438-ff7f-841f-535b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3231-18ee-2733-428e" name="Army General" hidden="false" collective="false" targetId="7135-76a4-e218-b0c4" type="selectionEntry"/>
+        <entryLink id="997b-7a3f-baf6-7a4c" name="Banner of the Entombed" hidden="false" collective="false" targetId="ae31-c66a-3e8d-fb74" type="selectionEntry"/>
+        <entryLink id="aecc-3891-1025-766d" name="Hierophant" hidden="false" collective="false" targetId="7718-325c-09da-3e17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="e6ec-925b-ed38-3810" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2947-11e2-19bb-d336" name="Tomb Architect" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="455e-6631-e735-caa2" name="Tomb Architect Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8666-9f26-8451-6361" name="Tomb Architect Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d246-047d-825a-fff6" name="Tomb Architect Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="91d1-8350-a8f2-4ef1" name="Master of Stone" hidden="false">
+          <description>Right before the battle (during step 7 of the Deployment Phase Sequence), and at the beginning of each friendly Player Turn, choose a friendly unit consisting entirely of models with Ensouled Statue within 18&quot; of the Tomb Architect. This unit gains Regeneration (5+) until the start of your next Player Turn or until the Tomb Architect is removed as a casualty, whichever comes first.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9c2d-f672-6199-59cf" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="e112-5417-2229-6ab7" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="c5ee-ea39-82a1-e0c0" name="Flammable" hidden="false" targetId="5df5-1a68-27be-1ad6" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5c11-aff0-4085-69f7" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4af9-d254-e557-987b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="7b4a-ce0a-1a51-ca4f" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b310-3ea6-089f-37b1" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="981e-a8aa-0e47-ddac" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f8f-4bc9-acbb-0f02" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b137-3a66-3d1a-a15f" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b29c-d309-455b-50b7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c321-45ad-4089-4e9b" name="Armour Enchantments" hidden="false" collective="false" targetId="6acc-67ca-6961-c964" type="selectionEntryGroup"/>
+                <entryLink id="cb3d-0f14-5373-b44a" name="Artefacts" hidden="false" collective="false" targetId="3677-bc9b-b029-4055" type="selectionEntryGroup"/>
+                <entryLink id="04b2-665f-b667-7081" name="Weapon Enchantments" hidden="false" collective="false" targetId="774e-115b-7473-7c20" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3d46-8eed-1de3-c7ee" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c24d-545d-a790-bf7b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3695-3590-3fbd-37a3" name="Paired Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a26f-4e17-be48-5ed8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="064f-49a4-80fc-1ffb" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2d96-f62e-36d3-66a7" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ccce-9fef-8af5-e360" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f7dc-8874-8409-2619" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b86d-d216-dd2f-498b" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="16c3-e8c3-b87b-4a5c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3529-f61b-7e90-4587" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7bb-2d57-fa46-68e5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="47dc-bfef-d2e3-87c9" name="Skeletal Horse" hidden="false" collective="false" targetId="4074-39fa-0fcc-6c98" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="649f-3f67-5fb0-4d54" name="Skeleton Chariot" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8aa2-2ae2-636e-28bf" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d58b-c950-e426-6f2b" name="Skeleton Chariot" hidden="false" collective="false" targetId="ae95-ec69-39c5-59d4" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6b77-3ebf-3baf-5a8d" name="Amuut" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b80-b43d-2813-0a33" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="699b-8dc6-f300-c7e2" name="Mason&apos;s Menagerie (local)" hidden="false" targetId="d425-7690-6b20-5848" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="4e54-6562-21dc-50c0" name="Amuut" hidden="false" collective="false" targetId="0438-ff7f-841f-535b" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="37ce-ecc2-8e2e-c658" name="Army General" hidden="false" collective="false" targetId="7135-76a4-e218-b0c4" type="selectionEntry"/>
+        <entryLink id="3bb7-c052-e441-6d81" name="Hierophant" hidden="false" collective="false" targetId="7718-325c-09da-3e17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="e6ec-925b-ed38-3810" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c87d-1b71-cfe8-9296" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2de9-5cd2-dbd7-122b" name="Casket of Phatep" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4410-b0ba-d73c-8f30" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3478-42de-d4d8-d0ec" name="Casket of Phatep Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d16c-7b42-af19-1910" name="Casket of Phatep Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a1c2-6f9c-db43-c3ac" name="Necropolis Guards Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="0bd3-ee5a-dfac-ba0a" name="Divine Light" hidden="false">
+          <description>Enemy Wizards within 36&quot; of one or more Caskets of Phatep suffer a -1 modifier to their casting rolls. When a Casket of Phatep is removed as a casualty, all units within 12&quot; suffer 3D3+3 hits with Strength 1 and Armour Penetration 10.</description>
+        </rule>
+        <rule id="08d3-8300-c63e-b12e" name="Phatep&apos;s Curse" hidden="false">
+          <description>Unless this model made an Advance Move or March Move during the current Player Turn, it can cast the following Bound Spell with Power Level (6/6): 
+Type: Damage, Hex, Range 36&quot;. Duration: Instant. 
+The target must take a Discipline Test rolling an additional D6. If failed, the target suffers a number of hits equal to the amount by which the test was failed. Hits are resolved with Armour Penetration 10 and wound automatically.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="692b-ba25-e79c-ff1e" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="2cfb-303c-9a1c-a0d8" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="e130-4579-483b-53ec" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+        <infoLink id="286b-acdd-4db8-d5fd" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="b05d-d7cd-f32c-e448" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2921-e489-1461-0902" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="e07c-c1ff-6591-ebb1" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ad29-5e40-baa0-9a97" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="c2ea-ee71-cf81-ea18" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="5b36-700d-bac6-edc0" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="4afa-fdf8-2ff0-3194" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="4b8b-12a9-bfb6-086a" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0d67-d0ce-ab6e-6f5c" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c2ae-418d-4061-ce53" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="240.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3305-3b43-2b06-6b08" name="Skeletons" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="dd84-8561-2d6f-4afb" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="1c4d-e060-7a14-fbe4" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="618f-ead0-4283-6afe" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="8c06-a4d9-67ac-51bd" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="001e-ef27-6a7b-a3bf" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0225-e283-f7f1-ba1f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4fe5-5521-3a5b-95f3" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1439-fd0c-c798-19fc" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (7)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="745b-47d1-943a-c74c" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2317-70e4-97f6-d4fa" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="de62-9108-24ce-bb50" name="Skeleton" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba4d-b766-9ce2-2c87" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3566-28dc-5cda-0ba1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a0d8-4dba-b60c-b965" name="Skeleton Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ef70-c5bd-07fd-dfc4" name="Skeleton Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="84e1-e027-53ae-8fdb" name="Skeleton Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0a4b-56d0-64cf-fba8" name="Spears" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0225-e283-f7f1-ba1f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2090-2c12-62d7-e716" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="974b-a1c3-852a-63bd" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d684-26ad-81a6-fc88" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d429-c43a-a944-5ed0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b195-7f07-18d3-e96c" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0225-e283-f7f1-ba1f" name="Replace Spear and Shield with Halberd" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="3305-3b43-2b06-6b08" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de62-9108-24ce-bb50" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9dc1-d2a5-1c74-84fa" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7983-f760-341e-d4ae" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="ae44-815d-4439-98c0" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5d95-93ec-5e9c-1138" name="Skeletons with Banner of the Entombed" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="2d2e-de86-640b-865b" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="4d0f-6ab0-d968-dad3" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="db69-a44f-4839-d745" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5a42-e7d2-b74b-429a" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="0ffe-a1bf-c961-c638" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="0ed5-e29b-391c-8cb1" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (7)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4524-bf1e-8b6c-a346" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="c4df-37d8-0624-2ee5" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0e21-43cd-6081-a778" name="Skeleton" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4483-cafd-f901-6833" type="min"/>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f11-37c9-0770-f012" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ccf0-5031-5ac5-068b" name="Skeleton Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c919-f41e-3484-a3ab" name="Skeleton Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6b8e-0a9c-4854-e4a5" name="Skeleton Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="21be-74fb-8889-f03a" name="Spears" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4609-dc20-44f1-ccd5" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4cef-8b19-9494-91c5" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="93fc-2f27-3d74-1d55" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="6dba-d46f-77e5-cb4f" name="Banner of the Entombed" hidden="false" collective="false" targetId="ae31-c66a-3e8d-fb74" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="931c-6d29-82a2-4617" name="Skeleton Archers" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="5d28-3d00-c157-4edb" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="952d-8714-41f8-f746" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="9fb4-1b46-d2f1-29a6" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="d476-478a-a75b-41ab" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0dea-ab8a-2da2-da04" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="915d-ba3d-15c8-8a49" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="52f8-adf4-fdd0-78e4" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="068e-a269-a04f-b69c" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4552-7848-733e-3221" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="8fa5-4a2e-625e-f03d" name="Ancient Ordnance (local)" hidden="false" targetId="edea-d85f-5b4e-838d" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="20e9-e0c7-feb7-0535" name="Skeleton Archer" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a126-3739-10bb-e2e9" type="min"/>
+            <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4d2-6966-12ff-1d81" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7b3b-a74a-cfb8-6206" name="Skeleton  Archer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7979-6d62-1177-d343" name="Skeleton Archer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0114-4dc0-f0b4-6bf8" name="Skeleton  Archer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5dc6-3af5-a8fe-bb14" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff0c-8809-e29f-8c70" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b5c7-3cca-3695-0a0f" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="0768-b6a6-c4cb-b6f5" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3069-966c-f27c-44cd" name="Skeleton Archers with Banner of the Entombed" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="bef1-25f2-49d2-9ddf" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="f3da-5e9a-39ca-841b" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="3260-edb5-8890-aae5" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3eb9-eaef-157b-6f6d" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="ce30-89ec-0223-64e3" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d894-075b-7d03-ca38" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5db1-39bd-8910-8e8f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="bbae-a0d5-9b03-9182" name="Ancient Ordnance (local)" hidden="false" targetId="edea-d85f-5b4e-838d" primary="false"/>
+        <categoryLink id="5462-9a64-3b30-2df2" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a573-3851-8206-b36e" name="Skeleton Archer" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b9ed-f5cb-b89b-f82a" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f20-2ea1-3611-304f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="188f-41ec-88f5-e7b9" name="Skeleton  Archer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="b687-6e65-b082-7818" name="Skeleton Archer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c7a3-0ddf-3ef4-1f03" name="Skeleton  Archer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="7075-c7cd-f30e-0f51" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="44c0-6a8c-1cf2-a673" name="Banner of the Entombed" hidden="false" collective="false" targetId="ae31-c66a-3e8d-fb74" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f209-a01d-0ab9-d6ca" name="Skeleton Cavalry" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="6c36-e678-c7cb-00c3" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d00-d825-93ab-b147" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c36-e678-c7cb-00c3" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="78ee-8377-aeb6-dd62" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="e4b2-8b0f-f7dc-4b2b" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="5a75-c886-982d-2f9b" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="d50f-7c76-b3f9-67f0" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="0189-13ad-8254-5d8f" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="7978-890b-5fc3-607d" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2c15-932b-6675-d98b" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="403f-31d0-d166-89f0" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a21-96e3-b759-2d34" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a37d-620b-1ea1-ac9f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="a266-9fd0-e4ce-f251" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8400-2c01-08a5-341f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8762-9095-7c6b-0570" name="Skeleton Cavalry" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b34d-551b-9847-4d9b" type="min"/>
+            <constraint field="selections" scope="parent" value="24.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e1b-16f9-3546-75b2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c238-a1b3-0c8b-1937" name="Skeleton Cavalry Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <modifiers>
+                <modifier type="set" field="b0d9-2dab-f10b-9b13" value="7&quot;">
+                  <conditions>
+                    <condition field="selections" scope="f209-a01d-0ab9-d6ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="590b-02f9-c9a0-baf1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="db10-a838-f72f-3ed6" value="14&quot;">
+                  <conditions>
+                    <condition field="selections" scope="f209-a01d-0ab9-d6ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="590b-02f9-c9a0-baf1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5c76-809c-cae5-2496" name="Skeleton Cavalry Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="fae6-2ee5-e7e8-3fbf" name="Skeleton Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="aab4-506e-85b4-a54c" name="Skeletal Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f06d-a100-ed97-5e0b" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1465-bd44-6e16-50de" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f0ff-955a-c6de-c64e" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8a21-96e3-b759-2d34" name="Lance" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="f209-a01d-0ab9-d6ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8762-9095-7c6b-0570" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a69-f8f2-fe1f-e6ae" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="85b5-8810-c770-1e97" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="590b-02f9-c9a0-baf1" name="+1 Armour, -1 Advance Rate and -2 March Rate" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="f209-a01d-0ab9-d6ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8762-9095-7c6b-0570" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0948-e543-e8d3-fb06" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="644e-03ed-4bd3-fe85" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5d00-d825-93ab-b147" name="Skeleton Cavalry with Banner of the Entombed" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="decrement" field="a151-57c8-fde1-90ad" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f209-a01d-0ab9-d6ca" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a151-57c8-fde1-90ad" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="58e6-919d-9d70-4f60" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="19f4-5ba7-ed9e-6921" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="5816-215e-1b77-7bae" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="06d3-72ac-c5bf-2e9b" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="4d48-324d-3059-9b44" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="81bc-0f9e-f58d-adce" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="aca7-ae9f-dbf7-9f24" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="b429-93e4-9ec0-afce" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="04e8-2499-db75-6f52" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0d38-cd3f-3e31-8062" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="9cf2-9eee-cf91-a015" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c2aa-c0fc-0ec6-f456" name="Skeleton Cavalry" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f331-f307-b687-bbbf" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d11e-9490-9fb5-9dd3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ba73-0b6f-db59-7e6e" name="Skeleton Cavalry Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="7e12-fd54-fe5e-b6e4" name="Skeleton Cavalry Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3aae-4451-ae05-96db" name="Skeleton Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6a72-1e68-185a-600d" name="Skeletal Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="e8df-bf9c-8ea6-9e2b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="0603-437e-1113-2a8d" name="Banner of the Entombed" hidden="false" collective="false" targetId="ae31-c66a-3e8d-fb74" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="06c8-7ee6-ac43-9ee5" name="Skeleton Scouts" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="fed6-7b0d-a7ea-8241" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38eb-afcb-1b5c-7d3d" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fed6-7b0d-a7ea-8241" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="85b7-6fc8-66bd-2d95" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="778b-daea-8357-a92c" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="3818-82be-f8c4-6791" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d3b1-6793-0df0-2ff7" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3542-8457-0fa3-3f67" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="db96-180f-0054-80d4" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="2cd0-c9c8-038f-e489" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="aa2e-c7a7-079f-9608" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6b60-7ce7-3485-934f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1d9f-4ef9-c40a-e210" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="545d-69fa-5411-11fe" name="Ancient Ordnance (local)" hidden="false" targetId="edea-d85f-5b4e-838d" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="25e9-dc58-1899-4c6c" name="Skeleton Scout" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f10-a8fa-11cf-9243" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="730c-d9cd-0bcf-8162" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="65d6-4e12-bfc9-e4a9" name="Skeleton Scout Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="385f-ff87-4300-72f4" name="Skeleton Scout Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8605-3619-d93a-b481" name="Skeleton Scout Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8cbf-feb0-1166-080a" name="Skeletal Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dc24-c145-b3a2-a21d" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="326f-ddad-6ebe-2ad4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5556-445a-a4c5-ec84" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="2dea-1976-0eaa-1b08" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="38eb-afcb-1b5c-7d3d" name="Skeleton Scouts with Banner of the Entombed" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="decrement" field="6876-185b-23ff-e791" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06c8-7ee6-ac43-9ee5" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6876-185b-23ff-e791" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a87c-b6a9-57c9-c6bf" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="5e0a-822b-2abf-549a" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="d93f-b7c8-9bba-4fd6" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8390-03b1-92d5-2398" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2d27-5b79-bfae-4be5" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="123e-36d6-b18c-ca00" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="55d8-00bd-a45a-c78f" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="26a8-1b59-4d3a-cdf8" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0a7f-e61e-a1b1-7d08" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="171d-2701-bd87-a3e1" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="dea6-8082-07b9-1814" name="Ancient Ordnance (local)" hidden="false" targetId="edea-d85f-5b4e-838d" primary="false"/>
+        <categoryLink id="96cf-01fb-7120-a447" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7230-6810-05c5-5ae3" name="Skeleton Scout" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c788-fa92-74f6-0340" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2763-e104-221e-7aca" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="16c6-a395-4138-1879" name="Skeleton Scout Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1a15-d9e4-b08e-4ba0" name="Skeleton Scout Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2d61-efb6-fe31-1b22" name="Skeleton Scout Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6ce6-854b-e394-b057" name="Skeletal Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="16.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f269-3f4d-20a3-ebdd" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="2510-c2e8-9d5e-9d5e" name="Banner of the Entombed" hidden="false" collective="false" targetId="ae31-c66a-3e8d-fb74" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="941c-1cef-d99e-a00c" name="Skeleton Chariots" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="282c-bf1c-aa4c-6fdc" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-aedf-d930-d78f" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="282c-bf1c-aa4c-6fdc" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="8b50-240c-80c5-b18d" name="Bound in Death" hidden="false">
+          <description>R&amp;F models in this unit must be fewer than 3 before hits can be distributed onto Characters with the same Type and Size as this unit.</description>
+        </rule>
+        <rule id="e7e5-4ce1-d367-22eb" name="Chariot Host" hidden="false">
+          <description>If the model part’s unit has at least one Full Rank, and there is a model in the rank directly behind it, its Impact Hits cause an additional hit (normally D3+2 instead of D3+1).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7fa3-1746-20fc-35b4" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="9dc9-2ba3-6b20-36a0" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="06d6-173a-d1d8-796f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="ac53-edef-9364-ccb6" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="568b-bda0-237f-cdac" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c22d-53a1-e2c2-a15e" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3f50-495b-a71f-7aec" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ba7-6294-b2b4-5fe2" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6d77-b9cb-4070-8d58" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="4071-8172-97ee-d8bf" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c94b-bf63-5ac3-b5e6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2c6c-3798-4c1c-cd2a" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="53d2-d430-da7d-bdd0" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="8e11-6522-f93f-67b5" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+1, Chariot Host)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7636-2938-1bea-c3ff" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="38cf-75ba-2523-4b80" name="Skeleton Chariot" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="2951-4882-0b8d-b474" value="6">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d95-85cc-7474-aa29" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2951-4882-0b8d-b474" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c866-299c-dbf7-20d9" name="Skeleton Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e4c3-79aa-87e7-aaf8" name="Skeleton Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="eaeb-109a-ead4-aa32" name="Charioteer (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="88a0-8d6d-105a-e2c9" name="Skeletal Horse (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="64fe-5d12-1c67-70ed" name="Chassis Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f53d-39ad-4401-1389" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c390-e99c-f742-de69" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7a72-6246-ca0e-2ce8" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7ba7-6294-b2b4-5fe2" name="Legion Charioteers" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+              <repeats>
+                <repeat field="selections" scope="941c-1cef-d99e-a00c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38cf-75ba-2523-4b80" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a40d-b836-a1a1-0ca6" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="c195-d79e-7196-9a30" name="Legion Charioteers" hidden="false">
+              <description>The model loses Light Troops and gains Scoring. Its Charioteers gain Devastating Charge (+1 Str, Fight in Extra Rank).</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="4979-6097-335c-da7e" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+            <infoLink id="2198-feeb-4118-aa3c" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (+1 Str, Fight in Extra Rank)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c94b-bf63-5ac3-b5e6" name="Lance" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+              <repeats>
+                <repeat field="selections" scope="941c-1cef-d99e-a00c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38cf-75ba-2523-4b80" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="02df-2601-3ffd-a434" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="50e2-08d8-5d7e-5b08" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="cf3a-7b8c-70a6-120a" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3234-aedf-d930-d78f" name="Skeleton Chariots with Banner of the Entombed" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="decrement" field="ea7b-ca41-007d-1f6d" value="1">
+          <repeats>
+            <repeat field="selections" scope="4bcd-01c8-ce5e-7108" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="941c-1cef-d99e-a00c" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea7b-ca41-007d-1f6d" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="9f80-4469-c16d-c280" name="Bound in Death" hidden="false">
+          <description>R&amp;F models in this unit must be fewer than 3 before hits can be distributed onto Characters with the same Type and Size as this unit.</description>
+        </rule>
+        <rule id="10ba-f3f5-94b1-c38f" name="Chariot Host" hidden="false">
+          <description>If the model part’s unit has at least one Full Rank, and there is a model in the rank directly behind it, its Impact Hits cause an additional hit (normally D3+2 instead of D3+1).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f49f-3402-04ff-896f" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="f822-1a3c-758a-ac93" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="5698-2f95-3290-5b73" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="d89c-49c6-8834-26b7" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7e1c-3385-ddfc-c61f" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="5c66-3846-cd42-6dd9" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="9287-e763-f3f2-ac8b" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="d4ff-ff06-d032-a547" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="dfc3-a7b8-7139-f61e" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="57a3-7b1c-fbb1-71b7" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="510c-5d09-5310-30cb" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+1, Chariot Host)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="db21-ec46-e7b1-6187" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+        <categoryLink id="13ee-ca94-1937-31d6" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4b3c-b190-5bc5-ad82" name="Skeleton Chariot" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f01-db8a-cd3a-dfbb" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7daf-52ee-c190-9118" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f5ee-aec8-3646-47df" name="Skeleton Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9c14-deff-4b35-5ecc" name="Skeleton Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8f15-d02b-e272-a5e0" name="Charioteer (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="61e0-251a-434a-c835" name="Skeletal Horse (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="200d-f86d-2f1e-5e86" name="Chassis Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ddcf-a8f3-badb-74ae" name="Legion Charioteers" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+              <repeats>
+                <repeat field="selections" scope="3234-aedf-d930-d78f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b3c-b190-5bc5-ad82" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac99-72d3-716e-e39e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="9b7b-7791-f371-ffc9" name="Legion Charioteers" hidden="false">
+              <description>The model loses Light Troops and gains Scoring. Its Charioteers gain Devastating Charge (+1 Str, Fight in Extra Rank).</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="b9f2-4cb0-9662-7a99" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+            <infoLink id="8cfa-842e-973f-01cb" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (+1 Str, Fight in Extra Rank)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="daf7-3df9-3135-b6e0" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="4c63-786e-249e-a335" name="Banner of the Entombed" hidden="false" collective="false" targetId="ae31-c66a-3e8d-fb74" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4882-75a0-ab38-7a04" name="Necropolis Guard" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="15bb-d197-47c9-c858" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="93b3-4a57-f2c2-c13f" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="d7bd-9e7e-321c-be87" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="cb5f-04fd-400b-9a19" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule"/>
+        <infoLink id="d8ab-2abe-f114-f71d" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c842-368e-c42e-e6c4" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="6421-efeb-592f-55c7" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="51bf-af1d-fbe5-c310" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="3400-781b-d9ca-a1ef" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="39e7-1579-56d5-56c4" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f991-909d-8787-a26d" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7a96-40e2-662a-c839" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b613-a8ec-0f78-5a3d" name="Necropolis Guard" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="a484-000b-2a84-dfea" value="30">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="6">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="a484-000b-2a84-dfea" value="35">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06ba-9268-35e8-272b" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a484-000b-2a84-dfea" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="57d9-4743-0b3e-e940" name="Necropolis Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="64ca-477b-ca4c-bd6a" name="Necropolis Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <modifiers>
+                <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6c2f-edc5-b363-799f" name="Necropolis Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <modifiers>
+                <modifier type="decrement" field="2a23-367f-8828-c297" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4d9b-314f-5d9f-0be5" name="Shield" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+              <repeats>
+                <repeat field="selections" scope="4882-75a0-ab38-7a04" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b613-a8ec-0f78-5a3d" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed15-cfd6-3504-e6ba" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8d13-10fe-620c-7ff4" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9205-540a-6b09-c796" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="4882-75a0-ab38-7a04" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4b10-59ff-55dd-0036" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a406-aea4-9173-7cf8" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a358-eb5a-aa3d-5c7d" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8255-2e3d-3b78-61cc" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9f21-c2cc-0961-03ea" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="4882-75a0-ab38-7a04" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b613-a8ec-0f78-5a3d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cbbe-8a4e-e380-8cba" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0234-c37b-a3e2-607c" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="23e8-ec46-449c-a529" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="4882-75a0-ab38-7a04" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b613-a8ec-0f78-5a3d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="be9e-270c-7a5b-342e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8a94-3b99-9a33-d5a0" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5372-18e3-8ac8-a381" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-185.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a15-3572-c3c6-f0d3" name="Tomb Cataphracts" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="decrement" field="4da5-7749-fa6f-eb13" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a15-3572-c3c6-f0d3" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4da5-7749-fa6f-eb13" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2b10-7d83-644f-c961" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="4564-98e3-2760-a44a" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="cfcc-b8bd-e6b0-dea7" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="c0f8-146c-5905-1cef" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="6db6-ca9a-d805-3319" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="b722-12e6-19a6-4e0f" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="3492-1484-656b-b960" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="6450-65cb-f211-6e06" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="3e2f-1e31-5067-53a3" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1e30-6920-d908-1a6d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0ab9-53ba-8fad-d1f3" name="Tomb Cataphract" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4396-31c0-75f7-b804" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="664a-2e67-62be-863f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="55f1-335d-11cd-d62a" name="Tomb Cataphract Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f45a-f9dd-ec82-b631" name="Tomb Cataphract Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3e5b-2df2-e996-99d5" name="Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cdf6-b510-4983-f909" name="Amuut Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee57-4673-2825-3eb1" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0df3-c6e3-b2e5-bad9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1aa0-9529-6a20-6e41" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="412c-71a0-5aa2-3d99" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="3dda-9466-86ae-937f" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2102-aa77-a2bb-0e9a" name="Tomb Cataphracts with Underground Ambush" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="decrement" field="d553-841f-757b-0842" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2a15-3572-c3c6-f0d3" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d553-841f-757b-0842" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="23a7-0371-02c0-0377" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="658a-2028-8516-2499" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="b05f-afb4-26e6-f7c7" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="d9be-fecd-315e-ee7f" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="c350-55bd-29e6-640c" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="fab2-82ab-edcc-5c5b" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="d638-4a90-ef12-f08a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="3202-d42f-a19f-86e0" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="6350-5768-b2bb-976b" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a9a5-23ad-be32-5ae0" name="Underground Ambush" hidden="false" targetId="1127-ca1a-3b4b-0aad" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e763-bf77-45e3-6e87" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="f9a8-a596-7781-e5f2" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f89e-65a6-ab28-c778" name="Tomb Cataphract" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="356b-fa67-f00e-e244" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="71f3-8cc3-1a2c-e4d4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ad5b-9a4b-30e3-2ef3" name="Tomb Cataphract Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8c73-92fb-aeef-9229" name="Tomb Cataphract Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="38f1-326d-fd7a-49b7" name="Rider Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="df1b-a40d-e79d-5634" name="Amuut Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3eb8-8419-2b4e-c24f" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="71ec-2acb-95dd-9c1e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b632-c07e-a6b6-5f1b" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="d7c4-b042-35b0-544d" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f615-f584-60ce-13a4" name="Shabtis" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b998-901e-c640-7c97" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e8d8-388a-3295-5007" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="5c46-a9e0-cacd-7fe8" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3c94-ba90-1e2c-1974" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="8665-9a63-5f26-e284" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="9792-a50a-a6eb-7a12" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5556-9a19-bda3-45cb" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6b0d-aa9b-a038-f794" name="Shabti" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e03-bda3-17bb-ff45" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bc2-f5a3-a5c7-c2bb" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="4d9e-8a36-e925-f31d" name="Shabti Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f864-45d8-7cf0-c6af" name="Shabti Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="912e-5fe2-0579-1b88" name="Shabti Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c836-1ef7-bf26-9510" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="857e-88c1-063a-b517" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="baf1-42df-22c0-5a5f" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="859d-9635-7201-114e" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed26-38e7-ad4d-6289" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5264-f3fe-4772-bf1e" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+                  <repeats>
+                    <repeat field="selections" scope="f615-f584-60ce-13a4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b0d-aa9b-a038-f794" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="822d-e4be-fe69-746a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="874a-aaf2-43d0-34a5" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d42c-6852-077b-293c" name="Halberds" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="18">
+                  <repeats>
+                    <repeat field="selections" scope="f615-f584-60ce-13a4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b0d-aa9b-a038-f794" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dcbd-4dbf-a8bc-3020" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0f84-8933-dabc-6a06" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7aed-e2dc-4d51-edf3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b3a-4aad-cf55-7958" name="Great Vultures" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ff2-a5ca-fc93-7b48" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7cc6-dd44-04c1-6879" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="0fbc-2071-5617-3680" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="6b1f-fb1b-dcdc-a89c" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="4020-4b06-acc6-a33b" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="063e-798a-7ee7-2971" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="318c-ea71-df61-ffeb" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3e79-eb58-609b-99b3" name="Great Vulture" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4404-7ad8-b26d-0280" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="88b7-6efa-7dbb-1b66" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7088-9bc2-e10d-770f" name="Great Vulture Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">2&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="32bd-c2b7-7718-8d22" name="Great Vulture Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a2ee-7753-6e6b-d58b" name="Great Vulture Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a9f1-d5e8-084a-2322" name="Scarab Swarms" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="decrement" field="5d13-4378-69fe-6104" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1bcc-06ca-fc4c-9e1c" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5d13-4378-69fe-6104" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="77a4-71c6-434f-02e1" name="Chitinous Tide" hidden="false">
+          <description>The model can make a number of Supporting Attacks equal to its Attack Value.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b471-1385-d173-1e56" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="832b-10a1-d6f6-08a2" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="856c-5aa6-ba0a-b750" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="5d7e-a299-ccb4-b845" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="c214-44a3-267a-07b4" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="92dc-6952-05d1-053f" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="append" field="name" value=" (1)">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b9c1-7284-434a-f89c" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+, 3+ Against non-Magical Attacks)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="168d-b619-23f4-44f0" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="44d0-5bcd-d64a-81e4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="af59-13fd-77c9-fe0e" name="Scarab Swarm" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="28">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="7426-dfd7-56a9-9df0" value="4">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="f3e9-2732-a48f-2827" value="7">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0462-54c4-ced2-041f" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7426-dfd7-56a9-9df0" type="max"/>
+            <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3e9-2732-a48f-2827" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5393-d560-f57b-dcc8" name="Scarab Swarm Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f1a8-479b-cfb7-05f2" name="Scarab Swarm Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="feb2-8851-c079-50e2" name="Scarab Swarm Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1bcc-06ca-fc4c-9e1c" name="Scarab Swarms with Underground Ambush" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="decrement" field="b94a-3d25-7d3e-500f" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9f1-d5e8-084a-2322" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b94a-3d25-7d3e-500f" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="e9d1-dcae-0937-ca12" name="Chitinous Tide" hidden="false">
+          <description>The model can make a number of Supporting Attacks equal to its Attack Value.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a006-ba88-dea4-ee66" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="bda8-8721-1b62-1cf2" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="2e50-d40c-a6d3-8cb3" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="b9bd-7918-32b2-7b04" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="c493-32d2-e286-e3d6" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="bcb6-a57e-016a-4255" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5)">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="75ff-99ee-d966-523c" name="Underground Ambush" hidden="false" targetId="1127-ca1a-3b4b-0aad" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a87d-c054-0ec7-f5af" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+        <categoryLink id="b65f-0038-56e2-b362" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="33d1-9a4b-889d-1148" name="Scarab Swarm" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac7d-20da-51a9-46cd" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0aff-044b-dd2b-14cb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eba4-1b97-0969-3073" name="Scarab Swarm Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="37c5-f848-b563-934f" name="Scarab Swarm Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d9a6-d25c-7626-fdb8" name="Scarab Swarm Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="45ff-4e65-e3a6-ad17" name="Shabti Archers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0ca-b06b-4bea-686c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b219-b78a-3e09-88ad" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="77ea-d91f-7594-b184" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="3ed0-a136-e584-37c3" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="7c75-0415-b87e-2736" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="e3c2-eabf-1225-ced4" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2359-9179-4b25-4334" name="Great Aspen Bow" hidden="false" targetId="6509-0400-a54d-c254" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="5507-8c6c-77f0-9781" name="New CategoryLink" hidden="false" targetId="edea-d85f-5b4e-838d" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="275f-b6bc-3539-6017" name="Shabti Archer" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="380f-7d75-813f-a33f" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f9d-4760-633c-99c9" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="b08d-0f43-ce0d-fa54" name="Shabti Archer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large </characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6157-2910-b174-4a2d" name="Shabti Archer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ecc2-0ee7-56a1-d10f" name="Shabti Archer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cc59-ea4f-3a6f-c583" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83aa-029e-9b19-6e83" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3d61-bb32-e757-7c2b" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="43f4-d016-4884-2933" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc72-49c3-8f16-9ca6" name="Sand Stalkers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="ea79-f4e6-45eb-8af6" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5eaf-cdc2-3529-8bf3" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea79-f4e6-45eb-8af6" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="94cb-83ab-087b-37f9" name="Petrifying Gaze (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6+1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">2</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, When rolling to wound with this attack, use the target&apos;s Agility instead of the target&apos;s Resilience.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="349a-1188-f5aa-baf0" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="199b-7427-706f-a05b" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="7c44-e1d9-c572-d6ad" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="4043-c17d-b78c-22f9" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="72fa-a8b5-2656-957f" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7313-1ff3-42cf-3b47" name="New CategoryLink" hidden="false" targetId="edea-d85f-5b4e-838d" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1577-8a93-70db-04a5" name="Sand Stalker" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c1f9-c490-4303-a855" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0df-7942-dda1-3226" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5af0-b768-cd5b-8236" name="Sand Stalker Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="bc0b-9859-a25f-385a" name="Sand Stalker Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ee6b-5e32-e76c-333c" name="Sand Stalker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b71b-e55b-a287-fcb5" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2a0-4186-e799-a6df" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5eaf-cdc2-3529-8bf3" name="Sand Stalkers with Underground Ambush" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="9204-54cd-792b-cce5" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc72-49c3-8f16-9ca6" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9204-54cd-792b-cce5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="df24-019e-1cac-67e2" name="Petrifying Gaze (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">D6+1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">2</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Quick to Fire, When rolling to wound with this attack, use the target&apos;s Agility instead of the target&apos;s Resilience.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1834-8f68-eea7-972f" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="fd1c-e993-96d3-7634" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="5373-765c-93b8-913e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="9bc0-6cee-05df-a7ee" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+        <infoLink id="2030-3bdf-6b9e-243d" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bdf5-11e6-c40a-21c7" name="Underground Ambush" hidden="false" targetId="1127-ca1a-3b4b-0aad" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d4dc-28a9-4d41-e00a" name="New CategoryLink" hidden="false" targetId="edea-d85f-5b4e-838d" primary="true"/>
+        <categoryLink id="d114-a231-6455-2ebf" name="Entombed (local)" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="12c4-0d6a-319f-6397" name="Sand Stalker" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ae5-7329-f86e-aaad" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="59ec-3f4c-096b-58db" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="25f7-e96c-3068-ea6e" name="Sand Stalker Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d789-0a6f-ec50-cad2" name="Sand Stalker Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cff1-26b8-764f-e766" name="Sand Stalker Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cfab-a309-203c-7590" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6d54-3db9-0308-68c1" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e056-32c9-5771-f76c" name="Charnel Catapult" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="24fd-8af8-0c78-001c" value="210">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="357d-c5f9-f957-6c70" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="28f1-8278-41f8-fe91" name="Charnel Catapult Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">4&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b404-4dcd-ce86-204e" name="Charnel Catapult Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0b5b-be7c-5c3a-de49" name="Crew Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="62f9-33e1-83dc-9409" name="Charnel Catapult (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12-60&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [7]</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">0 [4]</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (4). [Multiple Wounds (D3, Clipped Wings)] . This weapon always hits on a roll equal to or greater then its Aim</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e02a-dadf-ec66-b9d3" name="Charnel Catapult (4+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">12-48&quot;</characteristic>
+            <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+            <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+            <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+            <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Catapult (6). Flaming Attacks, Magical Attacks. Units that suffer at least one casualty from this weapon must take a panic test as if they had suffered 25% casualties. Panic tests caused by this weapon are taken at -1 Discipline. This weapon always hits on a roll equal to or greater than its Aim.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5d0a-1660-84f8-ff36" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="c738-7820-fb13-d6ad" name="Dust to Dust" hidden="false" targetId="8d07-0aa4-6c27-79a6" type="rule"/>
+        <infoLink id="d91f-d8d3-c328-d1d9" name="War Machine" hidden="false" targetId="610e-d71e-0439-9e7f" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0d60-47df-93d4-cd5d" name="New CategoryLink" hidden="false" targetId="edea-d85f-5b4e-838d" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="200.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ea10-c39a-1aeb-c7cc" name="Sand Scorpion" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7b39-9c31-5613-f0a8" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f209-1d66-38b8-b2a0" name="Sand Scorpion Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="376d-cc4b-01ca-8d5b" name="Sand Scorpion Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0579-5eb5-f111-5a3e" name="Sand Scorpion Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="12ce-fd33-5e7c-b082" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="d8be-c5f5-9a84-670b" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="669c-9bc5-cbc8-1107" name="Underground Ambush" hidden="false" targetId="1127-ca1a-3b4b-0aad" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fa7a-d042-4db6-99e4" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="1485-ce53-fe12-5a89" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="939f-69c6-9da6-7a02" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+            <modifier type="append" field="name" value=" (1)">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b11d-c833-9e78-ff04" name="New CategoryLink" hidden="false" targetId="d18e-d0ac-d05f-3410" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="25f7-6aa7-8fec-0876" name="Battle Sphinx" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="226e-8f82-9fab-987c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f5b9-aae0-a820-3dfa" name="Battle Sphinx Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3788-d9c7-793f-555d" name="Battle Sphinx Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">8</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="073d-1240-9601-cb8f" name="Battle Sphinx Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bd07-5204-4f77-be58" name="Rider (4) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b0bb-7d49-b19a-2f94" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="c97c-b94b-cdcf-84cd" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="fe54-1fab-728c-d6aa" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="984a-f9f9-bd67-5406" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Str 4, AP 1, Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7ccf-defe-5f25-9a4e" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="ff6f-c060-c6e1-c568" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="20b8-7514-06a6-b13b" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1228-2845-41e4-83f3" name="New CategoryLink" hidden="false" targetId="d425-7690-6b20-5848" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="480.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a31-d401-976d-3a8e" name="Dread Sphinx" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="42b3-9b38-2cfb-a2e5" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2c98-a2fe-c2f6-e134" name="Battle Sphinx Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (6&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (12&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1a7b-682f-8ae9-35fd" name="Battle Sphinx Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">8</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a2a0-c0ec-8387-2c6d" name="Battle Sphinx Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7ff5-3488-9b2f-17f4" name="Rider (4) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c951-c434-ecb5-cb57" name="Colossal Kopesh" hidden="false" typeId="a32f-208a-be3d-ad8d" typeName="5 Melee Weapon">
+          <characteristics>
+            <characteristic name="Str" typeId="7d4e-b182-dd11-52a0">+2</characteristic>
+            <characteristic name="AP" typeId="646b-1e72-1589-5083">+2</characteristic>
+            <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9">Multiple Wounds (D3, against Towering Presence)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b16d-50ff-3c3c-fac1" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="28e0-8e81-e62f-2221" name="Light Lance" hidden="false" targetId="8460-7bb5-aa92-d6ee" type="profile"/>
+        <infoLink id="cb04-34b8-8cd3-c18a" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="e515-acc9-7872-0ecd" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="4bc9-0f3f-83f1-2d90" name="Autonomous" hidden="false" targetId="d95c-2fec-ef44-1a3b" type="rule"/>
+        <infoLink id="679c-89ca-4f5c-4bb1" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="dd43-e031-3e80-8ab9" name="Resurrected" hidden="false" targetId="5fa7-01d3-9aa2-2756" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8a8d-5454-f081-6967" name="New CategoryLink" hidden="false" targetId="d425-7690-6b20-5848" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="480.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0d7-2fd3-7157-e622" name="Tomb Reapers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f564-93b2-b0d9-a4b7" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f18b-2eb6-4104-7899" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b229-adf6-6ba7-5a04" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="0db5-eefc-fefb-5129" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="7f2f-c1bb-3ea5-bf01" name="Autonomous" hidden="false" targetId="d95c-2fec-ef44-1a3b" type="rule"/>
+        <infoLink id="3102-7a71-7210-a2e7" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="0d1d-ec4e-509e-b442" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="83a2-3bbe-45bd-ded1" name="Mason&apos;s Menagerie (local)" hidden="false" targetId="d425-7690-6b20-5848" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="49ba-6611-6c7f-8a98" name="Tomb Reaper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4cd-399a-db08-b98c" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06ff-71f2-9ff2-3f4e" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="ff6f-ca5d-7454-66f9" name="Tomb Reaper Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (6&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (12&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a1e0-60f2-c548-6f1e" name="Tomb Reaper Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c5be-efa1-53b2-5524" name="Tomb Reaper Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b914-1b03-ce0c-8981" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc75-7a7f-d3fa-6715" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="293f-6672-e609-2b9f" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="e0d7-2fd3-7157-e622" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49ba-6611-6c7f-8a98" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="316b-371d-dce1-beb9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3301-3ec2-9a82-fd6a" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3873-d05d-fecd-bb60" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="e0d7-2fd3-7157-e622" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49ba-6611-6c7f-8a98" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f199-c884-4560-6c7e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0468-6dd6-6986-0069" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b46c-cac5-39e1-e373" name="Colossus" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a8c-d985-1004-5a32" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1067-f844-cd03-6152" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="baaf-8d2e-24d2-8226" name="Colossus Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c8ea-5b3c-088d-a26c" name="Colossus Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="decrement" field="597b-8735-3dd1-0e70" value="1">
+              <conditions>
+                <condition field="selections" scope="b46c-cac5-39e1-e373" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a4d-ffd1-ff1e-1dcb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="85a4-dbe2-7dad-a2ac" name="Colossus Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="decrement" field="8265-800f-bc87-d00a" value="1">
+              <conditions>
+                <condition field="selections" scope="b46c-cac5-39e1-e373" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3a4d-ffd1-ff1e-1dcb" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">6</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="dd04-b11c-438c-5114" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="a75f-977c-0f1b-ab61" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="f100-a790-3d35-b11e" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9909-bbff-f869-d390" name="New CategoryLink" hidden="false" targetId="d425-7690-6b20-5848" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9030-7571-5761-14a8" name="Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2385-0cd4-9b7c-4efb" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3a4d-ffd1-ff1e-1dcb" name="Scales of Destiny" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4d0-d9a0-214f-5cd6" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="e3ce-1b43-78f0-c7fe" name="Scales of Destiny" hidden="false">
+                  <description>The wielder suffers -1 Attack Value and -1 Armour.
+The model has two Bound Spells:
+- Fate&apos;s Judgement from Cosmology,
+	Power Level (4/8)
+- Ice and Fire from Cosmology, 
+	Power Level (4/8)</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f850-2bdc-e5ed-bf2d" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="186b-e584-46d5-72ab" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d7e2-014b-8195-dc7c" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="26f7-ddd8-58a1-1650" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6716-34f8-4211-af51" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5d12-7c4d-8de0-9d16" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a3ab-4e01-e86f-fbca" name="Giant Aspen Bow (5+)" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f011-40e3-c856-0974" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="624e-8849-a593-87a8" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="23db-4b11-7b1d-b3de" name="Giant Aspen Bow (5+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">48&quot;</characteristic>
+                    <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+                    <characteristic name="Str" typeId="f166-13ff-9227-4525">3 [6]</characteristic>
+                    <characteristic name="AP" typeId="857a-4ce1-d134-8701">10</characteristic>
+                    <characteristic name="Attributes" typeId="d988-3828-5f00-7582">[Multiple Wounds (D3)]. This weapon always hits on a roll equal to or greater then its Aim.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="420.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="7718-325c-09da-3e17" name="Hierophant" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0720-dfc3-3637-9427" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="38d3-7e9f-e758-39bb" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b31b-d3b1-4b4a-ea6e" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ec-925b-ed38-3810" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="fc86-bfb9-7743-99a2" name="Hierophant" hidden="false" targetId="61b8-31b1-d20f-6334" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7135-76a4-e218-b0c4" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a330-968b-437d-4d87" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb12-8df0-1539-c22b" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="948c-a5b6-46f0-7b00" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="3b73-d4ef-9d4a-8482" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f20d-a837-3005-83ea" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c23-e25b-0e94-5f6f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d70d-1fa3-e3aa-22d7" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6453-6ae7-ac45-15ba" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c966-70ce-c2e8-0aaf" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f564-93b2-b0d9-a4b7" name="Commander of the Terracotta Army" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7bc6-fd94-9b7b-ab64" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3a8c-d985-1004-5a32" name="Lord of the Barrow Legion" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92a5-837b-e932-a67a" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4074-39fa-0fcc-6c98" name="Skeletal Horse" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8335-8b36-8885-5208" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6989-d56f-c930-8d58" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="f50c-f6dd-66f4-96a4" name="Skeletal Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9de1-e102-8dd0-640d" name="Skeletal Horse Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d547-19bf-1788-50b0" name="Skeletal Horse Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6176-0f5c-26bf-b72a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ae95-ec69-39c5-59d4" name="Skeleton Chariot" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9f53-9805-15c7-ac8d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5646-7fad-1dd1-392b" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="f403-40b5-346d-3e75" name="Skeleton Chariot Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="95c4-7232-c8b7-5af0" name="Skeleton Chariot Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7f95-1434-d360-eac4" name="Chassis Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="133f-3f0f-77c2-0e70" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="31b1-6c78-7546-4c3c" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="7130-501f-3976-63c8" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="1b9f-d77b-cd54-d30a" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="c67e-1061-019c-0f36" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fcc0-5539-6a08-2641" name="Number of Horses" hidden="false" collective="false" defaultSelectionEntryId="9036-cad8-ed91-4119">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9fd2-0668-e2d6-1ad3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec75-dd77-cf72-3c3e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9036-cad8-ed91-4119" name="2 Skeletal Horses" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="767f-ed29-f290-170f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0428-65f2-56b0-af70" name="Skeletal Horse (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4b7c-10ee-c51f-a16c" name="4 Skeletal Horses" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb36-62a9-6a4f-169a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a16c-5c8b-d8f8-6d40" name="Skeletal Horse (4) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8442-66d7-e259-958c" name="Sha Guardian" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e263-611e-72ff-29a4" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b01-9d32-c5d6-9b20" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="fc37-fb0d-0e58-2002" name="Sha Guardian Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5cef-0b0c-7d67-b0cf" name="Sha Guardian Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">7</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d772-6024-4e5d-f05a" name="Sha Guardian Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="dfd4-25a0-dfb8-01f6" name="Eternal Guardian" hidden="false">
+          <description>When a model with this rule suffers a wound from an attack with Multiple Wounds, the number of wounds this is multiplied into (due to Multiple Wounds) is halved, rounding up.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="586e-72df-1064-7376" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="804b-d093-1bad-ab36" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="15b9-d73b-3016-a0ab" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="f30b-51e0-19d1-8a77" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e3a-edc6-977b-7a2b" name="Ark of Ages" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f584-4af1-de3a-36d9" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d329-eeb5-ac9f-db5c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7489-87e3-95db-aa0e" name="Ark of Ages Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9ec7-dc17-ead3-b1d5" name="Ark of Ages Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ee8f-b6d4-d5f4-817e" name="Guard (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b460-9ab9-b91d-5d29" name="Bound Spirits Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dbfe-5727-0106-8055" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="57fe-ba8e-9cf7-66ec" name="Sacred Ark" hidden="false">
+          <description>All friendly Wizards within 12&quot; of the Ark of Ages add +6&quot; to the Range of their non-Bound Spells. Spells of Type Aura only add +3&quot; to their Range.
+
+Furthermore, you gain the Well of Souls Flux Card. One use only. May be activated at the start of any of your Magic Phases. Instead of randomly drawing a Flux Card from the deck, you draw the Well of Souls Flux Card. In addition, instead of randomly drawing a Flux Card from the deck, your opponent must draw the Well of Souls Flux Card in the following Magic Phase. Afterwards discard the Well of Souls Flux Card (even if the opponent did not use it for whatever reason).
+
+Well of Souls
+5 Magic Dice 
+(both players)
+
+5 Veil Tokens
+(Active Player)
+When making a casting roll with 3 or more Magic Dice, all doubles count as triples. Note that a Caster can suffer multiple Miscast effects from a single casting roll.  However no Miscast effect can be applied more than once</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a1df-1ab9-0c76-2f5d" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="594b-e6e3-7a41-075f" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3fea-2a9f-5607-3de8" name="Aspen Bow" hidden="false" targetId="efbc-4974-e8d4-c4c9" type="profile">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c653-17ac-bed2-5ce6" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="b5a3-9740-fe17-47d3" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="7f5e-18f3-f303-3229" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="0b48-a72f-8128-9e6a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b6db-ec3b-fdd9-2f06" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="22b4-0110-6bb8-915b" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0438-ff7f-841f-535b" name="Amuut" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="480b-d6b4-9804-eae0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b59f-edc4-ddbc-7f46" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="d248-e7eb-51a9-99f9" name="Amuut Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="950e-6c6f-a147-81af" name="Amuut Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c6c8-9eb6-bb9d-5468" name="Amuut Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="785c-e99d-0a5c-e540" name="Ensouled Statue" hidden="false" targetId="20df-ea5e-7ab6-6613" type="rule"/>
+        <infoLink id="b270-51b0-e816-3541" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="c584-b12f-9caa-55ea" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b709-bc4a-6bf4-c455" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ae31-c66a-3e8d-fb74" name="Banner of the Entombed" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a3a-b334-56ea-3ac4" type="max"/>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b74a-6d70-afa3-6583" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8404-ebc9-d8eb-5080" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="c589-3045-d6ca-6fff" name="Banner of the Entombed" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+          <characteristics>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If taken by a Character, the bearer gains Underground Ambush. If taken by a R&amp;F model, the bearer’s unit gains Underground Ambush and additional models cannot be added to the unit during Army List creation. Standard Size models using this banner to Ambush must arrive in a formation containing exactly 5 models per rank (except for the last) and cannot make a reform (or a swift reform) during this player turn.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f2c6-94e3-1775-c73c" name="Underground Ambush" hidden="false" targetId="1127-ca1a-3b4b-0aad" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="4c8e-8b61-d6fe-8ee1" name="UD Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6511-d0e3-c78c-ee88" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="23e3-ed2e-b671-2aa5" name="Godslayer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e37-e1be-73a1-0af8" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="895a-eb0e-99a9-3691" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7a47-4062-c3bf-f41a" name="Godslayer" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Great Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wielder gains +1 Attack when using this weapon. Attacks made with this weapon gain Divine Attacks, and Multiple Wounds (2, against Aegis). (note that the latter also applies against models with conditional aegis saves)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f412-7fcc-a6ba-2648" name="Scourge of Kings" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f9c3-758a-dba1-3d43" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae6f-e9eb-b3ae-faf6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dcde-41c0-24bb-9015" name="Scourge of Kings" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon and Paired Weapons Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When using this weapon, the wielder’s Attack Value is set to 6. Attacks made with this weapon must reroll failed to-wound rolls when fighting in a Duel.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="749d-58a3-0ef5-39ab" name="UD Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="cd19-2b88-38db-6290" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cd19-2b88-38db-6290" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fee8-1bf2-f816-856c" name="Sun&apos;s Embrace" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46bc-63f5-9335-b3d7" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd46-80fd-c058-0add" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7509-8424-e29f-773c" name="Sun&apos;s Embrace" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Distracting while using this Shield.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="fb52-dc99-a6cf-ca63" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b920-ca2e-4282-73f2" name="Jackal&apos;s Blessing" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2995-6c55-b28a-8e8c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0624-d02d-87c5-81a5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fcc0-f3aa-896a-535f" name="Jackal&apos;s Blessing" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Suit of Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +2 Health Points and Regeneration (5+).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6ac6-0dfd-b376-d9e3" name="UD Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68eb-fee1-5c19-267b" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c87d-1b71-cfe8-9296" name="Ankh of Naptesh" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="749b-98ad-6cdf-3d5a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="80db-4b4c-f967-88d7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7fbc-3ef4-10ef-17db" name="Ankh of Naptesh" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Hierophant. R&amp;F models in the bearer’s unit gain Regeneration (6+).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ced1-e506-571d-b5de" name="Sekhem Sceptre" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4838-41fa-f9d3-3562" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="229b-9100-ed69-5b35" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="349d-2e14-c966-6724" name="Sekhem Sceptre" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Stubborn and Autonomous.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6178-4992-f326-d6ea" name="Crown of the Pharaohs - Pharaoh and Nomarchs only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a7c-1401-6ee8-58f9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e32-9dff-4b39-46a7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5a0c-ee45-226b-86ae" name="Crown of the Pharaohs" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer increases the range of its Commanding Presence by 6&apos;&apos;. At the start of each of your Player Turns, the bearer may lose Undying Will and choose a unit within 12&quot;. This unit benefits from Undying Will until the start of your next Player Turn.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2391-617b-454e-0e80" name="Steeds of Nephet-Ra" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ee0-fb95-fcc4-993d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db5a-9dc1-6fbb-9e28" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="193d-2332-44b7-f6be" name="Steeds of Nephet-Ra" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models with at least one Skeletal Horse model part in the bearer&apos;s unit gain Ghost Step and +4 March Rate.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d8a3-e7a4-d738-77b9" name="Sandstorm Cloak - Models on Foot Only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b97-f1de-047d-a988" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d4d-c0e1-0938-25b8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b6ce-d105-048c-a42b" name="Sandstorm Cloak" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Fly (5”, 15”) and can perform a Sweeping Attack that causes 2D6 hits with Strength 2 and Armour Penetration 1.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ae70-8f47-ec89-aca0" name="Book of the Dead" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f664-12a0-45ce-dec9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e698-77b9-8217-00ec" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3df7-816f-f137-4a1b" name="Book of the Dead" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer can cast Death is Only the Beginning as a Bound Spell with Power Level (4/8) and the following modifications: The spell is considered a Learned Spell (Instead of an Attribute Spell) and its Range is changed to 12&quot; Aura.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f20a-b6e9-54e1-de8d" name="Sacred Hourglass - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff22-1025-4422-df26" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81ce-c0da-bb9c-b207" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="962f-f40d-9632-e7b5" name="Sacred Hourglass" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer may reroll failed Casting Attempts that were rolled using 2 Magic Dice (by rerolling both Magic Dice).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="650d-0977-fb36-034a" name="Blessed Wrappings" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cfd-b5ca-3f6d-bae1" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f444-4c6e-45c4-529c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8845-fb38-7ace-52de" name="Blessed Wrappings" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +1 Health Point and loses Flammable if it had it (note that this does not prevent the model from gaining Flammable from other sources).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a820-de8a-2f74-cff8" name="Scroll of Desiccation" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4367-6a35-5de0-4781" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1faf-7578-8133-6eac" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="77e5-6635-ad7d-30f9" name="Scroll of Desiccation" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">After Determining Deployment Zones (at the end of step 6 of the Pre-Game Sequence), choose a Forest, Water, or Field Terrain Feature. This Terrain Feature ceases to be the Terrain Feature it used to be and loses all its rules. It is treated as Dangerous Terrain (1) for all enemy units.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6f95-6ac3-e77d-7ab9" name="Death Mask of Teput" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="93b9-e224-e36b-d63c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="17bd-51fb-5839-2b4c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d69e-19cc-e7a4-deab" name="Death Mask of Teput" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefacts</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models in enemy units in base contact with the bearer suffer -2 Offensive Skill.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="774e-115b-7473-7c20" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9550-b83d-9709-0fa0" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="f08e-74f0-941a-9eaa" name="UD Weapon Enchantments" hidden="false" collective="false" targetId="4c8e-8b61-d6fe-8ee1" type="selectionEntryGroup"/>
+        <entryLink id="f0a9-5b09-7be1-a1cf" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6acc-67ca-6961-c964" name="Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="191a-79a1-59d6-2f59" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="191a-79a1-59d6-2f59" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="97cc-c3a3-9e3d-76ba" name="UD Armour Enchantments" hidden="false" collective="false" targetId="749d-58a3-0ef5-39ab" type="selectionEntryGroup"/>
+        <entryLink id="8bb4-6daf-5220-9875" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3677-bc9b-b029-4055" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78ac-15a9-ba28-cbfd" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="1866-a3be-a96b-b0e8" name="UD Artefacts" hidden="false" collective="false" targetId="6ac6-0dfd-b376-d9e3" type="selectionEntryGroup"/>
+        <entryLink id="c6a1-25c7-0212-019b" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="5fa7-01d3-9aa2-2756" name="Resurrected" hidden="false">
+      <description>The number in brackets (), determines the number of Health Points Raised with Death is Only the Beginning (Hereditary Attribute Spell).</description>
+    </rule>
+    <rule id="61b8-31b1-d20f-6334" name="Hierophant" hidden="false">
+      <description>One of a Kind. An Undying Dynasties Army must include a single model with this Universal Rule. When a Hierophant casts Death is Only the Beginning as a non-bound spell, it may choose to target a friendly unit within 18&quot; (instead of the spells normal target restrictions).</description>
+    </rule>
+    <rule id="8d07-0aa4-6c27-79a6" name="Dust to Dust" hidden="false">
+      <description>At the end of any phase in which the Hierophant is removed as a casualty, every unit in the Army with Dust to Dust must pass a Discipline Test or lose a number of Health Points equal to the amount by which the test was failed, with no saves of any kind allowed. These lost Health Points are distributed following the rules for Unstable. The number of Health Points lost is reduced by 1 if the unit is affected by Rally Around the Flag.
+
+At the end of the Player Turn in which the Hierophant was removed as a casualty, a new Hierophant may be selected. In order to do so, nominate a friendly Wizard Character. This Character becomes the new Hierophant.
+
+At the start of each friendly Player Turn after the Army&apos;s Hierophant has been removed as a casualty and no new Hierophant has been selected, every unit with Dust to Dust must once again pass a Discipline Test or lose Health Points as described above.</description>
+    </rule>
+    <rule id="20df-ea5e-7ab6-6613" name="Ensouled Statue" hidden="false">
+      <description>The model gains Undead and Dust to Dust. If more than half of the models in a unit have Ensouled Statue, reduce the number of Health Points lost by this unit due to Dust to Dust and Unstable by 1.</description>
+    </rule>
+    <rule id="3a23-85ab-6fb7-3816" name="Undying Will" hidden="false">
+      <description>Models in a unit with one or more models with Undying Will gain +2 Offensive Skill, +2 Defensive Skill, Lethal Strike, and replace their Shooting Weapons&apos; Aim with (4+). Characters, Beasts, models with Ensouled Statue, and model parts with Harnessed are not affected by Undying Will.</description>
+    </rule>
+    <rule id="d95c-2fec-ef44-1a3b" name="Autonomous" hidden="false">
+      <description>Undead units consisting entirely of models with Autonomous may perform March Moves as normal even when outside the range of friendly models’ Commanding Presence. The unit must still pass a Discipline Test in order to do so if within 8&quot; of non-fleeing enemy units.</description>
+    </rule>
+    <rule id="1127-ca1a-3b4b-0aad" name="Underground Ambush" hidden="false">
+      <description>The model follows the rules for Ambush, with the following exception: Instead of entering the Battlefield from a table edge, place the unit anywhere on the Battlefield in a legal formation and following the Unit Spacing rule. Then roll a D6: 
+⦁	If 5-6 is rolled, the unit arrives where it was initially placed.
+⦁	If 1-4 is rolled, move the unit (without changing its Facing) 2D6” in a randomly chosen direction (This does not prevent the unit from moving following the rules for Ambush afterwards). If this would bring the unit within 1&quot; of other units, Impassable Terrain, or the Board Edge, the unit stops 1&quot; short of them and each model in the ambushing unit must take a Dangerous Terrain (1) Test. The unit may then perform a Pivot (and must follow the Unit Spacing rule after the Pivot).</description>
+    </rule>
+    <rule id="1aa0-b4b7-d77c-be14" name="Mummy&apos;s Curse" hidden="false">
+      <description>When the model with Mummy’s Curse is removed as a casualty, the model which caused the final wound suffers 1 hit with Strength 6 and Armour Penetration 10. This is treated as a Ranged Attack. If more than one model was part of the action which brought the downfall of the Character, randomise which of those models the hit is distributed towards .</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="efbc-4974-e8d4-c4c9" name="Aspen Bow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">3</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">0</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Fire. This weapon always hits on a roll equal to or greater than its Aim.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6509-0400-a54d-c254" name="Great Aspen Bow" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">36&quot;</characteristic>
+        <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">1</characteristic>
+        <characteristic name="Str" typeId="f166-13ff-9227-4525">5</characteristic>
+        <characteristic name="AP" typeId="857a-4ce1-d134-8701">2</characteristic>
+        <characteristic name="Attributes" typeId="d988-3828-5f00-7582">Volley Fire. This weapon always hits on a roll equal to or greater than its Aim.</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/vampireCovenant.cat
+++ b/vampireCovenant.cat
@@ -1,0 +1,5459 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="ef6e-1eeb-e440-8944" name="Vampire Covenant 2.0" revision="21" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="dc98-3346-9b99-6af4" name="The Suffering (local)" hidden="false"/>
+    <categoryEntry id="eda3-1b96-c963-9650" name="Swift Death (local)" hidden="false"/>
+    <categoryEntry id="91d5-fdbc-855c-9e2e" name="Core (VC)" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="3595-2e2e-b26d-8f77" name="Vampire Covenant (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="d945-6fc8-48d6-5e6f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="40.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="1dc2-e597-d318-df97" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="9bc6-e217-0d31-e8d9" name="Core (VC)" hidden="false" targetId="91d5-fdbc-855c-9e2e" primary="false">
+          <modifiers>
+            <modifier type="decrement" field="0764-f24a-234a-1f59" value="5">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="99a4-bb9f-a50c-678e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="0764-f24a-234a-1f59" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e448-b967-bfac-8172" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="8094-cb93-3c5a-0468" name="The Suffering (local)" hidden="false" targetId="dc98-3346-9b99-6af4" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="d965-3abd-f95e-4ee6" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="189a-fb46-6e79-94d4" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="30.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="dd7d-f394-d91e-6f81" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="99a4-bb9f-a50c-678e" name="Vampiric Bloodline" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf03-c0d6-b205-5577" type="max"/>
+      </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ad62-6d57-be87-9b90" name="Vampiric Bloodline" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e70-1fc5-4e97-6821" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9172-5158-ff5f-f4d4" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c295-84bf-e3c4-3d59" name="Brotherhood of the Dragon Bloodline" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4200-f3be-f090-a827" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e32-87ad-0b76-aad3" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="543a-c0c2-cc07-4680" name="Lamia Bloodline" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e50a-6f3b-c32b-a8b5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="435c-0353-3393-7807" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4564-c7ad-019e-10cc" name="Nosferatu Bloodline" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd10-a1f8-21d5-6e15" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c32c-4eab-d093-9880" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0a0f-243d-3482-b939" name="Strigoi Bloodline" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e47-9eb3-ec42-1a5b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="848d-35ea-a664-e2cf" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="96f7-15b4-bdfc-a16d" name="Von Karnstein Bloodline" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55fe-0f81-ed77-5d0c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae6b-b749-41eb-ec91" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b36-98dd-f57e-3d11" name="Vampire Count" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="f205-dd5c-ebd0-677e" name="Vampire Count Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="bcb2-5ce8-9e2f-f78d" name="Vampire Count Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="160d-4624-273f-2114" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">7</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c29e-1cf6-0e19-ab04" name="Vampire Count Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="increment" field="7d3b-bb95-3d29-26f7" value="2">
+              <conditions>
+                <condition field="selections" scope="3b36-98dd-f57e-3d11" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="8265-800f-bc87-d00a" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="3b36-98dd-f57e-3d11" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                    <condition field="selections" scope="3b36-98dd-f57e-3d11" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7d3b-bb95-3d29-26f7" value="2">
+              <conditions>
+                <condition field="selections" scope="3b36-98dd-f57e-3d11" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e61a-a8d5-07b9-dcfb" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="0046-1700-6e9c-8a7c" name="Awaken" hidden="false" targetId="ee94-d4bb-defb-f5e4" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Zombies)"/>
+            <modifier type="append" field="name" value=" (Zombies, Skeletons)">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c267-78d1-114d-bde3" name="Autonomous" hidden="false" targetId="6cd9-16c5-3f63-3b44" type="rule"/>
+        <infoLink id="e139-23ab-107b-b41d" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b5bd-e071-30f0-87a2" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e82a-e969-782b-142d" name="Gates of the Netherworld" hidden="false" targetId="9a62-c85f-1f78-e6ba" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b3d8-6c9e-1ccf-7a61" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8294-4ac9-886b-b1a4" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="90da-8e18-b167-ee62" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c91-eab2-c948-201d" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1ed5-5be3-9906-a895" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86ee-27d6-1cf1-ee6b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0c43-53f6-e09d-8fcb" name="Armour Enchantments" hidden="false" collective="false" targetId="3ced-8427-6428-c88a" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="3b36-98dd-f57e-3d11" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4da5-1adf-89d0-38cf" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="c9c8-08f3-d122-5e48" name="Artefacts" hidden="false" collective="false" targetId="0829-f3bd-215b-6820" type="selectionEntryGroup"/>
+                <entryLink id="450b-0590-519f-68e6" name="Weapon Enchantments" hidden="false" collective="false" targetId="ab6e-ba4a-ea93-bbf2" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="32a3-4614-e635-00eb" name="Wizard Level" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="6cba-c23c-6dbd-9dd8" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd25-68f9-eb23-4ffb" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cba-c23c-6dbd-9dd8" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3c8f-c91a-5184-cc40" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37d7-8713-b31f-a107" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bd9b-306d-dc18-d729" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="548f-7875-2726-9151" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f6f3-b405-3d45-d7b2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="cab1-6f0a-8b47-36be" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="171d-ef8e-c1eb-f53e" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a51-d7a4-3496-c790" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="989c-fc31-4bcb-7075" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4da5-1adf-89d0-38cf" name="Armour" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry id="31fe-27ba-4e40-9c68" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d42-67f2-3fa3-c814" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="242f-2eec-e2ba-eddf" name="Does not get Distracting from Lamia Bloodline" hidden="false">
+                  <description>This unit does not get Distracting via the Lamia Bloodline</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="f1f9-1929-db7b-2cd4" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aec5-f145-0a6b-38c1" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a800-081e-e8b1-058e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="828d-aee7-cdd8-39ed" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4109-68e2-c43f-5b27" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="121f-f805-86fd-11a9" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="50ff-7a9e-de13-f2c1" name="Does not get Distracting from Lamia Bloodline" hidden="false">
+                  <description>This unit does not get Distracting via the Lamia Bloodline</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="3f07-9a3e-31b6-c0a5" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3da2-1dfa-9e57-de21" name="Plate Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="3b36-98dd-f57e-3d11" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="596c-bea3-bd13-d684" value="1">
+                  <conditions>
+                    <condition field="selections" scope="3b36-98dd-f57e-3d11" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="596c-bea3-bd13-d684" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b59a-1edb-0406-a356" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="658f-e377-6b39-1d3b" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7ab1-8909-f0f1-9bae" name="Melee Weapon" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="89fb-50fd-c5cf-7b0d" value="-1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="89fb-50fd-c5cf-7b0d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="743e-95ba-5b05-f873" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4dee-d044-a646-e644" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b2a9-74ac-278f-ee95" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="63d5-73f9-3747-4d8d" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8325-19ec-45df-c044" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d62d-64f3-2869-d6e5" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d2d7-9fa9-f982-f497" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c683-5fb8-c2bf-54f9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="12a1-9295-0eb2-ffc1" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d775-94b6-22ca-1b12" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e33-4123-9a15-ee1c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5e6d-c41a-0171-5c66" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2d06-5f45-c74d-a8b4" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="870c-1d31-f7ec-7e1c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="da37-6da8-d851-bd3a" name="Skeletal Steed" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff13-a632-4eec-ab29" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="71a0-6658-1c6a-5472" name="Skeletal Steed" hidden="false" collective="false" targetId="cee8-4ec7-c374-1b1c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b7e9-f51e-d707-836d" name="Spectral Steed" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e96-4524-2ebc-9139" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e53e-1114-71bc-1a3c" name="Spectral Steed" hidden="false" collective="false" targetId="1ab7-28e6-a76e-680e" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5b1e-d3e0-4757-a34c" name="Monstrous Revenant" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86d3-18b4-204b-38d2" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="5729-1f28-205b-8587" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="6b18-a443-7779-848e" name="Monstrous Revenant" hidden="false" collective="false" targetId="8908-1292-8a37-d207" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4ab5-51d0-5b33-2443" name="Court of the Damned" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9970-da9c-8878-7b0b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e8dc-184b-1d80-4951" name="Court of the Damned" hidden="false" collective="false" targetId="480f-80cb-b650-da3f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="350.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="380a-27c5-cbe7-2cdb" name="Shrieking Horror" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe0e-7bd9-1fa5-d087" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="5500-ff73-99b9-59bd" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="152b-f3ad-dbff-bacd" name="Skeletal Steed" hidden="false" collective="false" targetId="cee8-4ec7-c374-1b1c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="430.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4d04-9fb5-ad85-3706" name="Zombie Dragon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f0d-0dc7-9aa9-98fa" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="3cb6-5ddd-e21c-f16a" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="08b2-5861-dd03-f672" name="Zombie Dragon" hidden="false" collective="false" targetId="d516-1369-f91d-3853" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="385.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a59d-9087-c120-43f1" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="9c5d-7cd3-41e6-092a" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32a3-4614-e635-00eb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32a3-4614-e635-00eb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="34c1-42c4-0fd1-d0a2" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c5d-7cd3-41e6-092a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34c1-42c4-0fd1-d0a2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2237-baeb-ac1f-b05b" name="Occultism" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb10-8db0-2d1e-279f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="af1d-3ddb-a25b-b297" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6dc0-aaf3-e075-12c7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7cfe-6c9a-b763-b9ba" name="Witchcraft" hidden="true" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1c8-5524-39fd-cf3d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0f97-f481-7127-c23d" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a52a-e209-1532-9a36" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7bc0-bd86-b47f-f1d0" name="Cosmology" hidden="true" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37b3-6ab0-cbdd-b1f0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7a9f-3e34-14f9-100c" name="Blood Powers" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f7d-072f-8fc6-439a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f66a-8ebe-20df-5d1f" name="Ancient Blood Powers" hidden="false" collective="false" targetId="8aaa-efe8-5149-ecb6" type="selectionEntryGroup"/>
+            <entryLink id="bc1a-54cb-a848-ec7f" name="Lesser Blood Powers" hidden="false" collective="false" targetId="3e3c-20fe-5381-2e4a" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="972f-e8b9-2148-4eaa" name="Army General" hidden="false" collective="false" targetId="f9bd-8831-67db-b5ec" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="25"/>
+          </modifiers>
+          <categoryLinks>
+            <categoryLink id="bf98-0499-97d5-cd3f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+        <entryLink id="fbb4-f3d3-b386-e49e" name="Vampiric Bloodline" hidden="true" collective="false" targetId="fa72-d202-5a3a-962a" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99a4-bb9f-a50c-678e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="330.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5b95-c805-8b50-1156" name="Vampire Courtier" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="db82-9f25-5dab-c010" name="Vampire Courtier Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5bf0-7381-5a80-6a30" name="Vampire Courtier Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="increment" field="160d-4624-273f-2114" value="2">
+              <conditions>
+                <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="ec15-bc66-645e-db5d" value="1">
+              <conditions>
+                <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c013-20c2-e4bb-41f5" name="Vampire Courtier Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="increment" field="7d3b-bb95-3d29-26f7" value="2">
+              <conditions>
+                <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="8265-800f-bc87-d00a" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                    <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7d3b-bb95-3d29-26f7" value="2">
+              <conditions>
+                <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9e07-7eec-353f-19e9" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="7c90-e342-0bf4-cacc" name="Awaken" hidden="false" targetId="ee94-d4bb-defb-f5e4" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Zombies)"/>
+            <modifier type="append" field="name" value=" (Zombies, Skeletons)">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fe29-cc50-5b76-6ad0" name="Autonomous" hidden="false" targetId="6cd9-16c5-3f63-3b44" type="rule"/>
+        <infoLink id="089f-2228-5ff9-ea6c" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="aed7-92f5-1977-630c" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e511-ed21-c000-1b40" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7208-3e1e-48e4-7fec" type="equalTo"/>
+                        <condition field="selections" scope="5b95-c805-8b50-1156" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83a1-0dec-9582-ad63" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7dc5-3463-2f31-8723" name="Gates of the Netherworld" hidden="false" targetId="9a62-c85f-1f78-e6ba" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f7ea-8fa9-c975-d9a9" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6000-2b65-e7f2-58d8" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8676-59d1-9d8d-c01e" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f250-3b4c-0991-e7d8" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0c8d-58e1-38b5-70aa" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ceb6-0097-ae8a-6758" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b5f8-1fbe-a662-07ee" name="Armour Enchantments" hidden="false" collective="false" targetId="3ced-8427-6428-c88a" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="5b95-c805-8b50-1156" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d41-a5c3-0b06-bfdb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="dc95-4921-a9b0-7b06" name="Artefacts" hidden="false" collective="false" targetId="0829-f3bd-215b-6820" type="selectionEntryGroup"/>
+                <entryLink id="6391-1203-7f7d-cbf4" name="Weapon Enchantments" hidden="false" collective="false" targetId="ab6e-ba4a-ea93-bbf2" type="selectionEntryGroup"/>
+                <entryLink id="f255-ba31-4e67-de92" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="5b95-c805-8b50-1156" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="435d-84d2-83fe-5a7d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="435d-84d2-83fe-5a7d" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="45b0-a08a-3c70-564e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="dbde-a92c-1204-6907" name="Battle Standard Bearer" hidden="false" collective="false" targetId="efb4-f04c-8589-ad57" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8366-ecf3-b1c8-3c87" name="Wizard Level" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="dd84-f3fc-5ca4-29e7" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="74e5-50ee-24a8-28d6" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd84-f3fc-5ca4-29e7" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5a28-e2ce-757e-8d16" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f5a3-0ec1-02a2-becf" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2381-58d7-9571-7621" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7409-0b12-82e9-a09b" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f18a-cddb-4c30-9075" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e159-436b-5aa5-734d" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7796-68c8-50ba-e5dd" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d9c-da05-aa1a-9803" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7895-acda-7e88-13a5" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="255.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5d41-a5c3-0b06-bfdb" name="Armour" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry id="7208-3e1e-48e4-7fec" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7710-1147-65fc-920f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="78d9-dce6-89a1-7d3c" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4ff3-bb61-53d6-d17b" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2a3-776e-e631-50fe" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a544-c493-8951-a54f" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="83a1-0dec-9582-ad63" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9566-5aa2-baac-532a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bc81-a6eb-0421-3dab" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="afa3-c0c3-b21c-007b" name="Plate Armour" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="5b95-c805-8b50-1156" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="8f72-601a-8d76-ed4d" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="5b95-c805-8b50-1156" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f72-601a-8d76-ed4d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0d2-6336-94a7-4f75" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="412f-7eea-43a3-aa3f" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4d6e-f2b7-74c0-283f" name="Melee Weapon" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="511a-7ecf-d3c5-e6cc" value="-1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="511a-7ecf-d3c5-e6cc" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fd44-66dd-030b-9d1b" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e831-9a7c-b1d7-87be" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e0bf-5722-5454-5700" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="606f-0e16-148b-3261" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a107-c86d-2c38-b6dd" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e00a-db72-846a-a616" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dbb8-bf15-459f-1710" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bc87-3c74-ce40-81d9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="29ec-0e42-7a13-cfc1" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="76dc-c669-1c16-db64" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a54-7610-27f5-eed6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="767a-40f9-c5f2-1fb0" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4fa0-8665-86bf-a6a7" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c2a-d221-9dc7-ec22" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4818-1cba-81d6-4830" name="Skeletal Steed" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d20e-76a2-40ec-4c96" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ee7e-4300-19a3-d1cd" name="Skeletal Steed" hidden="false" collective="false" targetId="cee8-4ec7-c374-1b1c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4df-9ae8-70a1-ad90" name="Spectral Steed" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cef2-1f4e-d291-f7cb" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6fd7-3b98-62d9-f83a" name="Spectral Steed" hidden="false" collective="false" targetId="1ab7-28e6-a76e-680e" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="75dc-b8a4-3321-40a6" name="Monstrous Revenant" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbe7-4113-c475-b26a" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="45fd-23c6-0524-7763" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="2d8a-42ad-6309-429e" name="Monstrous Revenant" hidden="false" collective="false" targetId="8908-1292-8a37-d207" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f775-97ac-5d47-65f0" name="Court of the Damned" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1db4-9038-da30-06a0" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6637-0b3b-c1c5-b74d" name="Court of the Damned" hidden="false" collective="false" targetId="480f-80cb-b650-da3f" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="350.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1d2a-ef3e-e314-26cd" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="92c8-537c-3b38-8996" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8366-ecf3-b1c8-3c87" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8366-ecf3-b1c8-3c87" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="a9b3-bd4a-3599-591d" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="92c8-537c-3b38-8996" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9b3-bd4a-3599-591d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3c11-a41a-f027-a6d4" name="Occultism" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8495-7aaf-1ff2-eb00" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="358d-af57-146f-9635" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b915-debd-759a-b19a" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7634-a8cc-915c-ffa9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b1dc-627c-c728-2aae" name="Witchcraft" hidden="true" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d71b-a9be-2a80-2928" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4596-c5e6-c8cd-16c5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7e43-b4bc-501b-441c" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a0ca-ca35-d660-ad99" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="224c-de7a-ab88-88a9" name="Cosmology" hidden="true" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4bd-bf0c-bd1e-303e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed94-16bb-f9b3-ad6e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="df46-e464-7a9b-1eaf" name="Army General" hidden="false" collective="false" targetId="f9bd-8831-67db-b5ec" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="25"/>
+          </modifiers>
+          <categoryLinks>
+            <categoryLink id="cb95-24f4-8e1c-a33f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+        <entryLink id="4f75-59ce-665b-edc2" name="Lesser Blood Powers" hidden="false" collective="false" targetId="3e3c-20fe-5381-2e4a" type="selectionEntryGroup"/>
+        <entryLink id="e503-879d-bb51-76bf" name="Vampiric Bloodline" hidden="true" collective="false" targetId="fa72-d202-5a3a-962a" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99a4-bb9f-a50c-678e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="38d9-b2df-62ca-93dc" name="Necromancer" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="7d4b-51ce-0892-0fef" name="Necromancer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0eec-c49a-d126-d66e" name="Necromancer Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="71cc-61f6-a126-c918" name="Necromancer Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d5ea-b0e0-0cb7-bb2d" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="3074-f18e-614c-f6cb" name="Gates of the Netherworld" hidden="false" targetId="9a62-c85f-1f78-e6ba" type="rule"/>
+        <infoLink id="29f5-2c9c-1dc6-a20c" name="Awaken" hidden="false" targetId="ee94-d4bb-defb-f5e4" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Zombies, Skeletons)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9cd0-5560-4c80-cccb" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="24e8-7224-bb0d-f5c9" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d47a-c320-219c-42b1" name="Light Armour" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b71d-89ea-85ed-8388" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2c24-a930-63ce-5104" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c733-bec7-772a-b2fe" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3299-b35a-7680-cf03" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="14cc-c369-104e-14b5" name="Special Equipment" hidden="false" collective="false">
+              <modifiers>
+                <modifier type="set" field="97a8-cf78-06fc-046f" value="200">
+                  <conditions>
+                    <condition field="selections" scope="38d9-b2df-62ca-93dc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6271-a5da-06cc-130f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="97a8-cf78-06fc-046f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5d27-e43f-9e19-25b0" name="Armour Enchantments" hidden="false" collective="false" targetId="3ced-8427-6428-c88a" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="38d9-b2df-62ca-93dc" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d47a-c320-219c-42b1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="2ebb-07bf-756d-a16e" name="Artefacts" hidden="false" collective="false" targetId="0829-f3bd-215b-6820" type="selectionEntryGroup"/>
+                <entryLink id="074c-e127-405c-2fda" name="Weapon Enchantments" hidden="false" collective="false" targetId="ab6e-ba4a-ea93-bbf2" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="55f8-6c4e-30e8-0795" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="e699-b975-c743-a0e5">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2788-e566-8b24-f7a4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3394-8f67-00f7-c59c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e699-b975-c743-a0e5" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf8c-f280-1214-a368" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4edd-83b7-4aef-f6ce" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="5e4f-19f7-a8e9-42c2" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a58b-c4b3-0493-8acb" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4913-e6b6-ba02-48a5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3dd5-8b9d-6218-baec" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6271-a5da-06cc-130f" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d64-e3f5-7061-2503" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a211-3fe8-2cc1-d61a" name="Wizard Master" hidden="false" targetId="fa5b-1bdc-8550-50c7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8044-38e2-ff26-393b" name="Path" hidden="false" collective="false">
+          <modifiers>
+            <modifier type="set" field="ef1a-db1c-53ce-4376" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d573-9ee1-1065-6f24" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef1a-db1c-53ce-4376" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3490-904f-3bd0-508f" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b97e-43fd-81a5-bf4d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="abba-93e6-7243-95a8" name="Alchemy" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f82c-bd80-0fa5-e709" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ffac-aceb-bd05-aea1" name="Mount" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd9d-28a4-2a6c-4819" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9f48-d0b7-3169-6f2d" name="Skeletal Steed" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f61d-df40-9fcf-4e06" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0323-54c1-8154-761a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2a44-3174-8156-109c" name="Skeletal Steed" hidden="false" collective="false" targetId="cee8-4ec7-c374-1b1c" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2052-2691-2143-ee7c" name="Cadaver Wagon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6067-fdf4-a075-eb06" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="70fc-59e8-34d2-e94a" name="Cadaver Wagon" hidden="false" collective="false" targetId="f1b3-993f-1106-82c9" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="340.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="56f8-a25f-8bb2-5633" name="Monstrous Revenant" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6271-a5da-06cc-130f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="18bc-c525-e2b1-0f50" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="53e0-7fbb-4835-5948" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="d941-5904-a3a5-bb85" name="Monstrous Revenant" hidden="false" collective="false" targetId="8908-1292-8a37-d207" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9054-c398-9938-faa5" name="Army General" hidden="false" collective="false" targetId="f9bd-8831-67db-b5ec" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="30"/>
+          </modifiers>
+          <categoryLinks>
+            <categoryLink id="b7ca-7c3e-cafa-d05c" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8325-70e6-d4cf-7dc1" name="Barrow King" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="19c3-a783-f68b-bd77" name="Barrow King Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f52b-ffe1-0162-6aad" name="Barrow King Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cafb-e6e0-bf4f-89e1" name="Barrow King Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="d10e-c849-a722-706f" name="Unliving Shield" hidden="false">
+          <description>Enemy models cannot allocate Close Combat Attacks towards a Necromancer as long as they can allocate attacks towards a model with Unliving Shield in the same unit as the Necromancer. This rule cannot be used if there are also models with Vampiric in the same unit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0faa-a19d-c445-a50b" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="e7b3-05be-dacc-2028" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="8490-4240-f99e-1ddf" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="24aa-c194-bd60-fe7f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="4b47-d659-7289-33a7" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="f64e-ecb9-4b2e-7054" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="3a10-bab9-aab0-aaa0" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="0b11-af40-0517-235f" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, Against Standard)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b51c-fa5c-85a4-98f8" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1761-de2c-ad12-8382" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e020-fcd9-1a77-1248" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="946b-3218-5178-57dd" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="34e8-e5f2-245a-adaa" name="Battle Standard Bearer" hidden="false" collective="false" targetId="efb4-f04c-8589-ad57" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9e8d-cd61-d997-7c3d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9992-d57b-e10e-9578" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e379-4a7a-49ed-36a7" name="Special Equipment" hidden="false" collective="false">
+              <constraints>
+                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="150.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81a1-bf5c-9599-6588" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e578-84f8-55c1-575e" name="Armour Enchantments" hidden="false" collective="false" targetId="3ced-8427-6428-c88a" type="selectionEntryGroup"/>
+                <entryLink id="e7a3-e83c-7c97-f411" name="Artefacts" hidden="false" collective="false" targetId="0829-f3bd-215b-6820" type="selectionEntryGroup"/>
+                <entryLink id="a594-ad6b-b23d-061a" name="Weapon Enchantments" hidden="false" collective="false" targetId="ab6e-ba4a-ea93-bbf2" type="selectionEntryGroup"/>
+                <entryLink id="b012-059b-de5b-f4bc" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="8325-70e6-d4cf-7dc1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e020-fcd9-1a77-1248" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a1ff-d14f-b25a-a52e" name="Skeletal Steed" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6fa-2f66-a89c-e7d3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c00f-3581-cbf6-acfc" name="Skeletal Steed" hidden="false" collective="false" targetId="cee8-4ec7-c374-1b1c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3470-b857-a358-2af2" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1203-0a71-53ff-4da4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a6e4-b7e0-df1b-1fad" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="031a-72ec-aab0-3ec1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="235b-7d2e-31cb-9cb2" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4821-f149-beff-f41e" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="27f4-3408-85b7-0dea" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="787b-7cf4-6cde-d6e3" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ead4-649e-51ec-e98e" name="Lance" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47f5-322a-1dd6-c4b8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="44f1-5b1a-c326-1fd4" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fc36-236e-b965-ab88" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7de7-1d65-756c-b842" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="680e-59f7-ad39-4748" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="175.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7a91-ba86-bdd7-d0e3" name="Fell Wraith" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="b6d9-e068-3f3a-3a4d" name="Fell Wraith Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7a35-94f7-068f-b006" name="Fell Wraith Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d8aa-6f76-e7a0-488b" name="Fell Wraith Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">10</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="05d6-0601-b1b6-1da4" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="8082-68de-2c08-afb2" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="e177-f9d5-41c1-317a" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="60d8-db2e-db2e-4400" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="2856-f8dd-aa97-ca6e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="336f-1988-c4a5-6bb1" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="56d7-d626-1bfe-7bb6" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a4ef-c2b2-de1f-2911" name="Ghostly Form" hidden="false" targetId="9221-c547-a843-bdb0" type="rule"/>
+        <infoLink id="f48c-8a33-1498-1206" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+, against non-Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4029-4517-2005-353f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="6fc9-a8b0-1fab-7827" name="The Suffering (local)" hidden="false" targetId="dc98-3346-9b99-6af4" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2aba-5265-96f2-ba73" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64bc-ffb8-549f-97d9" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1bf6-a300-6390-a28c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="04fa-bb15-2277-6fae" name="Skeletal Steed" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e04-85a3-6792-7941" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5b9a-2fc5-70d7-e406" name="Skeletal Steed" hidden="false" collective="false" targetId="cee8-4ec7-c374-1b1c" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="fc5b-214f-104c-fe66" name="Reaper" hidden="false" collective="false" targetId="4ae1-bf77-3f6f-bc33" type="selectionEntry"/>
+        <entryLink id="ae6c-9a49-8373-b06d" name="Weapon Enchantments" hidden="false" collective="false" targetId="ab6e-ba4a-ea93-bbf2" type="selectionEntryGroup">
+          <constraints>
+            <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6b88-242d-998b-6d42" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b2d-bed8-c784-9d57" name="Banshee" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="5b40-e422-aafe-fd73" name="Banshee Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1d40-82d8-8fce-c663" name="Banshee Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="dc89-0dae-5b1d-579e" name="Banshee Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="2f0c-e51c-7fa1-ecda" name="Wail of Woe" hidden="false">
+          <description>A model with this Special Attack can use it as a Shooting Attack and as a Special Attack in Close Combat.
+- As a Shooting Attack (normally in the Shooting Phase): Choose a target using the normal rules for Shooting Attacks, except it can be used even if the model performed a March Move previously in this Player Turn. It has Range 8&quot; and inflicts D6+2 hits with Strength 4, Armour Penetration 1, and Magical Attacks.
+- As a Special Attack in Close Combat (normally in the Melee Phase): The attack is made at the model part&apos;s Initiative Step. Declare that you are using Wail of Woe when allocating attacks. If used, the model part cannot make Close Combat Attacks. Choose a single unit in base contact as the target. The target unit suffers D3+1 hits with Strength 4, Armour Penetration 1, and Magical Attacks.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8209-e18c-f6d2-8385" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="00b7-08cd-6f95-8f58" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="1c19-7980-82f5-6b48" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="c92d-7535-44a4-7025" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="5c37-8a83-f6e7-ce63" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="055f-7913-cab7-44fd" name="Ghostly Form" hidden="false" targetId="9221-c547-a843-bdb0" type="rule"/>
+        <infoLink id="1c4b-ec3f-0adb-d73e" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2a3a-29ca-c5dd-ee57" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+, against non-Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d536-e4b3-342f-c627" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3e06-a92c-ce52-fa73" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+        <categoryLink id="b7eb-f3ae-b24a-b77e" name="The Suffering (local)" hidden="false" targetId="dc98-3346-9b99-6af4" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7316-5263-8df8-5613" name="Reaper" hidden="false" collective="false" targetId="4ae1-bf77-3f6f-bc33" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="165.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="981a-f36d-fc6d-d1c0" name="Zombies" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56ac-2882-f94e-6f1f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="0720-c98e-0f05-b648" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="b066-be3a-9deb-c5dd" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="2e4c-74a2-d36f-5d1e" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="bcde-8686-a6ac-2b6a" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2D6+4)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f34b-1a46-32e8-cb92" name="New CategoryLink" hidden="false" targetId="91d5-fdbc-855c-9e2e" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="16c6-ce1e-3b4c-31a2" name="Zombie" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="921c-08ab-0ce4-a2c6" type="min"/>
+            <constraint field="selections" scope="parent" value="80.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb11-9e48-263d-a44d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b9b8-e8f2-cce4-31c7" name="Zombie Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">2</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6951-6dfb-183d-4b1f" name="Zombie Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">1</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9a91-2dd0-5170-f80e" name="Zombie Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">1</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="26a3-0ff3-9f57-2a03" name="Command Group" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="ad35-3e37-2298-2c40" name="Musician" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c77a-51fd-6f12-35c8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1ce0-3b78-42ed-a3b0" name="Standard Bearer" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2abd-9300-1b52-5059" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84e9-3540-28ba-30c5" name="Skeletons" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="8fbd-7bfe-e839-6829" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="f053-99af-12bc-a42c" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="ff35-3901-d691-d1cf" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="1e05-cb48-d298-b890" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
+        <infoLink id="b563-cbe7-ff40-aee8" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="d4ca-cf0c-884c-acf4" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+4)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0209-251f-fb14-6546" name="New CategoryLink" hidden="false" targetId="91d5-fdbc-855c-9e2e" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3fed-d6cb-11e5-4462" name="Skeleton" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a5c4-aad7-969b-6b45" type="min"/>
+            <constraint field="selections" scope="parent" value="60.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a65b-b383-6cde-5ab4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1ceb-321d-cb6b-4274" name="Skeleton Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d2dd-2782-c950-aa0e" name="Skeleton Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">2</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a159-42f4-a09b-33b0" name="Skeleton Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a9e7-077d-d520-a573" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1e87-dd08-2a15-ee1e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3977-93a0-a1c7-dec5" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf64-c0a8-c7ac-d28d" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e1cd-6ca3-c07b-ac50" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f6a0-b11b-dd06-1cea" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="84e9-3540-28ba-30c5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3fed-d6cb-11e5-4462" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef30-6e86-a851-b9e9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dd31-9bd9-2234-ff00" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4935-b5d8-428f-0f5c" name="Spear" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="84e9-3540-28ba-30c5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3fed-d6cb-11e5-4462" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f747-22c1-c856-5a74" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5c03-9ae6-4849-72c5" name="Spear" hidden="false" targetId="c18a-75bb-fa2f-f7cf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ea2f-337a-f090-7dea" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e7a-b5e9-c79e-f284" name="Ghouls" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fec2-2ba9-8036-ef99" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="1678-3522-866c-3ff2" name="First Raised" hidden="false">
+          <description>As long as the unit has a Champion, it can perform Swift Reforms as if it had a Musician.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7ce0-2e1b-a1bc-846b" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="8dc6-7828-cbe0-5974" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="0cf7-e1d7-2692-7a32" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="1549-c644-e5e7-000d" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+4)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="cfe7-ff6c-b28b-5921" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="b2e0-71e3-160b-6648" name="Unholy Appetite" hidden="false" targetId="1a5e-a0a2-3a1f-6f38" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b91b-4b13-42f3-8ead" name="New CategoryLink" hidden="false" targetId="91d5-fdbc-855c-9e2e" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f580-5aaa-7232-fb12" name="Ghoul" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="0ce2-5e05-449a-42bf" value="35">
+              <conditions>
+                <condition field="selections" scope="6e7a-b5e9-c79e-f284" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96bb-70e3-7282-a899" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2725-dc1e-ccd3-b810" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7204-2a94-8d6d-dd17" type="max"/>
+            <constraint field="selections" scope="roster" value="800.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ce2-5e05-449a-42bf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3be8-8fed-aeaf-afa6" name="Ghoul Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">6</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0af6-d5bc-dbba-9e7f" name="Ghoul Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="19f0-6530-7117-abce" name="Ghoul Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="989b-f6d5-0c74-9534" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b00c-c8c4-87ae-b8ef" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="96bb-70e3-7282-a899" name="Vanguard" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+              <repeats>
+                <repeat field="selections" scope="6e7a-b5e9-c79e-f284" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f580-5aaa-7232-fb12" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae16-0942-f910-636e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fa30-4ee4-de26-6b99" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8c18-da40-6bdd-33b0" name="Bat Swarms" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="629c-e6ae-d903-a7a4" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="bdba-a77f-da2c-24a0" name="Storm of Wings" hidden="false">
+          <description>Enemy units in base contact with one or more Bat Swarms suffer -1 Offensive Skill and -1 Defensive Skill.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="bf07-c291-4621-474c" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="a536-2b7a-c58f-beb5" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="e25d-9209-bec0-1552" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="ef9a-7566-d8be-79f0" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="be18-bde2-747e-0452" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="248d-0ca0-9e21-be49" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+4)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="ce92-df33-1242-d68c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2373-f2d0-df8a-086e" name="Bat Swarm" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="672d-1841-3122-04c7" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eebd-e6bb-94be-0281" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="af82-5aaa-dc7e-b8fa" name="Bat Swarm Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">1&quot; (6&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">2&quot; (12&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">3</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f95d-f31e-57db-93f4" name="Bat Swarm Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">2</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="16d4-ccad-dfb9-a6d8" name="Bat Swarm Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">2</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="689c-29f9-e847-e5f8" name="Dire Wolves - Special" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="7f73-8998-5511-6aaa" value="1">
+          <repeats>
+            <repeat field="selections" scope="91d5-fdbc-855c-9e2e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2180-47ba-81f8-3558" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f73-8998-5511-6aaa" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="619c-5831-144c-6242" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="32f6-87b1-f4f7-3976" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="e230-50e5-e26a-6fd5" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="6cb3-4929-81cd-edb6" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d697-3a82-a38a-339d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d09a-d654-67b2-967d" name="Dire Wolves" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c37e-7352-a2c4-f6c9" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b86f-e445-7e7a-0d23" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="680c-216d-2c8d-9549" name="Dire Wolves Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">3</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="bc93-831a-1f7a-1952" name="Dire Wolves Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1697-904f-0b3d-4d51" name="Dire Wolves Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="11.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f85d-4395-2755-4cd7" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c092-97e4-4511-74a4" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2180-47ba-81f8-3558" name="Dire Wolves - Core" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="decrement" field="31c9-6268-83fa-540b" value="1">
+          <repeats>
+            <repeat field="selections" scope="f8f1-3d4f-12bf-73cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="689c-29f9-e847-e5f8" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="31c9-6268-83fa-540b" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ab8a-aeb3-936e-0f62" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="b011-51de-1071-4d68" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="76ac-82bb-fe26-ef61" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="48fa-bd50-7dbf-dbc2" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3f6b-9ad8-7410-a978" name="New CategoryLink" hidden="false" targetId="91d5-fdbc-855c-9e2e" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="28c1-997c-3892-d1b7" name="Dire Wolves" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d964-e5af-a811-cdfa" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9073-76fb-e2fe-63a4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="83f3-4948-e425-0495" name="Dire Wolves Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">9&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">18&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">3</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="5dd2-4452-ab7d-0aac" name="Dire Wolves Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="933c-9059-8c6f-2b48" name="Dire Wolves Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="11.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6e0d-a3c1-ffc5-6372" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fed0-1f21-d443-5443" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c91-2a29-a64e-d73d" name="Barrow Guard" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="f28f-a95b-ba96-eb97" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="1284-24f6-91d9-585c" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="c4a6-3206-7363-d3f8" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="005d-d47b-ecde-bc2f" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="e1e7-f3d6-c5cf-5f84" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+4)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ad51-b184-f62a-9ec4" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (General, Barrow King)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b03d-8a15-a841-e786" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="d85d-2db7-783d-66af" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="3ef8-9528-40c8-07d0" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, Against Standard)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2595-90f1-7653-5357" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f80a-2dfe-f721-edc4" name="Barrow Guard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecab-5a32-d819-e40f" type="min"/>
+            <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09c9-8e4d-1880-630b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c5a5-252c-91ce-6b44" name="Barrow Guard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="cff7-dfaf-6bdc-ad63" name="Barrow Guard Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a598-54bd-400d-5dea" name="Barrow Guard Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="22.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="df72-0073-af09-9264" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36cf-5dd5-6315-51ea" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5919-a2eb-d0c3-4c36" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a7d-1177-b535-da0d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9ea3-0d21-b858-ea76" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="26a5-7cba-81cd-fb0b" name="Black Standard of Zagvozd" hidden="false" collective="false" targetId="4d59-7f50-8df7-240c" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7be7-f8dd-1259-58f2" name="Options" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="55c2-1077-cc3b-a655" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ba0c-8fb4-9ee8-41f2" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                  <repeats>
+                    <repeat field="selections" scope="6c91-2a29-a64e-d73d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f80a-2dfe-f721-edc4" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ccc-34c6-2d8e-fbfa" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c53e-4666-0c53-7a11" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b2a8-1dfb-b73a-688f" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="6c91-2a29-a64e-d73d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f80a-2dfe-f721-edc4" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="966a-6436-a8f2-54f8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b541-1ce1-487f-710f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6817-ba73-585b-e386" name="Shield" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="6c91-2a29-a64e-d73d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f80a-2dfe-f721-edc4" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dd25-62bb-0c07-d330" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7f8f-69bc-b51c-2aca" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e806-6d1d-cc11-db7b" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-155.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4bcf-0f30-7065-a8f7" name="Barrow Knights" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68cd-b7f0-ed3e-2b2b" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ab15-e587-034a-7e4f" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="e204-d51a-aa08-83d6" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="428d-b541-61c3-366f" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="dbf5-3331-1102-6970" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="86e2-bb16-9f70-4686" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3b9d-7cfb-a21d-0398" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="4998-7c16-cb72-27f3" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="1f64-bf84-87a7-a283" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2, Against Standard)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e1de-69e6-3d59-8340" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="d37c-2277-890d-69ea" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="9ff4-5e4a-3857-261b" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="8321-4b4a-4d58-a88c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b039-09fe-6596-0c3b" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6f20-976f-f58b-2da1" name="Barrow Knight" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8777-5930-755b-63b4" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0766-800a-9272-4f00" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="755f-3a15-f1ab-5c51" name="Barrow Knight Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="e5f5-0e52-0883-6906" name="Barrow Knight Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="881d-420f-c449-f9e7" name="Barrow Knight Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="868f-2de1-12d9-def3" name="Skeletal Steed Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="48.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0bb7-fce7-a07a-3352" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d04f-5aff-5f77-24a6" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5710-01b8-edc6-bf20" name="Banner Enchantments" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec51-2b61-8f3b-848a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c3d3-a7f5-4fcf-9029" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="963a-885e-21ca-44ac" name="Black Standard of Zagvozd" hidden="false" collective="false" targetId="4d59-7f50-8df7-240c" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="640f-ba32-ddbe-96bd" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="570c-c8b9-434f-42a5" name="Ghasts" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9ebb-ac93-7d4b-acef" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="fce9-bc2e-6cc5-7b4d" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="ac5b-dc07-ee98-445d" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="5454-5ffb-07af-4a55" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="1410-493b-3426-91af" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9ea0-48db-1e17-9dca" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="e3b8-5034-54b9-8445" name="Unholy Appetite" hidden="false" targetId="1a5e-a0a2-3a1f-6f38" type="rule"/>
+        <infoLink id="a132-3f08-7ccf-4d55" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="20f0-c463-907d-df2c" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ddf7-e535-e789-2277" name="Ghast" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ecb-75a4-d47b-2675" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="62b8-82f2-1055-2806" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eec7-fa9a-c9fb-4ed3" name="Ghast Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8edd-1841-d9fc-4d1d" name="Ghast Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="41bb-4828-74ac-9ff2" name="Ghast Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="065e-9fcd-dc1d-844c" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="390e-6e9a-7481-5498" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-125.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c08-cbf0-87a3-21f2" name="Great Bats" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7a5-3155-deee-b95d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="0dda-40e9-4c08-115e" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="7585-931e-d2c0-69bf" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="9264-1052-506b-559d" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="096e-49f3-6c00-8a8d" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="98a1-a2c9-3d17-9454" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3+1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2845-99bd-8935-a1e5" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ccc0-b82d-0bc6-eba5" name="Great Bat" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="39ef-6c0e-96d1-b301" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a839-c735-ffe1-7d39" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3738-13a5-b941-7b51" name="Great Bat Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">1&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">2&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">3</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a329-a7eb-c952-bdd5" name="Great Bat Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="aac6-2dc6-6bc0-60bc" name="Great Bat Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4089-035c-b025-1e68" name="Cadaver Wagon" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc21-f93f-9d12-15a0" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f171-ed93-0b11-d0cf" name="Cadaver Wagon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6a48-a528-d6d5-5216" name="Cadaver Wagon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6832-130d-142a-77d4" name="Shambling Horde Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">1</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7819-dae5-b2b5-f07d" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="58e1-57f1-28c6-9443" name="Cadaver Master Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="710e-285f-069d-cd0a" name="No Rest for the Wicked" hidden="false">
+          <description>Universal Rule.
+All R&amp;F models in friendly units within 6” gain Fortitude (6+). Ghasts in friendly units within 6” gain Fortitude (4+) instead.
+Additionally, all R&amp;F models in friendly units from Core within 6” of one or more Cadaver Wagons gain Fortitude (+1, max 5+) during their first Round of Combat.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ce59-0866-cbbc-13a1" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="5399-1551-75e7-9489" name="Necromantic Aura" hidden="false" targetId="966f-af74-d464-6581" type="rule"/>
+        <infoLink id="65c2-48c0-d3fe-80a2" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="abfa-ea11-9606-9065" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="0919-d17a-94bb-43aa" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="3ab0-9938-4131-b9c1" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b328-cb72-fab1-7ca8" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="349f-4631-86e0-e79e" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="350.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9233-aa99-1b7a-addf" name="Court of the Damned" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b797-3344-9478-9c1c" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9389-ff7e-588c-0897" name="Court of the Damned Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4d08-2aec-3c21-b841" name="Court of the Damned Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6e72-73e7-ab99-a90f" name="Paramour (3) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6213-f716-c328-44ab" name="Spectral Pallbearers Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="caa2-9ca1-9417-b29e" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="2f9e-9e14-f540-5f74" name="Chill of the Grave" hidden="false">
+          <description>All models in enemy units within 6” of one or more models with Chill of the Grave suffer -2 Agility and -2 Defensive Skill.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8e70-7fa3-4438-c660" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="eec1-bdbc-7779-b193" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="7fcb-19f2-afe6-9ba0" name="Autonomous" hidden="false" targetId="6cd9-16c5-3f63-3b44" type="rule"/>
+        <infoLink id="c0ed-897c-2030-66bb" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="f12b-1b56-5fc5-0631" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="277b-64e6-18c9-06b7" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2e90-d6cd-31e5-3f1c" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="8607-38d8-cb8c-ca89" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="5fc9-a1b7-b53d-7eb2" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="4dd8-9746-261b-6e6a" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="55bf-1ee7-4a84-5256" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="24e8-f3e5-c408-f899" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2d17-b5fe-1c69-8739" name="Blood Ties: Lamia" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="c0b1-926d-451f-f420" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0b1-926d-451f-f420" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bad5-d3e2-8efa-4a5c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0260-0643-543f-2688" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="6bee-f333-7cc3-b314" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="310.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ee6-3349-6bd5-ad80" name="Altar of Undeath" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b51a-e013-d629-6c09" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b506-0b09-be6d-07cd" name="Altar of Undeath Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8b7f-7117-a37c-65a2" name="Altar of Undeath Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e457-8388-d90a-b597" name="Dark Conductor Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f854-e1a4-dfb1-1e33" name="Ghost Steeds Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2448-9e8a-ec76-7fcd" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="dff3-4982-c037-4536" name="Aura of Undeath" hidden="false">
+          <description>During its Shooting Phase, the model part can make a Shooting Attack that targets all enemy units within 12&quot; of the model (including those Engaged in Combat and outside Front Arc and/or Line of Sight). This attack can be used even if the Altar is Engaged in Combat. The targets suffer D6 hits with a Strength equal to the current Game Turn number and Armour Penetration 2.</description>
+        </rule>
+        <rule id="8f58-d26a-77f1-bbb7" name="Lash of Souls" hidden="false">
+          <description>The model can cast Pentagram of Pain (Occultism) as a Bound Spell with Power Level (4/8).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="545c-3f0a-0bba-8950" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="48a5-ac17-3d71-bf97" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="1fee-2e8f-e326-6413" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="bf56-5548-1db6-aad7" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="1caf-f87d-a415-0d0a" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="0d41-d32e-08cd-3e73" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="fedb-1527-d58c-c6f3" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="81be-d694-b9b4-c7b5" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="602b-8c3f-c93d-0967" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="e6e4-11a7-8777-38d8" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="7705-e033-2fa2-d7f5" name="Fortitude" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d70e-37cb-0de1-98f5" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3f5e-0f22-6b2e-d505" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="365.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3907-ee36-7811-a3a4" name="Dark Coach" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c4e-7ab6-3cfe-47c6" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6013-df86-d259-5a22" name="Dark Coach Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fb42-e0aa-9a49-c471" name="Dark Coach Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="af29-5803-928e-fa27" name="Coachman Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">10</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9803-d1ea-fdf6-3902" name="Vampire Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">6</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d1f5-6eb7-3a60-d9f9" name="Undead Mounts (2)" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="8265-800f-bc87-d00a" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f2e8-ee97-26da-f9af" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="c0ad-463d-7fc4-c25b" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="491b-50ea-e58a-b8c2" name="Unholy Conduit" hidden="false">
+          <description>Friendly units within 6” of the model gain Autonomous.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="338d-057e-7e84-b917" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="fd0e-ea31-98cf-cc16" name="Swiftstride" hidden="false" targetId="d15d-3c8e-23db-ab7b" type="rule"/>
+        <infoLink id="f15a-0b1b-3220-4a6b" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="2a8b-2df6-6e3c-6b0f" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="d45b-53fc-5a33-2057" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ac15-488d-72bb-5962" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="4d3c-ddda-8104-e969" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="b94e-0e6d-e492-4c6b" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0942-97b4-43f6-bf9d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b05f-4f3a-3661-dbe3" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="51d7-05c6-067d-b3a0" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6+1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7249-7b43-364f-8b21" name="Stubborn" hidden="false" targetId="51bf-5c8d-5b95-e33c" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="803d-0bff-8b68-e9b7" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2450-0ca8-4c78-96da" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f2e8-ee97-26da-f9af" name="Extended Chassis" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0aa1-1d34-6a60-956b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="ec89-96db-4d6e-b911" name="Extended Chassis" hidden="false">
+              <description>The Dark Coach changes its base size to 50x150mm and its Undead Mounts&apos; Attack Value is set to 2.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="430.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="418e-3cb4-7897-0902" name="Phantom Host" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9634-832e-522f-390c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="db5e-9cc9-b05a-19be" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="9833-df5e-3cb1-6292" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="9f27-6686-806c-26bb" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="a399-4ac3-bb23-ba56" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a7e3-5721-5861-5b81" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="d3c3-b71b-09a9-d8e8" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (2+, against non-Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e727-74cc-4dfc-84ee" name="Ghostly Form" hidden="false" targetId="9221-c547-a843-bdb0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4d06-8830-5481-ee98" name="New CategoryLink" hidden="false" targetId="dc98-3346-9b99-6af4" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="26f2-3310-1bb7-4060" name="Phantom Host" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="66c8-4371-d3e5-050c" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="074e-605a-e3fa-cffb" type="max"/>
+            <constraint field="selections" scope="roster" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a7c-1227-2cc4-cf62" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="74b2-2a25-4456-44de" name="Phantom Host Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="9502-7f11-6536-d3bc" name="Phantom Host Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="74bd-387a-d2f6-7501" name="Phantom Host Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="00b2-2113-f95b-4268" name="Wraiths" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f775-6ab6-451b-6bd3" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b4c4-e142-1076-0083" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="7f55-8128-fb63-1f43" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="1ff2-8eb2-2e96-7a59" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="6aea-d91f-3e91-b485" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6a34-956b-476b-a230" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="c38e-0db0-2662-93ef" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="43d0-2f51-cbe1-3589" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="2a64-4541-c5b1-40fd" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="6c89-aa5e-8382-5a8c" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+, against non-Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c5e3-0498-ddf7-8d29" name="Ghostly Form" hidden="false" targetId="9221-c547-a843-bdb0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8081-03a7-e03a-33c1" name="New CategoryLink" hidden="false" targetId="dc98-3346-9b99-6af4" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ec79-ab37-9115-ebce" name="Wraith" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d653-6a60-9f38-9b71" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53e5-d9ef-a7f0-84e1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="875c-166c-d2bc-fac4" name="Wraith Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="deec-90b2-fec5-87ec" name="Wraith Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="20d4-bf84-1169-3073" name="Wraith Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">10</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3297-27d4-b599-0aad" name="Champion" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d483-d140-2974-ddc1" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8ef3-f924-ff13-b328" name="Wizard Conclave" hidden="false" targetId="7455-f914-028b-3359" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (Raven&apos;s Wing - Witchcraft, Hasten the Hour - Evocation, Deceptive Glamour - Witchcraft)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="23be-f9f7-00a7-b1da" name="Reaper" hidden="false" collective="false" targetId="4ae1-bf77-3f6f-bc33" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="58a4-0c07-dc68-3efd" name="Spectral Hunters" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e98-4c0c-2c1e-09e2" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="dd61-5dad-d6e9-01ad" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="25c1-8241-b074-1136" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="23ef-dadd-ecc4-b0f2" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="4299-ebcd-957f-b44c" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3fb5-d6d6-c3a4-51c1" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="321c-e8ef-360a-b9a0" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="6a04-3ade-f820-33cb" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="a0b3-0531-28ac-d704" name="Flaming Attacks" hidden="false" targetId="49e5-2d9a-1ecc-101f" type="rule"/>
+        <infoLink id="438d-454a-026b-29fd" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b7d8-68ed-e30b-cd93" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9bcd-7b1b-79c7-6391" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+, against non-Magical Attacks)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="06ec-2427-0584-20ff" name="Ghostly Form" hidden="false" targetId="9221-c547-a843-bdb0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b7c1-b530-7d12-c4ec" name="New CategoryLink" hidden="false" targetId="dc98-3346-9b99-6af4" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2798-a391-3a3b-c6d4" name="Spectral Hunter" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5508-6fb0-817c-107a" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="85e1-d39c-bbd6-c493" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8080-1acd-a717-e8c7" name="Spectral Hunter Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="06a6-cec5-a847-7878" name="Spectral Hunter Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">1</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="1c5c-5f6b-30c3-5b25" name="Spectral Hunter Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">10</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="503e-93b8-5039-8b94" name="Ghost Steed Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="38.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5471-023a-a024-f64f" name="Champion" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f5cb-8b78-8d44-b131" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c250-2772-85d6-bafc" name="Wizard Conclave" hidden="false" targetId="7455-f914-028b-3359" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (Raven&apos;s Wing - Witchcraft, Whispers of the Veil - Evocation, Perception of Strength - Cosmology)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1e0-7e6d-9fc6-9392" name="Shrieking Horror" hidden="false" collective="false" type="model">
+      <modifiers>
+        <modifier type="set" field="6439-7607-05e9-bb49" value="1">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a7c6-75ab-7e65-df3c" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6439-7607-05e9-bb49" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d68d-e030-a8f2-cfec" name="Shrieking Horror Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">4</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="629c-4a99-176a-fc83" name="Shrieking Horror Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="86d2-bd76-16b7-cd22" name="Shrieking Horror Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="be7a-3aaa-b45d-778f" name="Chilling Shriek" hidden="false">
+          <description>A model with this Special Attack can use it as a Shooting Attack and as a Special Attack in Close Combat.
+- As a Shooting Attack: Choose a target using the normal rules for Shooting Attacks, except it can be used even if the model performed a March Move previously in this Player Turn. The attack has Range 8&quot;.
+- As a Special Attack in Close Combat: The attack is made at the model part&apos;s Initiative Step. Declare that you are using Chilling Shriek when allocating attacks. If used, the model part cannot make Close Combat Attacks. Choose a single unit in base contact as the target.
+Regardless of whether it is used as a Shooting or Melee Attack, the Chilling Shriek causes 1 hit to the target for each Health Point the model with Chilling Shriek currently has. These hits always have Strength 10, Armour Penetration 10, and Magical Attacks. When rolling to wound with this attack, use the enemy&apos;s Discipline instead of its Resilience.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8777-7543-7773-b128" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="deca-cce0-12f0-69bf" name="Fortitude" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0ae5-b3bc-edf9-9d86" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="3e6c-4df3-e7bf-d306" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e76f-a99f-2a88-1e5f" name="New CategoryLink" hidden="false" targetId="eda3-1b96-c963-9650" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="490.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="89de-42ee-75f9-4ba9" name="Vampire Knights" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1ce3-0392-d717-b598" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f4ac-d6ee-1a2b-2110" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="85e5-aa2a-1cc2-d005" name="Autonomous" hidden="false" targetId="6cd9-16c5-3f63-3b44" type="rule"/>
+        <infoLink id="0a41-085e-523d-272b" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="f713-a806-ce8d-24c7" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="4bde-b3c4-d422-e765" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c3ef-dc71-c380-d9e3" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+        <infoLink id="df8b-96cb-d63d-c7b2" name="Lance" hidden="false" targetId="f1a1-62ad-69ea-9d18" type="profile"/>
+        <infoLink id="2cad-c0ed-df0f-a79f" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c82c-43b1-86d5-ade8" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="38be-ebfc-f2b7-73c7" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (+1 Att)"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7878-78ab-55db-f4b4" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="506d-7d18-57ae-62ce" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="e98c-4c81-a1e4-75a8" name="New CategoryLink" hidden="false" targetId="eda3-1b96-c963-9650" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e14c-e28c-c46a-ac41" name="Vampire Knight" hidden="false" collective="false" type="model">
+          <modifiers>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="115">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b2b-4591-ba11-f281" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9e96-e40d-2964-f7fc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b559-2cb0-ed38-85c4" name="Vampire Knight Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4b1c-d78c-ff9a-f5fa" name="Vampire Knight Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">2</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4c95-6d29-3809-2857" name="Vampire Knight Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="2e22-5a56-2efa-068a" name="Undead Mount Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">3</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3dda-4b45-f7e6-7c81" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f089-e621-9579-07c3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7815-d59e-8af5-9b17" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="25d2-e9ab-e14d-13f8" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dd13-649c-36e7-4274" name="Winged Reapers" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="defe-063a-ffcb-1b5a" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f6cf-0298-10f6-d9c0" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="861d-d1cc-169d-ae3b" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="932f-e8de-36b8-77a1" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="27f2-9c7b-5495-0bc3" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="0315-329f-b6fa-a74f" name="Necromantic Aura" hidden="false" targetId="966f-af74-d464-6581" type="rule"/>
+        <infoLink id="7bf0-6fa6-c605-367f" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+        <infoLink id="e55d-129f-3bc5-cc51" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="98fe-fde3-4fa6-30f2" name="New CategoryLink" hidden="false" targetId="eda3-1b96-c963-9650" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2b40-f855-85fe-7a0d" name="Winged Reaper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bad0-64ae-221e-9488" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0bb8-4b4d-2370-5979" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7506-6994-e614-b05f" name="Winged Reaper Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (6&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (12&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">10</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="6468-9f2f-814d-ff9e" name="Winged Reaper Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ad3d-d221-a6d6-7585" name="Winged Reaper Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6321-027f-5f73-cc59" name="Melee Weapon" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dcc-684c-d453-3a3d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0e9d-4968-7eb8-05e1" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="dd13-649c-36e7-4274" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b40-f855-85fe-7a0d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f27-45f9-b809-af6d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ec22-b568-dbd1-76b9" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5005-fd90-45ec-46be" name="Halberd" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="dd13-649c-36e7-4274" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b40-f855-85fe-7a0d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf90-b055-2209-3545" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d8a2-bad4-376a-bdf8" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="82e0-959f-e4e3-d31e" name="Varkolak" hidden="false" collective="false" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5fc3-fc48-db73-19da" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7697-4f2c-6273-e300" name="Varkolak Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="62b0-423c-ed86-0853" name="Varkolak Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1e0e-670f-96cc-d3b3" name="Varkolak Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="58ba-c1c6-2dd8-93c5" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="6048-2407-cd3f-6849" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="ec03-13fb-615e-2055" name="Vanguard" hidden="false" targetId="e4e4-ef11-f62f-59b6" type="rule"/>
+        <infoLink id="fd8c-8383-cfc0-aa55" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="dd79-55a0-cff9-7381" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+        <infoLink id="d43d-ccd2-e937-ef8e" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (3+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="42b0-8e1c-58bb-a6b6" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bf07-029e-ba7d-a659" name="New CategoryLink" hidden="false" targetId="eda3-1b96-c963-9650" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="335.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="413f-f736-22ed-0bf2" name="Vampire Spawn" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3ab-2a6e-a540-a2f9" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="31eb-e2f3-f290-03d3" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="667c-a851-0d75-63e4" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="9dcd-89d0-8d8f-ca0a" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
+        <infoLink id="63d2-aea8-3247-7ef1" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
+        <infoLink id="9573-4a7f-635b-7ff1" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ff4f-92c5-e8f0-ce96" name="Autonomous" hidden="false" targetId="6cd9-16c5-3f63-3b44" type="rule"/>
+        <infoLink id="c79d-abdb-b4fd-de2e" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="5a5f-8001-c45b-9390" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d0bd-0570-3d05-e2be" name="New CategoryLink" hidden="false" targetId="eda3-1b96-c963-9650" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2138-be48-d63e-db4d" name="Vampire Spawn" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6041-15f3-2e1b-17f1" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a654-a040-0384-644e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6c73-deff-2a2b-c7bc" name="Vampire Spawn Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+              <characteristics>
+                <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (9&quot;)</characteristic>
+                <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (18&quot;)</characteristic>
+                <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+                <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f056-501b-9b68-74d7" name="Vampire Spawn Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+              <characteristics>
+                <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+                <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
+                <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+                <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="0448-c7e1-1fdf-1eb2" name="Vampire Spawn Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+              <characteristics>
+                <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+                <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+                <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+                <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+                <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="54a8-c41f-464e-44dd" name="Champion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1fc2-77e0-131b-f285" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5873-24de-7db3-02e7" name="Fell Wraith - Monstrous Revenant" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="6245-6b7f-81c3-c4b5" name="Fell Wraith Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4223-d831-2db5-6f32" name="Fell Wraith Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b015-2288-12cf-57d4" name="Fell Wraith Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">3</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">10</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="376b-1c09-8ea4-d523" name="Undead" hidden="false" targetId="b558-1cce-fbc9-afe6" type="rule"/>
+        <infoLink id="0858-cecf-128f-6437" name="Ashes to Ashes" hidden="false" targetId="07db-871a-166c-cd5c" type="rule"/>
+        <infoLink id="f0f1-3b85-09ff-7e8b" name="Terror" hidden="false" targetId="0b48-87f9-1467-7ef2" type="rule"/>
+        <infoLink id="b853-2ecb-461a-d66f" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
+        <infoLink id="8589-09d5-395e-ff54" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="3f23-020e-7659-1878" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="94e1-8c5f-606f-61e6" name="Reanimated" hidden="false" targetId="0728-cf99-bcf2-692a" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ebc9-aa90-103d-d7fd" name="Ghostly Form" hidden="false" targetId="9221-c547-a843-bdb0" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="907f-e29e-9b90-b6f1" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c7fc-f102-27a0-e75c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="827d-a534-c827-2d83" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b91f-aadf-4a8d-59ab" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="b1a1-0da2-6011-45c6" name="New CategoryLink" hidden="false" targetId="ce40-9d61-830e-cdef" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="723f-e4be-9975-f4fa" name="Monstrous Revenant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f388-4a6c-4317-35da" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0830-3044-f25b-0bfc" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="9dac-35c4-b1a9-ad89" name="Swift Death (local)" hidden="false" targetId="eda3-1b96-c963-9650" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="ee78-bf9c-b00c-6791" name="Monstrous Revenant" hidden="false" collective="false" targetId="8908-1292-8a37-d207" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="e9c8-a624-9349-e334" name="Reaper" hidden="false" collective="false" targetId="4ae1-bf77-3f6f-bc33" type="selectionEntry"/>
+        <entryLink id="8cba-6610-c557-4ee8" name="Weapon Enchantments" hidden="false" collective="false" targetId="ab6e-ba4a-ea93-bbf2" type="selectionEntryGroup">
+          <constraints>
+            <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a94-3160-63c4-1a10" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <sharedSelectionEntries>
+    <selectionEntry id="efb4-f04c-8589-ad57" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b26-e0c0-f066-c1a6" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d8d-25bb-5e65-e1bd" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4c5-4c04-0325-470d" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="5dce-1863-3bc1-5931" name="Rally Around the Flag" hidden="false" targetId="bf56-e3dc-41ca-292b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d59-7f50-8df7-240c" name="Black Standard of Zagvozd" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a5d-6a02-3b91-4f1c" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a90-a67d-acb2-c8d4" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="c015-6ede-d27b-ed9a" name="Black Standard of Zagvozd" hidden="false">
+          <description>Close Combat Attacks made by R&amp;F model parts without Harnessed in the bearer&apos;s unit gain +1 to hit. At the start of any Melee Phase, if the bearer&apos;s unit is unengaged, you may choose a friendly Standard Size Infantry or Barrow Knight unit within 6&quot; of the bearer. Close Combat Attacks made by R&amp;F model parts without Harnessed in that unit gain +1 to hit until the end of the Melee Phase.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f9bd-8831-67db-b5ec" name="Army General" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ef9-201a-ecfc-b6f6" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9be-819f-0ba6-f029" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7f6a-494c-f461-7ca8" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c37f-3fff-8802-dcb3" name="Commanding Presence" hidden="false" targetId="2304-d0e4-f97b-c4e5" type="rule"/>
+        <infoLink id="5485-f2d7-b22b-5c92" name="Master of Undeath" hidden="false" targetId="8adf-722f-ae2c-a1c4" type="rule"/>
+        <infoLink id="8c3a-fc99-7129-7df5" name="The Dead Arise" hidden="false" targetId="2499-8b27-4a7b-11b0" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cee8-4ec7-c374-1b1c" name="Skeletal Steed" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e2e-4d75-d69d-313f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf88-9be9-bf8c-8257" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="cb55-e735-34d1-c200" name="Skeletal Steed Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a85b-afb8-91f6-48fa" name="Skeletal Steed Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6582-3d34-9959-cc2a" name="Skeletal Steed Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="62e8-554a-244b-c521" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="500f-11d7-f23e-8e55" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="220c-ff1d-da96-4921" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1ab7-28e6-a76e-680e" name="Spectral Steed" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb15-8eed-03ad-a21a" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d97a-6929-f80a-8280" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2bb6-69bc-2492-d829" name="Spectral Steed Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">1</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8c49-22f0-319d-d3c8" name="Spectral Steed Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Standard</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f38f-b572-77ca-cb7c" name="Spectral Steed Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">C</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">C</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a44a-6a8c-6781-a7cd" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="7bc2-262b-7006-f626" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="7488-ab51-6605-c651" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="c6bf-1b72-6b49-b832" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8908-1292-8a37-d207" name="Monstrous Revenant" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e87-5be5-01e0-a5a2" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3acd-5a28-6332-c863" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="49de-685e-1878-8177" name="Monstrous Revenant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Cavalry</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f4c3-16e1-eab5-9da2" name="Monstrous Revenant Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="df51-f5eb-f401-05e6" name="Monstrous Revenant Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0004-892b-84eb-920c" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="5ae0-984a-394a-e68f" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="9f86-f4c7-c01c-8530" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="38da-a061-8564-dce0" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="2361-c08c-1e72-f2b0" name="Poison Attacks" hidden="false" targetId="f2fe-a751-2161-8c76" type="rule"/>
+        <infoLink id="ac67-2140-ac7c-01fe" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="f873-197b-ea6e-d426" name="Great Monstrous Revenant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="196e-372d-5c0a-c765" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9aed-8072-54e1-818f" name="Devastating Charge" hidden="false" targetId="c66c-e69e-a4f1-0351" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (+1 Str, +1 AP)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="276f-3976-6cc3-1166" name="New CategoryLink" hidden="false" targetId="0adc-f4e6-0c6b-c21b" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="480f-80cb-b650-da3f" name="Court of the Damned" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e62-308d-13f7-7e08" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af20-7cdc-4b4d-0757" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d8ea-5b71-a313-84ec" name="Court of the Damned Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3f95-795c-3598-b081" name="Court of the Damned Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3c15-e9d7-d31a-9fc6" name="Paramour (2) Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="daaa-8709-5237-b9c9" name="Spectral Pallbearers Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">2</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e6c3-f7ee-07d5-fc87" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f33b-e0b9-ec87-f9e5" name="Chill of the Grave" hidden="false">
+          <description>All models in enemy units within 6” of one or more models with Chill of the Grave suffer -2 Agility and -2 Defensive Skill, both to a minimum of 1.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="94f8-915e-3a35-58b5" name="Ghost Step" hidden="false" targetId="36f9-836f-d687-5d43" type="rule"/>
+        <infoLink id="3f1d-8d1b-21b3-28ef" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="b8ae-d5a5-2844-d029" name="Autonomous" hidden="false" targetId="6cd9-16c5-3f63-3b44" type="rule"/>
+        <infoLink id="da2c-a8e2-64ea-cb0b" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+        <infoLink id="f378-4d01-e538-c666" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="a1bd-4057-e582-4a8f" name="Vampiric" hidden="false" targetId="9809-d282-e3f2-8423" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1a7d-027e-e590-5e6d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="ccf3-ce57-e7bf-2464" name="Magical Attacks" hidden="false" targetId="97c6-651e-d93d-a61e" type="rule"/>
+        <infoLink id="a5c4-12db-23cb-a2b1" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="30d8-a8d8-845e-1a6d" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="4564-b79f-16fc-c99e" name="Blood Ties: Lamia" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="a04b-c0bf-107d-a2cf" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a04b-c0bf-107d-a2cf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ace-08ff-2bef-84f2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b3a6-a45a-305f-2cde" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a7c6-75ab-7e65-df3c" name="Shrieking Horror" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0567-e86e-a6fd-13d0" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d833-8244-7376-35ce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb36-31ad-d716-d3db" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2519-d4b2-ca69-2637" name="Shrieking Horror Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (16&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0199-377a-d56f-d0e1" name="Shrieking Horror Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fb74-b18b-2a54-227e" name="Shrieking Horror Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">4</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="fbe2-035e-fa5b-5207" name="Chilling Shriek" hidden="false">
+          <description>Model parts with this Special Attack have a Shooting Attack and a Melee Attack as detailed below.
+⦁	Shooting Attack: Choose a target using the normal rules for Shooting Attacks, except it can be used even if the model performed a March Move previously in this Player Turn. The attack has Range 8&quot;.
+⦁	Melee Attack: If used, the model part cannot make Close Combat Attacks. The Chilling Shriek attack is made at the model part&apos;s Initiative Step. Choose a single unit in base contact as the target.
+Regardless of whether it is used as a Shooting or Melee Attack, the Chilling Shriek causes 1 hit to the target for each Health Point the model with Chilling Shriek currently has. These hits always have Strength 10, Armour Penetration 10, and Magical Attacks. When rolling to wound with this attack, use the enemy&apos;s Discipline instead of its Resilience.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3dc4-0c2b-0f55-d4cb" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="cd3c-546f-a0eb-39bc" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7f74-b894-985e-ef46" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d516-1369-f91d-3853" name="Zombie Dragon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="886d-8b2f-fd32-9c31" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa57-1076-fd80-e1b7" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3e5-0ca3-942e-b7ab" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6157-22de-93dd-c3da" name="Zombie Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Gigantic</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8bfe-5c86-75a8-fb9d" name="Zombie Dragon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <modifiers>
+            <modifier type="set" field="160d-4624-273f-2114" value="5">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7423-1c20-115d-dc59" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="597b-8735-3dd1-0e70" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7423-1c20-115d-dc59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">6</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="70b9-ab9a-9240-6a60" name="Zombie Dragon Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <modifiers>
+            <modifier type="set" field="7d3b-bb95-3d29-26f7" value="5">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7423-1c20-115d-dc59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">4</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="33c9-112b-5403-964f" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
+        <infoLink id="d6c7-815e-9c29-3a0c" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9977-fd37-290b-cd78" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="cc42-9203-efde-1dff" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b6f7-db7b-1d9d-8378" name="Breath Attack" hidden="false" targetId="3be7-d693-e8e8-6b1e" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (Toxic Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="7423-1c20-115d-dc59" name="Colossal Zombie Dragon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="10e9-fd59-cb83-3798" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f1b3-993f-1106-82c9" name="Cadaver Wagon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2379-0609-16f4-6eae" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc91-56ea-b204-1c7e" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ccd4-a1bf-1a9b-f906" name="Cadaver Wagon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+          <characteristics>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
+            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
+            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Construct</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d299-45bc-1f20-d23f" name="Cadaver Wagon Defence" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+          <characteristics>
+            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
+            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
+            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+2</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e655-1b24-5e1d-23cd" name="Shambling Horde Offence" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">8</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">1</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="51a3-a8db-b8e7-71df" name="Chassis" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+          <characteristics>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="35a8-a49a-6d7e-d61f" name="No Rest for the Wicked" hidden="false">
+          <description>Universal Rule.
+All R&amp;F models in friendly units within 6” gain Fortitude (6+). Ghasts in friendly units within 6” gain Fortitude (4+) instead.
+Additionally, all R&amp;F models in friendly units from Core within 6” of one or more Cadaver Wagons gain Fortitude (+1, max 5+) during their first Round of Combat.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e249-95b8-70be-eff7" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+        <infoLink id="a44f-e2b3-a8ad-2aa7" name="Necromantic Aura" hidden="false" targetId="966f-af74-d464-6581" type="rule"/>
+        <infoLink id="0c23-9898-7ff5-c729" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4f8f-af64-3e0a-dd66" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+        <infoLink id="b6e3-faeb-3c7e-b861" name="Inanimate" hidden="false" targetId="ca83-2dad-d908-5f4c" type="rule"/>
+        <infoLink id="0ac1-c470-33de-84d0" name="Impact Hits" hidden="false" targetId="197f-58cf-73ad-ac42" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4ae1-bf77-3f6f-bc33" name="Reaper" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e30-5029-ae5b-9a4c" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f46e-7fc7-d279-f4bf" type="max"/>
+        <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e02-bbeb-0688-09b0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="3ac7-a313-1979-22b0" name="Reaper" hidden="false" targetId="2d4a-2a22-2cf0-d9ed" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="fa72-d202-5a3a-962a" name="Vampiric Bloodline" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e68-4cd6-4eeb-688a" type="notInstanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="63e6-a04a-b428-16d4" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b915-debd-759a-b19a" name="Brotherhood of the Dragon Bloodline" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="3737-7a88-f289-6561" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3737-7a88-f289-6561" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a7e-2645-7546-e441" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a487-d988-f968-8a69" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d71b-a9be-2a80-2928" name="Lamia Bloodline" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="4321-e6a8-8f13-1444" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4321-e6a8-8f13-1444" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86a6-0a51-c0a9-1f70" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2f8b-f710-b98a-c7b1" name="Lightning Reflexes" hidden="false" targetId="f17a-c7f9-af34-a039" type="rule"/>
+            <infoLink id="f6fa-0b53-b3af-5308" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b4bd-bf0c-bd1e-303e" name="Nosferatu Bloodline" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="cea7-b60e-5c4f-ef11" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cea7-b60e-5c4f-ef11" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e842-25fa-ad2a-f73e" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f61d-df40-9fcf-4e06" name="Strigoi Bloodline" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="ac6f-6351-47c4-7d4b" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac6f-6351-47c4-7d4b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b8f5-17a6-c346-4e03" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e41d-814d-6537-e10d" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
+            <infoLink id="4971-8d59-58b7-8f44" name="Regeneration" hidden="false" targetId="faef-6f9d-ae02-d420" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (4+)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="42a5-a6aa-fb1c-bd10" name="Von Karnstein Bloodline" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="3774-e898-0206-6672" value="1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3774-e898-0206-6672" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c62-19e7-27ca-3e0d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8aaa-efe8-5149-ecb6" name="Ancient Blood Powers" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a2f-9030-7662-d638" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="4fc8-3406-9e92-3cfa" name="Crimson Rage" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5acb-90a8-de60-de43" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b9dc-3ab9-bdee-4e22" name="Crimson Rage" hidden="false">
+              <description>Every unsaved wound caused by the Vampire&apos;s Close Combat Attacks, before applying Multiple Wounds, generates another Close Combat Attack at the same Initiative Step. Resolve these attacks before removing any casualties. These new attacks do not generate any further attacks.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="130.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6377-5369-5aee-11f1" name="Commandment" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a1a-d6bd-3aa3-b1bf" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b6da-1205-512b-4d3c" name="Commandment" hidden="false">
+              <description>All R&amp;F models in a unit joined by the Vampire have their Defensive Skill and Offensive Skill set to 6. </description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c173-9231-13b4-d883" name="Blood Magic" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b03-cd87-99f7-f61b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="eee2-a7ac-a14f-d42c" name="Blood Magic" hidden="false">
+              <description>During Spell Selection, choose a Path (this may be a different Path than the one the model selects its spells from). When the Vampire or a friendly Wizard within 12” casts the Hereditary Spell or any spell from the chosen Path, the Casting Value of the Spell is reduced by 2. If a friendly Wizard within 12” of the Vampire Miscasts, it suffers a +1 Miscast Modifier, and when rolling casting rolls with a single Magic Dice, a natural roll of ‘1’ or ‘2’ on the Magic Dice is always a failed Casting Attempt, regardless of any modifiers.
+</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1941-e4c5-6046-9436" name="Ghoul Lord" hidden="true" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6b2-1887-071d-8861" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a7c0-600a-2237-8648" name="Ghoul Lord" hidden="false">
+              <description>The Vampire, its mount, and all R&amp;F models in its unit gain Poison Attacks. If the unit it joins already had Poison Attacks, all R&amp;F models in the unit wound automatically on a successful natural to-hit roll of 1 less than normal (i.e. 5+ instead of 6+).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f2d5-5734-4a4a-8d0f" name="Storm Caller" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="529b-ebd3-c83d-9d3a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="c177-7674-d0b6-1d24" name="Storm Caller" hidden="false">
+              <description>All units within 12&quot; of the Vampire gain Hard Target.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="07b1-4e7f-b2cb-83ef" name="VC Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb26-fe99-a7bb-6e16" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0b0f-2655-85a4-5e93" name="Reaper&apos;s Harvest" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99ae-2a0d-9dec-d0dc" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81a7-809f-c23c-8728" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6360-2e96-ef22-bd48" name="Reaper&apos;s Harvest" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon always have Strength 10 and Armour Penetration 10 and gain Divine Attacks and Magical Attacks. When rolling to wound with attacks made with this weapon, use the enemy&apos;s Discipline instead of its Resilience.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4906-041f-5489-9e5a" name="True Thirst - Vampire Counts and Courtiers Only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23c1-144d-ff66-c264" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb8f-80d0-c111-8505" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c2e6-6897-2c94-24f5" name="True Thirst" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon gain +1 Strength, +1 Armour Penetration, and Magical Attacks. For each unsaved wound caused by this weapon during a Melee Phase, Raise 1 Health Point of R&amp;F models in the wielder’s unit at the end of the Melee Phase. The number of Raised Health Points in each phase cannot exceed the fixed component of the Reanimated value of the R&amp;F models in the unit, disregarding any D3 or D6 parts (e.g. you can Raise 4 Zombies in a single phase).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b813-2849-3314-2f6e" name="VC Armour Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="14f0-0d2c-2c79-34ba" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6a0f-f301-b6ed-b988" name="Legend of the Black King" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa4a-90cd-7eea-d003" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9aeb-a184-8ddf-9138" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ddbd-3fb4-24b2-2020" name="Legend of the Black King" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour and Heavy Armour Enchantment</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains +1 Armour and Aegis (4+).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="df96-36cc-0ce6-f2d6" name="VC Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="357c-9985-5b9d-1aa8" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="73a2-84fb-72e8-92f8" name="Hypnotic Pendant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2550-6bb3-d105-91a0" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dded-a495-c2ab-3215" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="cba3-bb43-759e-6189" name="Hypnotic Pendant" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Distracting. All Standard Size R&amp;F models in the bearer&apos;s unit gain Parry.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="100.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="63fe-7cb6-a8f1-2cf5" name="Eternity Gem - Vampire Counts and Courtiers on Monstrous Revenant without Towering Presence only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="61a9-ebe3-0240-acec" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d04f-9fd2-41f3-e966" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bfb4-dc62-6578-2865" name="Eternity Gem" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks against the wearer with Lethal Strike and/or Multiple Wounds lose these Attack Attributes. One use only: Must be activated when the wearer suffers the first wound in the game (after Armour Saves). The wearer gains Aegis (2+) against this wound.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="95.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="730c-c665-25b4-5ffc" name="Night&apos;s Crown - Standard Size Only" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a15e-99a0-41e5-9d8d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4609-14aa-7506-bd5d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1e70-9601-9f53-8cc8" name="Night&apos;s Crown" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Close Combat Attacks allocated towards the bearer do not gain Strength modifiers of the +X type conferred by Melee Weapons. Close Combat Attacks can never wound the bearer on better than 4+.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8528-8a87-647a-5e68" name="Necromantic Staff - Wizards only - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bb7-7b6a-a75c-fab9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ab6a-c1e6-2d58-1b39" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7449-0815-0eee-9ade" name="Necromantic Staff" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Dominant. The bearer gains Channel (1). The bearer may cast the first Boosted version (6&quot; Aura) of Arise! as a Bound Spell with Power Level (4/8).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9b27-e360-2d9a-4460" name="Unholy Tome - Wizards only - Dominant" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e31b-67d7-8ff0-83ad" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a7e-db30-90af-9e57" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="165c-0ba9-05aa-84d0" name="Unholy Tome" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Dominant. The bearer can cast Danse Macabre from Evocation as a Bound Spell with Power Level (4/8).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8a81-1dff-a520-d3ba" name="Cursed Medallion" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5510-9700-2695-fb07" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b785-736a-ebd1-26bd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9bfc-f027-63fa-5c3c" name="Cursed Medallion" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Right before the battle (during step 7 of the Deployment Phase Sequence), choose a Character, Champion, or a single model unit in the opponent&apos;s Army List. The bearer must reroll failed to-hit and to-wound rolls against the chosen model.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ab6e-ba4a-ea93-bbf2" name="Weapon Enchantments" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8362-afa6-a35f-2d1f" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="a9ce-dcfc-ccf3-784b" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+        <entryLink id="5dda-9a3c-6598-fcbd" name="VC Weapon Enchantments" hidden="false" collective="false" targetId="07b1-4e7f-b2cb-83ef" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3ced-8427-6428-c88a" name="Armour Enchantments" hidden="false" collective="false">
+      <modifiers>
+        <modifier type="set" field="8895-01c9-b646-3a78" value="2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8895-01c9-b646-3a78" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="7a5c-ba66-811c-6646" name="VC Armour Enchantments" hidden="false" collective="false" targetId="b813-2849-3314-2f6e" type="selectionEntryGroup"/>
+        <entryLink id="4dfb-c370-d8bf-adfc" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0829-f3bd-215b-6820" name="Artefacts" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="233b-1c03-f59c-9526" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="1cb2-21a0-53df-3568" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+        <entryLink id="ae29-f14b-8fef-1795" name="VC Artefacts" hidden="false" collective="false" targetId="df96-36cc-0ce6-f2d6" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3e3c-20fe-5381-2e4a" name="Lesser Blood Powers" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e52-573e-6001-6f9a" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b20d-c09a-b6ef-19fd" name="Eternal Duelist" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="4496-5687-e36c-9c23" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5e76-d888-20a1-5ba6" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4496-5687-e36c-9c23" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="4c31-9ccd-66ce-2b16" name="Eternal Duelist" hidden="false">
+              <description>The Vampire must reroll natural to-hit and to-wound of &apos;1&apos; with its Close Combat Attacks.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="14bb-cf5d-0878-1472" name="Monster Hunter" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="c3a7-2923-b2fb-aaae" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7d1-9810-2380-53f9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c3a7-2923-b2fb-aaae" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="3246-f2be-207b-bf3d" name="Monster Hunter" hidden="false">
+              <description>The Vampire gains Multiple Wounds (2, against Towering Presence).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a469-7cc2-b511-9e20" name="Flying Horror - Models on Foot Only" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="d7d9-d0b0-756d-0b04" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a470-f030-eae3-fe99" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7d9-d0b0-756d-0b04" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b772-df26-2f37-dc3c" name="Flying Horror" hidden="false">
+              <description>The Vampire gains Fly (7”, 14”) and Storm Wings (see Bat Swarms).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="32b8-2fb1-9826-dbce" name="Bestial Bulk" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c741-8ffa-d101-81d4" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f54f-04e3-a4d6-087e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="8595-1bb6-2a8e-4750" name="Bestial Bulk" hidden="false">
+              <description>The Vampire gains +1 Resilience and cannot use any Weapon Enchantments or Armour. The Vampire changes its Size to Large and its base size to 40x40mm. As long as the Vampire is joined to a unit of Ghasts, the Vampire gains Scoring. If playing Capture the Flags, the Vampire gains Scoring (no matter if joined to a unit of Ghasts or not). </description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="754f-39b0-09d5-5bc6" name="Hour of the Wolf" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="56e1-dabe-907f-ca66" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="310c-7e4b-cb99-ff0d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56e1-dabe-907f-ca66" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="089d-9820-4ce0-85cc" name="Hour of the Wolf" hidden="false">
+              <description>The Vampire&apos;s unit gains Swiftstride. The Vampire gains Awaken (Zombies, Direwolves, Bat Swarms, Great Bats).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8088-8eab-3286-2976" name="Unbreakable Will" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="9afc-f852-bcb3-dd4a" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43f3-3460-6ad5-c1cd" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9afc-f852-bcb3-dd4a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="8977-4af8-701e-59e5" name="Unbreakable Will" hidden="false">
+              <description>At the beginning of each Round of Combat, select a single friendly unit Engaged in the same Combat as the Vampire (this can be the Vampire&apos;s own unit). This unit gains Stubborn until the end of the Melee Phase.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="67ed-01c1-ab9d-a97b" name="Forbidden Path" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="db45-d0d0-33c0-4f2e" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd84-ccd4-5253-4ab5" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db45-d0d0-33c0-4f2e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="42bb-c682-b0bd-5313" name="Forbidden Path" hidden="false">
+              <description>A Wizard Master with this Blood Power becomes a Wizard Adept using two different Paths it has access to (it knows spells from both paths). A Wizard Adept becomes a Wizard Apprentice using two different Paths it has access to.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="db41-20c6-5f19-e716" name="Arcane Knowledge" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="7e5c-2ec8-d682-0abd" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9395-b4a2-ee30-49d3" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7e5c-2ec8-d682-0abd" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="e26f-bb59-6767-a57e" name="Arcane Knowledge" hidden="false">
+              <description>The Vampire knows the Hereditary Spell in addition to its other spells. Spells cast by the Vampire gain +6&quot; Range. This effect is decreased to +3&quot; Range for Aura spells. Bound Spells and spells without Range are not affected.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2208-4b49-3371-ebbd" name="Mask of Innocence" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="899b-8397-073b-357e" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e0df-2771-a395-2b5d" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="899b-8397-073b-357e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="baa9-6b47-5dc6-bf78" name="Mask of Innocence" hidden="false">
+              <description>Enemy units in base contact with one or more Vampires with this Mask of Innocence suffer -1 Discipline.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f30b-4575-1ad6-e689" name="Mesmerising Gaze" hidden="false" collective="false" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c295-84bf-e3c4-3d59" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4564-c7ad-019e-10cc" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a0f-243d-3482-b939" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96f7-15b4-bdfc-a16d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="a87a-0e9e-aaa2-69e4" value="-1">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="543a-c0c2-cc07-4680" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2c2c-0ef8-c83d-7d2c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a87a-0e9e-aaa2-69e4" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="45eb-5657-031f-961e" name="Mesmerising Gaze" hidden="false">
+              <description>The Vampire can cast Whispers of the Veil from Evocation as a Bound Spell with Power Level (4/8).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="0728-cf99-bcf2-692a" name="Reanimated" hidden="false">
+      <description>The number in brackets determines the number of Health Points Raised with Arise! (Hereditary Spell) and The Dead Arise (Bound Spell).</description>
+    </rule>
+    <rule id="8adf-722f-ae2c-a1c4" name="Master of Undeath" hidden="false">
+      <description>One Character in the Vampire Covenant Army must be nominated to be the Master. At the start of the game, the General is always the Master.</description>
+    </rule>
+    <rule id="07db-871a-166c-cd5c" name="Ashes to Ashes" hidden="false">
+      <description>At the end of any phase in which the Master is removed as a casualty, every unit in the Army with one or more models with Ashes to Ashes must pass a Discipline Test or lose a number of Health Points equal to the amount by which the test was failed, with no saves of any kind allowed. These Health Point losses are distributed following the rules for Unstable, except that they can never be distributed to models that do not have Ashes to Ashes. The number of Health Points lost is reduced by 1 if the unit receives Rally Around the Flag.
+
+At the end of the Player Turn in which the Master was removed as a casualty, a new Master may be selected. To do so, nominate a friendly Wizard Character, which either has Vampiric or is using Evocation. This Character becomes the new Master.
+
+At the start of each friendly Player Turn after the Master has been removed as a casualty and no new Master has been selected, every unit with Ashes to Ashes must once again pass a Discipline Test or lose Health Points as described above.
+</description>
+    </rule>
+    <rule id="9a62-c85f-1f78-e6ba" name="Gates of the Netherworld" hidden="false">
+      <description>Whenever a model with Gates of the Nehterworld successfully casts Arise!, after resolving the spell&apos;s effect, choose a friendly unit with a Reanimated value and within 12&quot; of the Caster. This unit, or a single Character inside the unit, Raises 1 Health Point. No unit can be chosen more than twice per Magic Phase by Gates of the Netherworld.</description>
+    </rule>
+    <rule id="ee94-d4bb-defb-f5e4" name="Awaken" hidden="false">
+      <description>The model can Raise Health Points above a unit&apos;s starting size for the units stated within brackets. However, units cannot be increased beyond twice their starting size or beyond the maximum unit size written in their unit entry. A unit&apos;s starting size is the size of the unit as written in the Army List (or the size of the unit at the time of its creation).</description>
+    </rule>
+    <rule id="966f-af74-d464-6581" name="Necromantic Aura" hidden="false">
+      <description>All friendly units within 6&quot; of one or more models with Necromantic Aura reduce the number of Health Point losses caused by Ashes to Ashes and Unstable by 1. </description>
+    </rule>
+    <rule id="2499-8b27-4a7b-11b0" name="The Dead Arise" hidden="false">
+      <description>The model can cast the following Bound Spell with Power Level (4/8).
+Range 12&quot;, Type: Ground, Duration: Instant. 
+Summon a unit listed in from the ones from the Awaken (X) Universal Rule of the Caster (declare which before casting) with as many Health Points as given by the Reanimated value of the unit. All models must be placed within the spell&apos;s Range, with at least one model on the target point. All upgrades except Command Group are allowed. The unit loses Scoring (if it had it)</description>
+    </rule>
+    <rule id="6cd9-16c5-3f63-3b44" name="Autonomous" hidden="false">
+      <description>Undead units consisting entirely of models with Autonomous may perform March Moves as normal, even when outside the range of friendly models&apos; Commanding Presence. The unit must still pass a Discipline Test in order to do so if within 8&quot; of non-Fleeing enemy units. </description>
+    </rule>
+    <rule id="2d4a-2a22-2cf0-d9ed" name="Reaper" hidden="false">
+      <description>A unit consisting entirely of models on foot with Reaper of which at least one model part has Reaper ignores all other units when moving in the Movement Phase, but it must follow the Unit Spacing rule at the end of its move.
+
+The unit can make a Sweeping Attack. The enemy unit suffers 1 hit with Strength 5 and Armour Penetration 10 for each model with Reaper in the unit.</description>
+    </rule>
+    <rule id="9809-d282-e3f2-8423" name="Vampiric" hidden="false">
+      <description>At the end of each Melee Phase, check and resolve the following effects for all units and Characters with Vampiric:
+⦁	Characters: If at least one attack with Vampiric made by the Character caused an enemy to lose a Health Point, the Character can make a single Vampiric roll. If successful, the Character Recovers a single Health Point.
+⦁	Units: If at least one attack with Vampiric made by a R&amp;F model in the unit caused an unsaved wound, the unit can make a single Vampiric roll. If successful, the unit Raises a single Health Point. 
+A Vampiric roll is successful if the D6 scores X+ (where X is the number stated within brackets). Use only the best value if a unit or Character has multiple parts with this Attack Attribute that each caused unsaved wounds. A roll of &apos;1&apos; on a Vampiric roll is always a failure and a &apos;6&apos; is always a success. Models with Towering Presence suffer a -2 modifier to their Vampiric rolls.</description>
+    </rule>
+    <rule id="1a5e-a0a2-3a1f-6f38" name="Unholy Appetite" hidden="false">
+      <description>After a Round of Combat in which attacks with Unholy Appetite​ caused an enemy model to lose one or more Health Points, all attacks with Unholy Appetite from models in the same unit​ must reroll failed to-hit rolls until the end of the next Player Turn.</description>
+    </rule>
+    <rule id="9221-c547-a843-bdb0" name="Ghostly Form" hidden="false">
+      <description>The model gains Magical Attacks and Ghost Step. R&amp;F models with this rule can only be joined by Characters with Ghostly Form.</description>
+    </rule>
+  </sharedRules>
+</catalogue>

--- a/vampireCovenant.cat
+++ b/vampireCovenant.cat
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ef6e-1eeb-e440-8944" name="Vampire Covenant 2.0" revision="21" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ef6e-1eeb-e440-8944" name="Vampire Covenant 2.0" revision="22" battleScribeVersion="2.02" authorName="Karanadon, Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
-    <categoryEntry id="dc98-3346-9b99-6af4" name="The Suffering (local)" hidden="false"/>
-    <categoryEntry id="eda3-1b96-c963-9650" name="Swift Death (local)" hidden="false"/>
-    <categoryEntry id="91d5-fdbc-855c-9e2e" name="Core (VC)" hidden="false"/>
+    <categoryEntry id="dc98-3346-9b99-6af4" name="The Suffering" hidden="false"/>
+    <categoryEntry id="eda3-1b96-c963-9650" name="Swift Death" hidden="false"/>
+    <categoryEntry id="91d5-fdbc-855c-9e2e" name="Core" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="3595-2e2e-b26d-8f77" name="Vampire Covenant (local)" hidden="false">
+    <forceEntry id="3595-2e2e-b26d-8f77" name="Vampire Covenant" hidden="false">
       <categoryLinks>
         <categoryLink id="d945-6fc8-48d6-5e6f" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -4028,9 +4028,6 @@ Regardless of whether it is used as a Shooting or Melee Attack, the Chilling Shr
           <infoLinks>
             <infoLink id="b91f-aadf-4a8d-59ab" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="b1a1-0da2-6011-45c6" name="New CategoryLink" hidden="false" targetId="ce40-9d61-830e-cdef" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
           </costs>
@@ -4245,9 +4242,6 @@ Regardless of whether it is used as a Shooting or Melee Attack, the Chilling Shr
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="276f-3976-6cc3-1166" name="New CategoryLink" hidden="false" targetId="0adc-f4e6-0c6b-c21b" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
           </costs>
@@ -4589,13 +4583,6 @@ Additionally, all R&amp;F models in friendly units from Core within 6” of one 
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fa72-d202-5a3a-962a" name="Vampiric Bloodline" hidden="false" collective="false">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e68-4cd6-4eeb-688a" type="notInstanceOf"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="63e6-a04a-b428-16d4" type="max"/>
       </constraints>

--- a/warriorsOfTheDarkGods.cat
+++ b/warriorsOfTheDarkGods.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.2" revision="38" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.2" revision="39" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="25f6-6ecf-2669-118b" name="8 Manifestation">
       <characteristicTypes>
@@ -10,7 +10,37 @@
   </profileTypes>
   <categoryEntries>
     <categoryEntry id="9c7a-3ec7-761f-798c" name="Doomlord General" hidden="false"/>
+    <categoryEntry id="1fbe-4213-4620-8ebc" name="Legendary Beasts (local)" hidden="false"/>
   </categoryEntries>
+  <forceEntries>
+    <forceEntry id="10a7-dcf0-85e0-68cf" name="Warriors of the Dark Gods (local)" hidden="false">
+      <categoryLinks>
+        <categoryLink id="9290-13d4-68c8-15bd" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="45.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="4756-3c62-1980-8447" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3b5f-1b7a-95fb-0e12" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false">
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="20.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="b70c-5732-5c2a-5edc" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7533-38d3-2f4d-94b2" name="Special" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
+        <categoryLink id="491d-2594-6fc5-5b41" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false">
+          <modifiers>
+            <modifier type="increment" field="e5e8-b343-e1be-6828" value="10">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c986-b1a1-09fe-0359" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="limit::24fd-8af8-0c78-001c" scope="roster" value="35.0" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="e5e8-b343-e1be-6828" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
   <selectionEntries>
     <selectionEntry id="007b-ee98-bbf2-a52a" name="Exalted Herald" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -386,7 +416,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7655-5c62-56f1-c053" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="0f70-cdce-3d3e-be47" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+                <categoryLink id="03e6-7c4d-c766-8365" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
               </categoryLinks>
             </entryLink>
             <entryLink id="830c-f7a4-a6ac-7d49" name="Wasteland Dragon" hidden="false" collective="false" targetId="21a7-64b7-d8bc-f979" type="selectionEntry">
@@ -402,7 +432,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9698-f2cf-e3e2-e903" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="26e9-d36d-f5b8-d647" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+                <categoryLink id="0f16-c47e-5360-442f" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
               </categoryLinks>
             </entryLink>
           </entryLinks>
@@ -506,7 +536,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="aea8-502d-a496-e66a" name="Warband Standard" hidden="false" collective="false" targetId="8636-7719-69f0-0244" type="selectionEntry"/>
+        <entryLink id="aea8-502d-a496-e66a" name="Trophy Rack" hidden="false" collective="false" targetId="8636-7719-69f0-0244" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="295.0"/>
@@ -601,6 +631,21 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="254b-d9c1-df68-e406" name="Army General" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da3d-da64-7d84-e06a" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf15-c3dc-0a88-1fb1" type="min"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="9cdd-94a5-df80-5d5b" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="5994-7cf8-5518-400b" name="Army General" hidden="false" collective="false" targetId="c30a-4220-8c73-d69b" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -937,7 +982,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2450-fabc-4790-478e" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="0e2b-8c35-8581-3226" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+                <categoryLink id="6e8b-3a38-70df-018f" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
               </categoryLinks>
             </entryLink>
             <entryLink id="46e3-1ebc-c065-f85a" name="Wasteland Behemoth" hidden="false" collective="false" targetId="46d6-395a-e95c-848b" type="selectionEntry">
@@ -948,7 +993,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b45c-7ba2-1d62-5141" type="max"/>
               </constraints>
               <categoryLinks>
-                <categoryLink id="19ab-4721-4256-b738" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+                <categoryLink id="fde9-41df-000e-506a" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
               </categoryLinks>
             </entryLink>
             <entryLink id="5734-ced8-7f12-7815" name="Battleshrine" hidden="false" collective="false" targetId="1b4a-aa28-6744-2c55" type="selectionEntry">
@@ -1228,16 +1273,6 @@ The model part gains Battle Focus when in a unit that has R&amp;F models with Ba
       </costs>
     </selectionEntry>
     <selectionEntry id="c986-b1a1-09fe-0359" name="Feldrak Ancestor" hidden="false" collective="false" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="fd13-ee02-6c4d-f46d" value="1">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52a8-daa4-79ee-d831" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd13-ee02-6c4d-f46d" type="min"/>
-      </constraints>
       <profiles>
         <profile id="ffb6-dc75-ea53-dda3" name="Feldrak Ancestor Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -1292,17 +1327,10 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a1b3-ef80-22ef-35f1" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
-        <categoryLink id="4d02-1d13-d395-8921" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+        <categoryLink id="9729-dcca-8e73-8f59" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="16f7-509b-ea96-1952" name="Army General" hidden="false" collective="false" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="b893-84c8-4406-2dbb" value="1">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52a8-daa4-79ee-d831" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4452-30dc-1b14-f8e5" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b893-84c8-4406-2dbb" type="min"/>
@@ -1602,12 +1630,12 @@ After using the Breath Attack, the model loses a Health Point (no saves of any k
       <modifiers>
         <modifier type="set" field="e6b6-9295-d5a9-53dc" value="2">
           <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c7a-3ec7-761f-798c" type="equalTo"/>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="254b-d9c1-df68-e406" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6b6-9295-d5a9-53dc" type="max"/>
+        <constraint field="selections" scope="roster" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6b6-9295-d5a9-53dc" type="max"/>
       </constraints>
       <profiles>
         <profile id="f037-3d8e-09a9-20a5" name="Fallen Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
@@ -3766,7 +3794,7 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
         <infoLink id="1c45-b3fb-7d36-d1bc" name="Unbreakable" hidden="false" targetId="99ef-69e8-164b-3335" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="c32b-595b-4e02-55a5" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="true"/>
+        <categoryLink id="429e-68b2-d668-5d90" name="New CategoryLink" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="400.0"/>
@@ -3817,10 +3845,13 @@ Whenever the model loses a Health Point, it gains +1 Attack Value. Whenever it g
         <infoLink id="fdc7-b085-8024-3fb5" name="Battle Fever" hidden="false" targetId="0e05-c2ea-20d5-5859" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="f04d-1fa5-712b-23c9" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="true"/>
+        <categoryLink id="2007-d6c0-e261-fee0" name="New CategoryLink" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="8e28-08b8-0cfe-24ee" name="Big Brother" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af9c-23fb-6b33-dc7b" type="max"/>
+          </constraints>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
           </costs>
@@ -3927,7 +3958,7 @@ Whenever the model loses a Health Point, it gains +1 Attack Value. Whenever it g
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="aacf-9511-1cc7-41e6" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="true"/>
+        <categoryLink id="4dce-88d8-5e38-8832" name="New CategoryLink" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8e66-ae15-522a-eea9" name="Melee Weapon" hidden="false" collective="false">
@@ -4031,7 +4062,7 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="bb69-e9bc-1598-10b6" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="true"/>
+        <categoryLink id="4fd6-2061-a173-cb9d" name="New CategoryLink" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6271-7b1c-4097-bb9f" name="Ominous Gateways" hidden="false" collective="false">
@@ -4171,7 +4202,7 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9b7e-11f1-30a5-cf94" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
-        <categoryLink id="3e9f-c49d-d987-be5e" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
+        <categoryLink id="2b72-ebab-4b53-df8c" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="245.0"/>
@@ -4242,160 +4273,6 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e24f-8262-f852-8a80" name="Doomlord (General)" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="b9ad-8622-2ba7-3183" name="Doomlord Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
-          <characteristics>
-            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
-            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
-            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
-            <characteristic name="Size" typeId="2e17-9c12-bfb4-59b0">Large</characteristic>
-            <characteristic name="Type" typeId="3145-83b1-14d6-8023">Infantry</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="5e66-b138-8d6c-1b3b" name="Doomlord Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
-          <characteristics>
-            <characteristic name="HP" typeId="f381-7850-7fa8-3440">4</characteristic>
-            <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
-            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
-            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="5655-293b-ce43-4422" name="Doomlord Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
-          <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">5</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">7</characteristic>
-            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
-            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="325f-bf08-039f-771a" name="Master of Destruction" hidden="false">
-          <description>The bearer can use a Shield (or a Spiked Shield) simultaneously with a Great Weapon or a Halberd.</description>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="a02a-65d3-6cad-cc9b" name="Path of the Exiled" hidden="false" targetId="45c4-f6e9-92e8-a409" type="rule"/>
-        <infoLink id="f1d2-13c8-4aea-a63c" name="Hell-Forged Armour" hidden="false" targetId="4b6e-450b-00c6-c6e9" type="profile"/>
-        <infoLink id="1d5a-2a8b-21bb-bd3a" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="e24f-8262-f852-8a80" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f890-c75e-1f95-1f70" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="8af2-c138-be5d-702a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
-        <categoryLink id="e4f3-f840-867b-2a8e" name="Doomlord General" hidden="false" targetId="9c7a-3ec7-761f-798c" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="e531-02b9-0925-88c1" name="Special Equipment" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b5cd-7f39-09c8-bf65" type="max"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="aa10-8abf-d1ad-2de0" name="Special Equipment" hidden="false" collective="false">
-              <constraints>
-                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e18a-690e-24dc-55fb" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="c6bc-44d9-fa9e-dd6b" name="Armour Enchantments" hidden="false" collective="false" targetId="f975-dd5b-da67-142e" type="selectionEntryGroup"/>
-                <entryLink id="287d-7b6f-a044-07eb" name="Weapon Enchantments" hidden="false" collective="false" targetId="cb21-fc0e-6fbe-9a3b" type="selectionEntryGroup"/>
-                <entryLink id="0c2c-fc82-243b-dbb3" name="Banner Enchantments" hidden="true" collective="false" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="e24f-8262-f852-8a80" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="49ae-a946-8772-3c98" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="22b3-67a4-b420-86ea" name="Artefacts" hidden="false" collective="false" targetId="17df-ad66-db37-0a37" type="selectionEntryGroup"/>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f890-c75e-1f95-1f70" name="Replace Shield with Spiked Shield" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ff6-33cd-594e-fb3c" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="5bc4-8727-b9da-bc84" name="Spiked Shield" hidden="false" targetId="7063-e7a2-b5ce-ea7b" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="975b-dd1b-fad9-eaec" name="Melee Weapon" hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9ec-3dbe-877e-0f26" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="b82b-74e3-66e9-d268" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5ce-4293-e011-83c9" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="ccf4-5053-1c31-9462" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="eca4-63c3-b5f1-6521" name="Great Weapon" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="259b-51ca-ef1d-080e" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="d59d-20a0-7738-0f10" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a9a9-6a27-6842-f61c" name="Halberd" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="473b-7687-af83-426a" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="284a-2f91-2bd7-c5f9" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7d38-2c32-b471-1ad9" name="Wasteland Behemoth" hidden="false" collective="false" targetId="46d6-395a-e95c-848b" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="225"/>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77ad-ce87-302c-f649" type="max"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="b9bc-22e7-4110-5545" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-          </categoryLinks>
-        </entryLink>
-        <entryLink id="49ae-a946-8772-3c98" name="Trophy Rack" hidden="false" collective="false" targetId="8636-7719-69f0-0244" type="selectionEntry"/>
-        <entryLink id="a812-b0c1-074b-d1b5" name="Army General" hidden="false" collective="false" targetId="c30a-4220-8c73-d69b" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="360.0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>

--- a/warriorsOfTheDarkGods.cat
+++ b/warriorsOfTheDarkGods.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.2" revision="39" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.2" revision="40" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="25f6-6ecf-2669-118b" name="8 Manifestation">
       <characteristicTypes>
@@ -10,10 +10,10 @@
   </profileTypes>
   <categoryEntries>
     <categoryEntry id="9c7a-3ec7-761f-798c" name="Doomlord General" hidden="false"/>
-    <categoryEntry id="1fbe-4213-4620-8ebc" name="Legendary Beasts (local)" hidden="false"/>
+    <categoryEntry id="1fbe-4213-4620-8ebc" name="Legendary Beasts" hidden="false"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="10a7-dcf0-85e0-68cf" name="Warriors of the Dark Gods (local)" hidden="false">
+    <forceEntry id="10a7-dcf0-85e0-68cf" name="Warriors of the Dark Gods" hidden="false">
       <categoryLinks>
         <categoryLink id="9290-13d4-68c8-15bd" name="Characters" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false">
           <constraints>
@@ -275,14 +275,9 @@
             <selectionEntry id="1121-bef0-a730-02ea" name="Daemonic Wings" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52a8-daa4-79ee-d831" type="equalTo"/>
-                        <condition field="selections" scope="0e4c-6a11-1423-6af4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="639d-9691-d5a4-fa06" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="639d-9691-d5a4-fa06" type="equalTo"/>
+                  </conditions>
                 </modifier>
               </modifiers>
               <constraints>
@@ -699,9 +694,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc5f-42b2-4036-0c89" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="ea85-4ca9-e0c9-358b" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-          </categoryLinks>
         </entryLink>
         <entryLink id="301d-a84e-15f6-e3a5" name="Trophy Rack" hidden="false" collective="false" targetId="8636-7719-69f0-0244" type="selectionEntry"/>
       </entryLinks>
@@ -1160,9 +1152,6 @@ The model part gains Battle Focus when in a unit that has R&amp;F models with Ba
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c199-3527-1efe-8cbf" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="caa6-a1dc-3cca-7998" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="9c3d-847a-f901-7dcd" name="War Dais" hidden="false" collective="false" targetId="b168-546c-9ddc-a9b9" type="selectionEntry">
               <modifiers>
@@ -1195,9 +1184,6 @@ The model part gains Battle Focus when in a unit that has R&amp;F models with Ba
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14f0-6abd-31a3-2883" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="3254-8bb1-b0e1-6c24" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
-              </categoryLinks>
             </entryLink>
             <entryLink id="23b8-b8df-367a-9ee2" name="Black Steed" hidden="false" collective="false" targetId="4851-37d7-9820-f20b" type="selectionEntry">
               <modifiers>
@@ -4453,21 +4439,16 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
         <infoLink id="3a57-fe2c-8da1-556c" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
         <infoLink id="c129-7f2f-eb7b-7298" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="299a-6d61-7f48-2bfc" name="Legendary Beasts" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="69d9-8b66-3397-5214" name="Wings" hidden="false" collective="false" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52a8-daa4-79ee-d831" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7ef-6667-b5ba-8527" type="max"/>
           </constraints>
           <categoryLinks>
             <categoryLink id="87f7-4444-98e6-d46a" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="false"/>
-            <categoryLink id="9d73-91d2-8cad-b6e6" name="New CategoryLink" hidden="false" targetId="304c-a8a1-cb0f-3db5" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
@@ -4719,13 +4700,6 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
       </costs>
     </selectionEntry>
     <selectionEntry id="fdff-f359-5df2-64b3" name="Scythed Skywheel" hidden="false" collective="false" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52a8-daa4-79ee-d831" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c8e-34ff-df6a-f320" type="max"/>
       </constraints>
@@ -4814,13 +4788,6 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
       </costs>
     </selectionEntry>
     <selectionEntry id="21a7-64b7-d8bc-f979" name="Wasteland Dragon" hidden="false" collective="false" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52a8-daa4-79ee-d831" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23d7-099c-d64a-10b2" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ba4e-e92a-824e-1076" type="max"/>


### PR DESCRIPTION
All files named to naming convention. Removed all forces and categories from game system and pulled them down into the armies instead.

* Made Doomlord (General) option irrelevant.
* Made extra force for Vermin Daemon ireelevant
* Made extra force for Vampiric Bloodlines irrelevant
* Made extra force entry for Feldrak Ancestor irrelevant
* Version 2.2 Update for Asklanders
* Point cost fixes for DL 2.2
* Count Chimera mounts correctly towards Legendary Beasts
* Do not prevent some non-sensical, but technically allowed upgrades with Feldrak Ancestor

Fixes #297 
Fixes #294 
Fixes #293 
Fixes #289 
