### PR TITLE
Army file scrubbing: Beast Herds

### DIFF
--- a/beastHerds.cat
+++ b/beastHerds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f4f2-e414-182d-9513" name="Beast Herds 2.0" revision="18" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f4f2-e414-182d-9513" name="Beast Herds 2.0" revision="19" battleScribeVersion="2.02" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="b739-c731-20eb-f075" name="Ambush Predators" hidden="false"/>
     <categoryEntry id="c6e5-9f4e-63f5-1cc0" name="Terrors of the Wild" hidden="false"/>
@@ -568,15 +568,6 @@
             <modifier type="append" field="name" value=" (Forest)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="83d0-ceb1-da04-f32c" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="ce92-bf1a-5a18-09ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96e3-71c7-3074-ce09" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c577-952c-ce72-0862" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
@@ -625,7 +616,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a43c-0d36-6e34-4a1f" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="18ef-5634-34fc-fe65" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+            <infoLink id="18ef-5634-34fc-fe65" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
@@ -644,9 +635,10 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="96e3-71c7-3074-ce09" name="May become" hidden="false" collective="false">
+        <selectionEntryGroup id="96e3-71c7-3074-ce09" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="07d9-a9d8-9145-213c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a7c-4bcc-8d48-808c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce58-16cf-f25b-d0f7" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="ee4d-5c67-578f-1b12" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
@@ -665,11 +657,16 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="07d9-a9d8-9145-213c" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="c27f-54e0-70a0-0019" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
+            </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9cff-1b38-a037-20a6" name="Must Select Spells from" hidden="false" collective="false">
+        <selectionEntryGroup id="9cff-1b38-a037-20a6" name="Magic Path" hidden="false" collective="false">
           <modifiers>
-            <modifier type="set" field="7403-e586-3f7a-96cf" value="2">
+            <modifier type="set" field="hidden" value="true">
               <conditions>
                 <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
               </conditions>
@@ -699,6 +696,45 @@
             <selectionEntry id="2d19-492a-9477-8ee3" name="Evocation" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="593b-f55c-fbd0-01d1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d6e0-25cb-919f-3868" name="Magic Path" hidden="true" collective="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8deb-ef08-4e9c-8fb6" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c312-95ee-71c7-2a6e" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8c90-b553-6a73-f9bb" name="Shamanism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57fa-0f64-4fbf-0325" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1ab1-a32a-fd12-b4cf" name="Druidism" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d09d-b810-418c-6150" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3e7a-86c5-ecce-73e5" name="Evocation" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="22bf-de08-101a-4625" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
@@ -763,15 +799,6 @@
             <modifier type="append" field="name" value=" (Forest)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="12ec-ce34-346a-9116" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="377e-9f45-b2cc-9f0c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="44df-53e3-8c12-99c9" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="a50d-f690-7c08-1d76" name="Ambush" hidden="false" targetId="2dda-ee2f-cfce-7f16" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -786,9 +813,9 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="f2cb-eff3-aaff-4f77" name="Special Equipment" hidden="false" collective="false">
               <modifiers>
-                <modifier type="set" field="5d14-c335-909b-0f63" value="200">
+                <modifier type="set" field="5d14-c335-909b-0f63" value="200.0">
                   <conditions>
-                    <condition field="selections" scope="377e-9f45-b2cc-9f0c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e839-ddaa-fe17-03f8" type="equalTo"/>
+                    <condition field="selections" scope="377e-9f45-b2cc-9f0c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="611f-a490-96ac-eaeb" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -822,7 +849,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a6-83b8-d64f-2125" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="7b1c-9aaa-8450-8f62" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+            <infoLink id="7b1c-9aaa-8450-8f62" name="Light Armour" hidden="false" targetId="ceb4-e216-c1ec-56a4" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
@@ -841,30 +868,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="44df-53e3-8c12-99c9" name="May become" hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03d5-3e2c-3eec-ad51" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="057f-d3c7-eae7-b647" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7dfd-c55f-b721-65c3" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e839-ddaa-fe17-03f8" name="Wizard Master" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="dd52-e290-56d1-7b1d" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e908-9fd2-b2cb-a12f" name="Must Select Spells from" hidden="false" collective="false">
+        <selectionEntryGroup id="e908-9fd2-b2cb-a12f" name="Magic Path" hidden="false" collective="false">
           <modifiers>
             <modifier type="set" field="7377-27cd-a9de-5e13" value="2">
               <conditions>
@@ -900,6 +904,35 @@
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d98-b572-a677-2b85" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="361d-85f7-0f4b-846a">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="30c7-aae3-ae08-dfe6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6abb-9c5c-dc20-17d1" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8ba3-1d81-54f0-8809" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="ea5c-13f0-dd6c-a280" name="Wizard Adept" hidden="false" targetId="c0a6-6da5-98d6-f051" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="611f-a490-96ac-eaeb" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="944a-dad0-7587-7710" name="Weapon Master" hidden="false" targetId="a9a1-31b4-37a3-4138" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="225.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="361d-85f7-0f4b-846a" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="aaca-2422-ebf9-ae0d" name="Wizard Apprentice" hidden="false" targetId="0d8a-3fd8-a61d-5b74" type="rule"/>
+              </infoLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1140,7 +1173,7 @@
       <entryLinks>
         <entryLink id="8141-9a0f-672a-1940" name="Greater Totem Bearer" hidden="false" collective="false" targetId="2660-c88a-bf3d-3113" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="85"/>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="85.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8b1-d72d-57e2-26b6" type="max"/>
@@ -2222,7 +2255,7 @@
         </selectionEntry>
         <selectionEntry id="560d-cf72-0ae5-5fa8" name="Throwing Weapons (5+)" hidden="false" collective="false" type="upgrade">
           <modifiers>
-            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2">
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="2.0">
               <repeats>
                 <repeat field="selections" scope="e997-3585-abdd-4579" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fed7-344d-0670-b5a5" repeats="1" roundUp="false"/>
               </repeats>
@@ -2486,11 +2519,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="116d-6072-81cc-6cdc" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="862f-c712-8ca8-ca90" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
-              <categoryLinks>
-                <categoryLink id="3bac-3338-646e-4abe" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
-            </entryLink>
+            <entryLink id="862f-c712-8ca8-ca90" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
@@ -2572,9 +2601,6 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c7b-c7d3-5ca2-0a64" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="c03f-d2ee-9ed2-3719" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
               </costs>
@@ -2583,9 +2609,6 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7ce-b923-4322-add0" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="0d04-e394-f6bb-dbe9" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
               </costs>
@@ -2668,9 +2691,6 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e973-6f12-9f5a-56de" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="7c69-13b8-4165-519f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
               </costs>
@@ -2679,9 +2699,6 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d60-05af-c2ff-2c47" type="max"/>
               </constraints>
-              <categoryLinks>
-                <categoryLink id="be78-e3cd-f42b-ee5c" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
               </costs>
@@ -2740,7 +2757,7 @@
         <categoryLink id="7c20-96a9-6324-5a1c" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b00f-1b53-88f2-b373" name="Feral Hound" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b00f-1b53-88f2-b373" name="Feral Hound" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bf5-8abd-2fc1-a7c4" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3e5-2692-5333-943c" type="min"/>
@@ -2804,14 +2821,11 @@
         <categoryLink id="e2eb-b690-ee2c-e33b" name="Ambush Predators (local)" hidden="false" targetId="b739-c731-20eb-f075" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9a5a-5677-4326-95eb" name="Feral Hound" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9a5a-5677-4326-95eb" name="Feral Hound" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db12-0715-60da-86ec" type="max"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ce5-3349-f7b0-6a11" type="min"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="69c5-7f5b-79ca-6bd6" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
           </costs>
@@ -2910,9 +2924,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a795-485b-92e6-0045" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="1544-a23b-2c4d-80d7" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink id="b29a-b4c5-7edc-0f31" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
           </entryLinks>
@@ -3035,9 +3046,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d403-b75a-3560-6078" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="21b2-7f2c-f10d-39d4" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="false"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink id="c8e6-3503-0d0d-a5b9" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
           </entryLinks>
@@ -3055,7 +3063,7 @@
                 <condition field="selections" scope="2270-bb3a-ad96-ebda" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3e7-8c28-0d42-6aa8" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="15"/>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="15.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4258-73f5-cf0b-e48f" type="max"/>
@@ -3119,7 +3127,7 @@
         <categoryLink id="125b-5071-e5a4-b65d" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="14ae-e4e1-d6c6-7b1d" name="Minotaur" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="14ae-e4e1-d6c6-7b1d" name="Minotaur" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a29-5584-9307-5a29" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="96b4-f4c2-954b-5350" type="max"/>
@@ -3139,15 +3147,8 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f3dd-e3e5-9f77-e3ff" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="87d9-00bd-3eb3-cc5f" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <entryLinks>
-            <entryLink id="cfee-c0e8-8fa1-bb60" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
-              <categoryLinks>
-                <categoryLink id="7f2a-91c6-4c84-0fbd" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
-            </entryLink>
+            <entryLink id="cfee-c0e8-8fa1-bb60" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
@@ -3159,9 +3160,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc81-d9ff-feb5-e30e" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="7597-51b1-cb3d-0427" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="38d6-1c70-3e83-d6d6" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
               <modifiers>
@@ -3243,9 +3241,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5723-6f09-98fc-b3d6" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="f34b-adc1-41d3-75cf" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -3323,9 +3318,6 @@
           <infoLinks>
             <infoLink id="2f66-34a2-8cac-1c16" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="5d5c-1e6b-662f-f0b7" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
@@ -3341,14 +3333,11 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="029c-4dc2-0163-2b03" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="709d-262f-ff6e-75d2" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink id="0264-2fd7-bacd-1c15" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
-              <categoryLinks>
-                <categoryLink id="541c-e8ed-f3e3-18b1" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d34-501a-b705-7a6c" type="max"/>
+              </constraints>
             </entryLink>
           </entryLinks>
           <costs>
@@ -3361,9 +3350,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bcd-7e65-afe5-78ed" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="b395-a643-5a58-b2a1" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="e838-0152-5dcd-168c" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
               <modifiers>
@@ -3445,9 +3431,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84e7-2929-7737-7ff1" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="bc2e-ab92-e03f-b280" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -3527,9 +3510,6 @@
           <infoLinks>
             <infoLink id="7e5e-abe9-7f1a-6fd0" name="Throwing Weapons" hidden="false" targetId="8c83-06ff-024f-a235" type="profile"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink id="26c0-10bd-c578-5918" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
@@ -3545,15 +3525,8 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dcdf-24b8-bcea-41ab" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="831a-84ae-2881-6c13" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <entryLinks>
-            <entryLink id="359a-dddc-7078-396e" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup">
-              <categoryLinks>
-                <categoryLink id="84c3-14f5-8e0c-b953" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-              </categoryLinks>
-            </entryLink>
+            <entryLink id="359a-dddc-7078-396e" name="Banner Enchantments" hidden="false" collective="false" targetId="77fe-fe82-fc43-7c81" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
@@ -3565,9 +3538,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eaf-ca6f-96e8-c937" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="ed91-776e-1180-5bd5" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="cd71-2cc6-d262-44cd" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
               <modifiers>
@@ -3649,9 +3619,6 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a5b-7c2d-2e80-4f6d" type="max"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink id="9c97-6aea-4d5d-b6a0" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
-          </categoryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -4010,7 +3977,7 @@
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="230.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f605-9c88-9e05-b238" name="Briar Beast" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f605-9c88-9e05-b238" name="Briar Beast" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8551-aa73-674f-7cad" type="max"/>
       </constraints>
@@ -4120,7 +4087,7 @@
         <categoryLink id="eb46-f0a5-745f-7757" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2ba1-6690-58c1-14b0" name="Gargoyle" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2ba1-6690-58c1-14b0" name="Gargoyle" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ec7-94bc-101d-3f92" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b638-59bd-25d2-e110" type="max"/>


### PR DESCRIPTION
* Magic Path Update for Soothsayer
* Banner Enchantments for Special category units do no longer count towards core
* Command Group options for Special categoriy units do no longer counts towards core
* Soothsayer Light Armour correctly shows rules for Light Armour (instead of Heavy Armour)
* Renamed Soothsayer options "One choice only" and "May become" to "Magic Path" and "Wizard Level"
* Categorized all unit models correctly as models (instead of upgrades)