### PR TITLE
DL file scrubbing

### DIFF
--- a/daemonLegions.cat
+++ b/daemonLegions.cat
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a422-c29f-5027-f336" name="Daemon Legions 2.2" revision="31" battleScribeVersion="2.02" authorName="Artur &apos;WarX&apos; Fijalkowski, DarkSky" authorContact="wiki.warx@gmail.com" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a422-c29f-5027-f336" name="Daemon Legions 2.2.2" revision="32" battleScribeVersion="2.02" authorName="Artur &apos;WarX&apos; Fijalkowski, DarkSky" authorContact="wiki.warx@gmail.com" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <publications>
+    <publication id="3f95-f87e-5df2-4102" name="T9A – Daemon Legions"/>
+  </publications>
   <profileTypes>
     <profileType id="e6e2-5027-c8f6-da13" name="2 Defensive">
       <characteristicTypes>
@@ -18,13 +21,6 @@
         <characteristicType id="6779-0c09-2d7f-5077" name="AP"/>
         <characteristicType id="b053-1905-7bef-a4b3" name="Agi"/>
         <characteristicType id="4713-eeae-87ae-0ef2" name="Rules"/>
-      </characteristicTypes>
-    </profileType>
-    <profileType id="cd63-b670-ea21-438d" name="7 Manifestation">
-      <characteristicTypes>
-        <characteristicType id="2370-1857-1c8d-6a2c" name="Sin"/>
-        <characteristicType id="aa84-02c9-7d6d-3550" name="Guiding"/>
-        <characteristicType id="8ab6-438f-59da-7237" name="Description"/>
       </characteristicTypes>
     </profileType>
     <profileType id="af60-d32b-0a9b-275d" name="8 Dominion">
@@ -1073,6 +1069,9 @@
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8bf-7d3f-3cda-092b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd86-150b-09c3-2432" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="99a9-7372-8cd5-ccf9" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
@@ -1168,7 +1167,7 @@
             </entryLink>
             <entryLink id="d289-4174-f51f-3c07" name="Unit - Aura of Despair" hidden="false" collective="false" targetId="6f4b-fe91-ef41-420a" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="4.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1827,7 +1826,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="41ad-ae6c-84eb-a455" name="Wizard Level" hidden="false" collective="false">
+        <selectionEntryGroup id="41ad-ae6c-84eb-a455" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="cd70-3261-6536-a5fd">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca3-7176-9917-79de" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="904f-f1bf-6aa8-74e4" type="min"/>
@@ -2104,7 +2103,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
           </modifiers>
           <characteristics>
             <characteristic name="Sin" typeId="3905-9e58-d9a0-f7d5">Lust</characteristic>
-            <characteristic name="Description" typeId="2945-4921-f954-c0f5">The affected models gain +2″ March Rate and must reroll failed Charge Range rolls when Charging an enemy unit in its Flank or Rear Facing.</characteristic>
+            <characteristic name="Description" typeId="2945-4921-f954-c0f5">The model gains Strider. Units consisting entirely of models with Dominion of Lust must reroll failed Charge Range rolls if they are Located in the Charged unit’s Flank or Rear Facing when rolling their Charge Range in the Charge Phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2231,7 +2230,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <entryLinks>
         <entryLink id="c682-1835-927b-d05b" name="Army General" hidden="false" collective="false" targetId="82d3-0515-73cb-6df1" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="35"/>
+            <modifier type="set" field="24fd-8af8-0c78-001c" value="35.0"/>
           </modifiers>
         </entryLink>
       </entryLinks>
@@ -2577,7 +2576,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </profiles>
       <rules>
         <rule id="88e6-54cb-19f1-aa52" name="Spell Craving" hidden="false">
-          <description>The model can perform up to 3 Supporting Attacks. When determining Combat Score, a side with at least one model with Spell Craving Engaged in Combat adds +X to its side’s Combat Score, where X is the number of non-Bound non-Attribute Spells known by enemy Wizards in units in base contact with it.</description>
+          <description>The model can perform up to 3 Supporting Attacks. When determining Combat Score, a side with at least one model with Spell Craving Engaged in Combat adds +X to its side’s Combat Score, where X is the number of non-Bound non-Attribute Spells known by enemy Wizards in units in base contact with it (note that multiple instances of the same spell count as 1 each).</description>
         </rule>
         <rule id="2a71-36d4-1e9d-16f8" name="Veil Stalker" hidden="false">
           <description>The model follows the rules for Ambush with the following exceptions. When the unit arrives, it may choose to be placed within 6″ of an enemy model with Channel (instead of with its Rear Facing touching the Board Edge). If so, it cannot perform any Advance Moves this Movement Phase (note that this does not prevent the unit from performing a Reform).</description>
@@ -2948,9 +2947,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e6c-edaa-00fc-f98b" name="Blazing Glories" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0e6c-edaa-00fc-f98b" name="Blazing Glory" hidden="false" collective="false" type="unit">
       <modifiers>
-        <modifier type="decrement" field="ad7c-694b-1248-8aa7" value="1">
+        <modifier type="decrement" field="ad7c-694b-1248-8aa7" value="1.0">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4018-2042-49c3-9881" repeats="1" roundUp="false"/>
           </repeats>
@@ -2960,7 +2959,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad7c-694b-1248-8aa7" type="max"/>
       </constraints>
       <profiles>
-        <profile id="5ea5-776f-69a8-f15c" name="Blazing Glories" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+        <profile id="5ea5-776f-69a8-f15c" name="Blazing Glory" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
@@ -2969,7 +2968,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
           </characteristics>
         </profile>
-        <profile id="6898-0438-7574-198f" name="Blazing Glories" hidden="false" typeId="e6e2-5027-c8f6-da13" typeName="2 Defensive">
+        <profile id="6898-0438-7574-198f" name="Blazing Glory" hidden="false" typeId="e6e2-5027-c8f6-da13" typeName="2 Defensive">
           <characteristics>
             <characteristic name="HP" typeId="61df-0ca3-17b2-f001">5</characteristic>
             <characteristic name="Def" typeId="5b8d-8753-654e-d9f8">*</characteristic>
@@ -2978,7 +2977,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             <characteristic name="Aeg" typeId="9820-1785-03cb-9eae">5+</characteristic>
           </characteristics>
         </profile>
-        <profile id="1249-f19c-026e-eeb1" name="Blazing Glories" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
+        <profile id="1249-f19c-026e-eeb1" name="Blazing Glory" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
           <characteristics>
             <characteristic name="Att" typeId="e9a7-9590-af60-1be6">5</characteristic>
             <characteristic name="Off" typeId="b767-2d7a-52d9-f1ba">*</characteristic>
@@ -3010,9 +3009,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="320.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4018-2042-49c3-9881" name="Blazing Glories - Fly" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4018-2042-49c3-9881" name="Blazing Glory - Fly" hidden="false" collective="false" type="unit">
       <modifiers>
-        <modifier type="decrement" field="01eb-821e-8d4e-f4ae" value="1">
+        <modifier type="decrement" field="01eb-821e-8d4e-f4ae" value="1.0">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e6c-edaa-00fc-f98b" repeats="1" roundUp="false"/>
           </repeats>
@@ -3022,7 +3021,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="01eb-821e-8d4e-f4ae" type="max"/>
       </constraints>
       <profiles>
-        <profile id="0be1-9f06-058d-fd82" name="Blazing Glories" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+        <profile id="0be1-9f06-058d-fd82" name="Blazing Glory" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <modifiers>
             <modifier type="append" field="b0d9-2dab-f10b-9b13" value=" (7&quot;)"/>
             <modifier type="append" field="db10-a838-f72f-3ed6" value=" (14&quot;)"/>
@@ -3035,7 +3034,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
           </characteristics>
         </profile>
-        <profile id="6751-6c7d-042b-33eb" name="Blazing Glories" hidden="false" typeId="e6e2-5027-c8f6-da13" typeName="2 Defensive">
+        <profile id="6751-6c7d-042b-33eb" name="Blazing Glory" hidden="false" typeId="e6e2-5027-c8f6-da13" typeName="2 Defensive">
           <characteristics>
             <characteristic name="HP" typeId="61df-0ca3-17b2-f001">5</characteristic>
             <characteristic name="Def" typeId="5b8d-8753-654e-d9f8">*</characteristic>
@@ -3044,7 +3043,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             <characteristic name="Aeg" typeId="9820-1785-03cb-9eae">5+</characteristic>
           </characteristics>
         </profile>
-        <profile id="4b36-6aa5-6e31-be4e" name="Blazing Glories" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
+        <profile id="4b36-6aa5-6e31-be4e" name="Blazing Glory" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
           <characteristics>
             <characteristic name="Att" typeId="e9a7-9590-af60-1be6">5</characteristic>
             <characteristic name="Off" typeId="b767-2d7a-52d9-f1ba">*</characteristic>
@@ -3065,6 +3064,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <infoLink id="2f0d-0165-743a-24af" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
         <infoLink id="2dd0-3ea1-7c05-9d15" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
         <infoLink id="309d-65a9-fee5-3d08" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+        <infoLink id="e8dd-fd68-cd74-f9eb" name="Fly" hidden="false" targetId="4a5a-48a4-b2f9-f6ed" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ff38-8b87-7ce9-76e5" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
@@ -3283,7 +3283,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
           <entryLinks>
             <entryLink id="5bd1-daca-9105-2bcd" name="Unit - Incendiary Ichor" hidden="false" collective="false" targetId="7679-cd89-0364-5aad" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="3.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3292,7 +3292,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="c9a7-e519-0329-e07c" name="Unit - Red Haze" hidden="false" collective="false" targetId="f196-5e13-bbef-20bd" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="21">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="21.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3301,7 +3301,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="4f1d-1b5f-1065-65e0" name="Unit - Whipcrack Tail" hidden="false" collective="false" targetId="a8de-e45d-4d3c-5858" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="12">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="12.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3310,7 +3310,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="9927-97e4-150c-cd3d" name="Unit - Chitinous Scales" hidden="false" collective="false" targetId="3fe2-a165-7438-54da" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3319,7 +3319,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="fe72-ae89-924c-f0f3" name="Unit - Centipede Legs" hidden="false" collective="false" targetId="9014-f681-74cb-b6b6" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="8.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3341,7 +3341,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e553-596e-9b35-0b6a" type="max"/>
       </constraints>
       <profiles>
-        <profile id="da09-0401-15b8-9439" name="Furies" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+        <profile id="da09-0401-15b8-9439" name="Fury" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot; (10&quot;)</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot; (20&quot;)</characteristic>
@@ -3350,7 +3350,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             <characteristic name="Type" typeId="3145-83b1-14d6-8023">Beast</characteristic>
           </characteristics>
         </profile>
-        <profile id="7cdf-784a-b66e-c14d" name="Furies" hidden="false" typeId="e6e2-5027-c8f6-da13" typeName="2 Defensive">
+        <profile id="7cdf-784a-b66e-c14d" name="Fury" hidden="false" typeId="e6e2-5027-c8f6-da13" typeName="2 Defensive">
           <characteristics>
             <characteristic name="HP" typeId="61df-0ca3-17b2-f001">1</characteristic>
             <characteristic name="Def" typeId="5b8d-8753-654e-d9f8">3</characteristic>
@@ -3496,13 +3496,13 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </profiles>
       <rules>
         <rule id="1bba-f834-77ff-b863" name="Morphlings" hidden="false">
-          <description>During Spell Selection, each unit of Veil Serpents must choose a Manifestation from the list below and apply the effects during the game. • Chilling Yawn • Mesmerising Plumage • Tar Skin</description>
+          <description>During Spell Selection, each unit of Veil Serpents must choose a Manifestation from the list below and apply the effects during the game.
+· Mirrored Scales
+· Mesmerising Plumage
+· Chilling Yawn</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="3d49-17ed-83a9-c2fd" name="Tarskin - Dominant" hidden="false" targetId="400c-0a14-47ec-0756" type="profile"/>
-        <infoLink id="6db5-9a02-dd5e-b22c" name="Mesmerising Plumage - Dominant" hidden="false" targetId="533b-99fe-e5f6-c690" type="profile"/>
-        <infoLink id="54ff-3ce2-1fb0-88af" name="Chilling Yawn - Dominant" hidden="false" targetId="5659-3a16-3d07-276f" type="profile"/>
         <infoLink id="4666-965a-a69e-eb7d" name="Wizard Conclave" hidden="false" targetId="7455-f914-028b-3359" type="rule"/>
         <infoLink id="2f57-f0f9-5b5f-a082" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
         <infoLink id="7069-e44e-7a92-27ff" name="Supernal" hidden="false" targetId="4d9a-1dea-1661-4083" type="rule"/>
@@ -3674,7 +3674,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
           <entryLinks>
             <entryLink id="8c7c-d9fc-3bc0-a63e" name="Unit - Dextrous Tentacles" hidden="false" collective="false" targetId="fedb-d9a8-d699-5d44" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="7">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="7.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3683,7 +3683,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="ffc3-1767-0312-b5e7" name="Unit - Unhinging Jaw" hidden="false" collective="false" targetId="f5b5-176e-d138-9e9e" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="7">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="7.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3692,7 +3692,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="f74d-8873-3655-ae02" name="Unit - Digestive Vomit" hidden="false" collective="false" targetId="dd92-a99c-d63c-b2bf" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="10.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3701,7 +3701,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
             </entryLink>
             <entryLink id="f070-2a0c-22f0-7d77" name="Unit - Kaleidoscopic Flesh" hidden="false" collective="false" targetId="f137-39d8-d3f5-c363" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="24fd-8af8-0c78-001c" value="11">
+                <modifier type="increment" field="24fd-8af8-0c78-001c" value="11.0">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -3715,7 +3715,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <entryLink id="3c29-c3ec-a3dc-d661" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
         <entryLink id="cd5a-e088-6d5e-43af" name="Unit - Broodmother" hidden="false" collective="false" targetId="5c5d-b745-4ab1-3403" type="selectionEntry">
           <modifiers>
-            <modifier type="increment" field="24fd-8af8-0c78-001c" value="15">
+            <modifier type="increment" field="24fd-8af8-0c78-001c" value="15.0">
               <repeats>
                 <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
@@ -3829,9 +3829,10 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="13af-d873-0aaf-a85c" name="Wizard Level" hidden="false" collective="false">
+        <selectionEntryGroup id="13af-d873-0aaf-a85c" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="55f5-e607-86db-b72f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c4a-8e23-6bf5-85f5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="278b-28f5-2ddf-e180" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="f44a-6c55-9fd4-a0f5" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
@@ -3855,6 +3856,11 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
               <costs>
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
               </costs>
+            </selectionEntry>
+            <selectionEntry id="55f5-e607-86db-b72f" name="Not a Wizard" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0988-cd84-6988-4c3b" type="max"/>
+              </constraints>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4678,6 +4684,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="f9a2-7553-a87c-bf04" name="Guiding - Brimstone Secretions" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="5318-a13b-f993-edcc" name="Brimstone Secretions (Guiding)" hidden="false" targetId="a361-9ff9-d38c-2ae8" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="6ae5-6720-033a-d708" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4686,6 +4695,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="ea63-a68c-9cf7-1dfc" name="Guiding - Bronze Backbone" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="6b5f-7070-1400-02cc" name="Bronze Backbone (Guiding)" hidden="false" targetId="c7b6-f47e-fed1-71e5" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="175b-d4c5-c3d1-44b3" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4694,6 +4706,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="0b67-5711-5237-9d0b" name="Guiding - Broodmother" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="7a01-6997-3dd9-1bb5" name="Broodmother (Guiding)" hidden="false" targetId="ef3b-cd0e-ac78-b679" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="8928-ca09-b79c-9617" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4702,6 +4717,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="2612-a224-6aeb-79f0" name="Guiding - Dextrous Tentacles" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="fd85-1aa4-d0e3-0d83" name="Dextrous Tentacles (Guiding)" hidden="false" targetId="9b4d-89d1-b96c-e25b" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="ccdc-eb4f-e22a-ad69" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4710,6 +4728,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="179b-e388-9bae-22b6" name="Guiding - Centipede Legs" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="73bd-ecb7-675e-ebc0" name="Centipede Legs (Guiding)" hidden="false" targetId="cc45-50dd-97b5-5f44" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="221b-5c1e-6c6e-5184" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4718,6 +4739,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="3f58-f25a-0f16-83da" name="Guiding - Divining Snout" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="2084-e2be-9849-f3b8" name="Divining Snout (Guiding)" hidden="false" targetId="5305-baaf-a522-1b32" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="6ded-9f23-3858-ad2e" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4726,6 +4750,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="0f8b-2e42-512d-02cd" name="Guiding - Hot Blood" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="56b1-eaf2-88b4-5503" name="Hot Blood (Guiding)" hidden="false" targetId="b0ee-64ce-7e01-f781" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="ace1-7ce3-6f34-c07e" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4734,6 +4761,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="ea93-0ccc-70d3-a3e9" name="Guiding - Horns of Hubris" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="ca50-cc4a-c29d-0a62" name="Horns of Hubris (Guiding)" hidden="false" targetId="d52b-8bbc-273f-c6cc" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="1277-6a1e-f5cb-d39c" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4742,6 +4772,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="179e-fcf9-a896-dd42" name="Guiding - Mirrored Scales" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="a00f-5207-bd5a-3ef9" name="Mirrored Scales (Guiding)" hidden="false" targetId="856b-4f84-b1d7-6eab" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="f88a-530c-4898-e067" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4750,6 +4783,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="2330-6767-ac04-a1f2" name="Guiding - Digestive Vomit" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="c5d5-aeaa-38e2-1cbd" name="Digestive Vomit (Guiding)" hidden="false" targetId="e33b-baf7-0483-6ca0" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="9ebb-64e6-819d-56c2" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4758,6 +4794,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="7117-498b-a994-43c2" name="Guiding - Red Haze" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="0f6f-dc37-9ac2-a8c1" name="Red Haze (Guiding)" hidden="false" targetId="f061-bc6e-b687-8fef" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="ff0e-6b73-309c-9582" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4766,6 +4805,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="1eb6-6ae5-2c96-e356" name="Guiding - Kaleidoscopic Flesh" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="61cb-a2fa-6d81-a6cd" name="Kaleidoscopic Flesh (Guiding)" hidden="false" targetId="cee3-07d3-84e2-15e3" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="aa39-9c81-3dc3-f04b" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4774,6 +4816,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="95a7-7337-4dc7-4932" name="Guiding - Grasping Proboscis" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="cad9-d050-7b18-0b49" name="Grasping Proboscis (Guiding)" hidden="false" targetId="332d-f18e-f808-ee41" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="b35f-378b-460e-20d0" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4782,6 +4827,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="5826-3909-0c8c-2c4d" name="Guiding - Roaming Hands" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="ae84-036d-1fb5-3f4d" name="Roaming Hands (Guiding)" hidden="false" targetId="e889-67b0-7efc-9d09" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="302c-33ea-bff6-9047" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4790,6 +4838,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="a1d4-7820-3de0-1d03" name="Guiding - Smothering Coils" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="fc81-9f69-e72d-051f" name="Smothering Coils (Guiding)" hidden="false" targetId="2a42-39f9-fdfc-c751" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="b792-545b-be26-fc09" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4798,6 +4849,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="70ab-bfa2-3976-8592" name="Guiding - Unhinging Jaw" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="e9b6-1069-e529-0738" name="Unhinging Jaw (Guiding)" hidden="false" targetId="a327-0702-2d00-a321" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="969c-5aaf-5551-969c" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4806,6 +4860,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="6b3d-d010-50b1-7379" name="Guiding - Piercing Spike" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="0993-daaa-155d-0f72" name="Piercing Spike (Guiding)" hidden="false" targetId="1b39-4678-0f67-af7a" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="2815-c2fa-8162-ecbd" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4814,6 +4871,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="e2a2-d153-2657-2772" name="Guiding - Segmented Shell" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="c17c-dbdd-c3c0-afe8" name="Segmented Shell (Guiding)" hidden="false" targetId="62b3-5cc4-e382-0ea9" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="d8fe-618e-e5a1-8412" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4822,6 +4882,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="dfa2-c180-3133-bbc7" name="Guiding - Venom Sacs" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="fa65-4db0-c387-2d92" name="Venom Sacs (Guiding)" hidden="false" targetId="03ec-e4ff-5b7e-009e" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="e902-7b93-ea8b-5f99" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4830,6 +4893,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="c3f8-3d1a-0f09-8b45" name="Guiding - Whipcrack Tail" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="3068-5c73-ba91-0a33" name="Whipcrack Tail (Guiding)" hidden="false" targetId="345a-6276-7db8-c575" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="e371-761a-8b69-540f" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4855,6 +4921,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd3d-601b-0877-ddea" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="e7cf-a861-5b40-d535" name="Aura of Despair" hidden="false" targetId="6c21-6c4d-93b5-7fee" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="25d4-e871-f10e-4af6" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4877,6 +4946,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3497-45ae-7573-af46" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="e3a1-d2b7-d962-c49a" name="Brimstone Secretions" hidden="false" targetId="1b6a-bf48-2d0c-1b89" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -4896,6 +4968,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc9e-6242-7a53-6e42" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="c61d-f881-566e-69c1" name="Bronze Backbone" hidden="false" targetId="b20f-b5d9-40cf-f241" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
       </costs>
@@ -4918,6 +4993,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b19-d5d0-f4a5-e784" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="8afb-63eb-7195-4ba1" name="Broodmother" hidden="false" targetId="5864-c9bc-5aa0-2996" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="f26e-e4ba-4692-dd2b" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4940,6 +5018,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc4c-cdaa-7cce-6de1" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="ceec-fb5d-7d18-2be5" name="Centipede Legs" hidden="false" targetId="69cb-edb7-a8e1-9e2c" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -4948,6 +5029,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a869-feeb-e1ab-cbad" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="cae7-f4ee-b3ba-eea0" name="Charged Tendrils" hidden="false" targetId="fdd8-3ed1-3ee7-adef" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -4970,6 +5054,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="373f-6c62-c2dc-a8bf" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="b44c-b03c-0f55-98b5" name="Chilling Yawn" hidden="false" targetId="5ed6-5249-9ce8-cde8" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="2726-30ab-8dbf-edfd" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -4981,6 +5068,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4ea-aed7-8219-3a15" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="24dd-939e-6232-973e" name="Cloven Hooves" hidden="false" targetId="b464-caac-eb5a-e188" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
       </costs>
@@ -4989,6 +5079,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6500-15fc-835f-cd46" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="fa7a-8532-76bb-e559" name="Chitinous Scales" hidden="false" targetId="0f8a-515b-da8d-31ce" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5008,6 +5101,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5a9-9605-aa34-7aa5" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="a51e-6860-ecfc-d723" name="Digestive Vomit" hidden="false" targetId="7479-f430-568c-f382" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
@@ -5016,6 +5112,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b44a-5c48-4189-9edd" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="f01e-0392-afff-f545" name="Dark Hide" hidden="false" targetId="5f62-e239-0005-22b1" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5035,6 +5134,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86d0-a793-3274-1ce3" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="d9ac-32f9-2218-c0f9" name="Dextrous Tentacles" hidden="false" targetId="2397-fa03-e8b9-6925" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
       </costs>
@@ -5054,6 +5156,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02a8-6bbe-1b78-5160" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="daae-576a-3adb-c486" name="Divining Snout" hidden="false" targetId="853b-f9ad-f26b-60f6" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
       </costs>
@@ -5073,6 +5178,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1153-1d5a-935a-5280" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="87f9-ff8b-7ef5-229f" name="Grasping Proboscis" hidden="false" targetId="e980-5c7d-2eed-185f" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
       </costs>
@@ -5088,6 +5196,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5d8-4f82-5b72-6ee4" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="2009-c327-b0b6-064e" name="Greenfire Eyes" hidden="false" targetId="20d1-921b-231c-5964" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
@@ -5096,6 +5207,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f4a-e9f2-3fca-7717" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="9c5c-7acf-ddb0-2cd6" name="Hammer Hand" hidden="false" targetId="2d09-c66a-79ff-4849" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
@@ -5115,6 +5229,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c3f-69da-9408-2801" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="918f-57ed-22a1-a70e" name="Horns of Hubris" hidden="false" targetId="ec0d-9a79-f1ff-21b6" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5134,6 +5251,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="881d-fdbc-a17f-95d4" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="d6a7-a250-c73c-4ece" name="Hot Blood" hidden="false" targetId="8e5e-e260-1cab-aadf" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
       </costs>
@@ -5153,6 +5273,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e97f-0761-8f04-7cd6" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="6912-5eb6-83c6-6472" name="Incendiary Ichor" hidden="false" targetId="c5dc-a2e2-a42a-794c" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
       </costs>
@@ -5161,6 +5284,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b842-67ba-2ec7-47fe" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="1870-3ffd-8c30-d933" name="Iron Husk" hidden="false" targetId="d125-afbd-5f7f-dc96" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="110.0"/>
       </costs>
@@ -5180,6 +5306,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="514b-3830-fd64-15d6" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="1eb2-ba8d-1e0a-3dd1" name="Kaleidoscopic Flesh" hidden="false" targetId="1c95-9b98-5fcf-059d" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
@@ -5199,6 +5328,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0024-95d3-42e5-cf32" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="2789-936b-d704-5c37" name="Living Shield" hidden="false" targetId="d688-cdcb-904a-e480" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5207,6 +5339,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5071-70eb-e9ee-8790" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="cb11-b9e5-0965-103c" name="Mark of the Eternal Champion" hidden="false" targetId="a527-8372-68fa-ed2e" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
@@ -5229,6 +5364,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c445-ff14-ae23-0601" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="d26d-309e-c8ea-92eb" name="Mesmerising Plumage" hidden="false" targetId="28b0-b249-7513-c1c8" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="16f0-07d3-5b44-4b68" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -5247,6 +5385,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6594-4b71-97e1-0e32" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="97a7-5b78-85b7-0054" name="Piercing Spike" hidden="false" targetId="4f01-a1c0-875f-0af5" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5266,6 +5407,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7201-47e5-ec6e-fd78" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="17a5-f7e2-b0ad-6081" name="Red Haze" hidden="false" targetId="b434-337b-bd50-4c7b" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
@@ -5285,6 +5429,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dd6-cfee-4d7b-a5c1" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="dcf0-afd7-58f8-d93d" name="Roaming Hands" hidden="false" targetId="280f-0f0b-5ea6-a75c" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
       </costs>
@@ -5304,6 +5451,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6df-e206-74f1-3ac6" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="19fd-7fea-c995-ec0d" name="Segmented Shell" hidden="false" targetId="fbee-3c55-4196-5a18" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
       </costs>
@@ -5323,6 +5473,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6ee-532a-f976-4261" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="b6eb-2df4-af9a-03e9" name="Smothering Coils" hidden="false" targetId="02ac-94df-710c-04f7" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
       </costs>
@@ -5332,6 +5485,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1977-d26a-b857-0a59" type="max"/>
         <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b204-ac28-d078-af1a" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="7287-870a-ac4c-5e98" name="Sorcerous Antennae" hidden="false" targetId="1b87-097f-c091-4721" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
@@ -5340,22 +5496,20 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad58-e35d-b9a5-5215" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="a839-6f06-d184-23b6" name="Stiff Upper Lip" hidden="false" targetId="a698-7ce7-9a73-e5db" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4b6d-8a81-99f3-3838" name="Character - Tar Skin" hidden="false" collective="false" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c4f-b73d-ae9a-e817" type="max"/>
-      </constraints>
-      <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0eb1-e819-8e39-60bf" name="Character - Third Eye" hidden="false" collective="false" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aad-70ef-0860-9fc6" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="787e-1677-90d0-4a2e" name="Third Eye" hidden="false" targetId="a398-0648-5cdb-87c8" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
       </costs>
@@ -5375,6 +5529,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8452-60a8-488d-8e92" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="747e-bcb9-8ff7-2169" name="Unhinging Jaw" hidden="false" targetId="4039-deb4-6680-d42a" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
@@ -5383,6 +5540,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed44-5cd8-bd6c-2592" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="9c67-1482-d3e5-a1a8" name="Unnatural Roots" hidden="false" targetId="dd4f-13ad-fabf-fb40" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5398,6 +5558,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5aa-4f29-b48c-d963" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="00ac-b9af-b79c-2918" name="Venom Sacs" hidden="false" targetId="38b8-6e18-7a60-c9cf" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
       </costs>
@@ -5417,6 +5580,9 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb0-da92-1e75-5aa2" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="ede2-a8b9-53d5-f8ab" name="Whipcrack Tail" hidden="false" targetId="90cf-6591-ffa0-a360" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
       </costs>
@@ -5426,19 +5592,17 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b21-328c-28f4-48fd" type="max"/>
         <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ee5-62c7-c8ad-4b4d" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="fe05-98ad-7a2d-7239" name="Withering Vapour" hidden="false" targetId="5322-fd75-3892-9134" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a008-0eb0-81ad-0e39" name="Guiding - Tar Skin" hidden="false" collective="false" type="upgrade">
-      <categoryLinks>
-        <categoryLink id="7733-f64f-0b57-8b5a" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
-      </categoryLinks>
-      <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="dd82-d2e9-2966-3793" name="Guiding - Incendiary Ichor" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="9757-1e63-49a8-613f" name="Incendiary Ichor (Guiding)" hidden="false" targetId="fad0-dcaf-7a4b-0e0d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7e22-120f-47d8-82f5" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -5447,36 +5611,57 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       </costs>
     </selectionEntry>
     <selectionEntry id="ba49-8bc7-c589-c54b" name="Unit - Stiff Upper Lip" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="65aa-2c11-ae8a-c113" name="Stiff Upper Lip" hidden="false" targetId="a698-7ce7-9a73-e5db" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ed85-6fc9-ffad-b111" name="Unit - Bronze Backbone" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="c653-99dd-ef15-59cb" name="Bronze Backbone" hidden="false" targetId="b20f-b5d9-40cf-f241" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6712-49f2-5348-8362" name="Unit - Smothering Coils" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="e1ff-38b0-1a91-726c" name="Smothering Coils" hidden="false" targetId="02ac-94df-710c-04f7" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1551-a143-9262-463f" name="Unit - Chilling Yawn" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="0675-43d4-1dbd-9f89" name="Chilling Yawn" hidden="false" targetId="5ed6-5249-9ce8-cde8" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e3be-cff3-6092-e8d1" name="Unit - Mesmerising Plumage" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="d802-4c04-d64a-90ef" name="Mesmerising Plumage" hidden="false" targetId="28b0-b249-7513-c1c8" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="534b-7d71-737c-c912" name="Unit - Mark of the Eternal Champion" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="f3cc-12b8-9abd-051a" name="Mark of the Eternal Champion" hidden="false" targetId="a527-8372-68fa-ed2e" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3e2c-0f67-7121-d0cf" name="Unit - Charged Tendrils" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="d36c-7c7b-c071-1037" name="Charged Tendrils" hidden="false" targetId="fdd8-3ed1-3ee7-adef" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
@@ -5492,141 +5677,217 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d80b-331d-6d51-2379" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="3f53-359b-65b2-7c54" name="Sorcerous Antennae" hidden="false" targetId="1b87-097f-c091-4721" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dc2e-45f8-578d-b084" name="Unit - Dark Hide" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="bfe4-3cad-c196-e714" name="Dark Hide" hidden="false" targetId="5f62-e239-0005-22b1" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7679-cd89-0364-5aad" name="Unit - Incendiary Ichor" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="aca6-3837-deea-419a" name="Incendiary Ichor" hidden="false" targetId="c5dc-a2e2-a42a-794c" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e153-94cd-6d94-7245" name="Unit - Cloven Hooves" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="5ea8-ed9f-b744-ec23" name="Cloven Hooves" hidden="false" targetId="b464-caac-eb5a-e188" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a8de-e45d-4d3c-5858" name="Unit - Whipcrack Tail" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="0926-9f0c-263c-c2db" name="Whipcrack Tail" hidden="false" targetId="90cf-6591-ffa0-a360" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c10c-4085-48a0-3e83" name="Unit - Unnatural Roots" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="6a26-e6bd-d79b-213d" name="Unnatural Roots" hidden="false" targetId="dd4f-13ad-fabf-fb40" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d76e-a1e4-1dd2-738b" name="Unit - Venom Sacs" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="58c4-0dd9-c837-60b8" name="Venom Sacs" hidden="false" targetId="38b8-6e18-7a60-c9cf" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f5b5-176e-d138-9e9e" name="Unit - Unhinging Jaw" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="3016-2cb0-5aa9-0f27" name="Unhinging Jaw" hidden="false" targetId="4039-deb4-6680-d42a" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3bc5-58a2-f553-694a" name="Unit - Hot Blood" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="2f99-c6ae-77f4-9c08" name="Hot Blood" hidden="false" targetId="8e5e-e260-1cab-aadf" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b964-16ff-626f-3a9b" name="Unit - Piercing Spike" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="00de-76f7-4834-dfe0" name="Piercing Spike" hidden="false" targetId="4f01-a1c0-875f-0af5" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="98ea-ee0f-2037-cffd" name="Unit - Divining Snout" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="9d8b-ce20-cd21-4398" name="Divining Snout" hidden="false" targetId="853b-f9ad-f26b-60f6" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dd92-a99c-d63c-b2bf" name="Unit - Digestive Vomit" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="bf82-2743-a6c8-e593" name="Digestive Vomit" hidden="false" targetId="7479-f430-568c-f382" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f137-39d8-d3f5-c363" name="Unit - Kaleidoscopic Flesh" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="79cf-2d49-4fbc-fd8c" name="Kaleidoscopic Flesh" hidden="false" targetId="1c95-9b98-5fcf-059d" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1e9e-1598-a3cc-5610" name="Unit - Grasping Proboscis" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="77ee-18f4-aae0-1c0f" name="Grasping Proboscis" hidden="false" targetId="e980-5c7d-2eed-185f" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="deaa-fae6-282f-a5dd" name="Unit - Horns of Hubris" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="5563-cec0-0905-6c96" name="Horns of Hubris" hidden="false" targetId="ec0d-9a79-f1ff-21b6" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9014-f681-74cb-b6b6" name="Unit - Centipede Legs" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="05e9-7328-c1e8-edb1" name="Centipede Legs" hidden="false" targetId="69cb-edb7-a8e1-9e2c" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca78-5b27-f154-1827" name="Unit - Brimstone Secretions" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="cd34-7ddd-280f-d074" name="Brimstone Secretions" hidden="false" targetId="1b6a-bf48-2d0c-1b89" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fedb-d9a8-d699-5d44" name="Unit - Dextrous Tentacles" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="c78f-6bb8-0bf2-b202" name="Dextrous Tentacles" hidden="false" targetId="2397-fa03-e8b9-6925" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8101-3b21-c1ae-8871" name="Unit - Segmented Shell" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="064c-5d82-5d9a-2eef" name="Segmented Shell (Guiding)" hidden="false" targetId="62b3-5cc4-e382-0ea9" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6629-56f3-ec7a-1bdf" name="Unit - Roaming Hands" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="d835-1018-0c33-ba2d" name="Roaming Hands" hidden="false" targetId="280f-0f0b-5ea6-a75c" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="df10-be3e-95ef-f9d9" name="Unit - Greenfire Eyes" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="fe91-0b34-c56d-db4b" name="Greenfire Eyes" hidden="false" targetId="20d1-921b-231c-5964" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d44f-3ef6-47b7-c253" name="Unit - Hammer Hand" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="85ca-f577-9eec-efa6" name="Hammer Hand" hidden="false" targetId="2d09-c66a-79ff-4849" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9571-d0e9-f227-e54f" name="Unit - Living Shield" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="d657-017e-2478-e621" name="Living Shield" hidden="false" targetId="d688-cdcb-904a-e480" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5c5d-b745-4ab1-3403" name="Unit - Broodmother" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="e456-9339-1388-1fd9" name="Broodmother" hidden="false" targetId="5864-c9bc-5aa0-2996" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3fe2-a165-7438-54da" name="Unit - Chitinous Scales" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="29d4-232d-320f-fbb4" name="Chitinous Scales" hidden="false" targetId="0f8a-515b-da8d-31ce" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f196-5e13-bbef-20bd" name="Unit - Red Haze" hidden="false" collective="false" type="upgrade">
-      <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4c48-446c-20b6-9a3d" name="Unit - Tar Skin" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="5cb5-b600-e889-3b87" name="Red Haze" hidden="false" targetId="b434-337b-bd50-4c7b" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f4b-fe91-ef41-420a" name="Unit - Aura of Despair" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="834e-654d-2ce9-4971" name="Aura of Despair" hidden="false" targetId="6c21-6c4d-93b5-7fee" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
@@ -5646,11 +5907,17 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c3-0f08-d55c-7238" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="a020-8963-5cc8-9688" name="Mirrored Scales" hidden="false" targetId="2358-2b51-8513-65e6" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f518-7ef1-f94f-a7dd" name="Guiding - Living Shield" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="c6fa-5a8a-19b7-08d8" name="Living Shield (Guiding)" hidden="false" targetId="73c3-6c8d-ef45-cb14" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="c886-97ed-bdc4-e942" name="Dominant Manifestations" hidden="false" targetId="56dd-1865-f8d0-bf12" primary="false"/>
       </categoryLinks>
@@ -5854,7 +6121,6 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <entryLink id="e5df-eadd-6f4a-0625" name="Guiding - Centipede Legs" hidden="false" collective="false" targetId="179b-e388-9bae-22b6" type="selectionEntry"/>
         <entryLink id="2dc9-9e06-8387-8e93" name="Guiding - Mirrored Scales" hidden="false" collective="false" targetId="179e-fcf9-a896-dd42" type="selectionEntry"/>
         <entryLink id="d685-3ada-211d-9a86" name="Guiding - Kaleidoscopic Flesh" hidden="false" collective="false" targetId="1eb6-6ae5-2c96-e356" type="selectionEntry"/>
-        <entryLink id="01f7-6ca8-9bdc-23a1" name="Guiding - Grasping Proboscis" hidden="false" collective="false" targetId="95a7-7337-4dc7-4932" type="selectionEntry"/>
         <entryLink id="0328-ea68-4799-1bab" name="Guiding - Living Shield" hidden="false" collective="false" targetId="f518-7ef1-f94f-a7dd" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
@@ -6030,6 +6296,190 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
     <rule id="671a-279f-78f4-8edc" name="Elusive" hidden="false">
       <description>Units composed entirely of models with Elusive may declare a Flee Charge Reaction despite being Fearless.</description>
     </rule>
+    <rule id="d125-afbd-5f7f-dc96" name="Iron Husk" hidden="false">
+      <description>The model’s Resilience is set to 6.</description>
+    </rule>
+    <rule id="1c95-9b98-5fcf-059d" name="Kaleidoscopic Flesh" hidden="false">
+      <description>The model gains Hard Target (1).</description>
+    </rule>
+    <rule id="cee3-07d3-84e2-15e3" name="Kaleidoscopic Flesh (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Hard Target (1).</description>
+    </rule>
+    <rule id="a527-8372-68fa-ed2e" name="Mark of the Eternal Champion" hidden="false">
+      <description>If the bearer is not a Wizard, it becomes a Wizard Apprentice that does not select spells as normal but always knows Spear of Infinity (Hereditary Spell). If the bearer is already a Wizard, it knows Spear of Infinity in addition to its other spells and cannot select it during Spell Selection.</description>
+    </rule>
+    <rule id="2358-2b51-8513-65e6" name="Mirrored Scales" hidden="false">
+      <description>Each Close Combat Attack allocated towards the bearer that rolls a natural ‘1’ on its to-hit roll is distributed onto the attacking model’s Health Pool.</description>
+    </rule>
+    <rule id="2397-fa03-e8b9-6925" name="Dextrous Tentacles" hidden="false">
+      <description>The model gains +1 Agility.</description>
+    </rule>
+    <rule id="dd4f-13ad-fabf-fb40" name="Unnatural Roots" hidden="false">
+      <description>A side with one or more models with Unnatural Roots Engaged in Combat at the end of the Round of Combat adds +1 to its Combat Score.</description>
+    </rule>
+    <rule id="a398-0648-5cdb-87c8" name="Third Eye" hidden="false">
+      <description>At the beginning of each friendly Charge Phase, draw the Flux Card for that Player Turn instead of step 2 of the Magic Phase Sequence.</description>
+    </rule>
+    <rule id="73c3-6c8d-ef45-cb14" name="Living Shield (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Parry.</description>
+    </rule>
+    <rule id="d688-cdcb-904a-e480" name="Living Shield" hidden="false">
+      <description>The model gains Parry.</description>
+    </rule>
+    <rule id="5f62-e239-0005-22b1" name="Dark Hide" hidden="false">
+      <description>The model gains Scout with the following exception: it must be deployed fully inside the owner’s Deployment Zone, and the owner must have deployed at least one unit normally.</description>
+    </rule>
+    <rule id="0f8a-515b-da8d-31ce" name="Chitinous Scales" hidden="false">
+      <description>The model gains +2 Armour, to a maximum of 3.</description>
+    </rule>
+    <rule id="fdd8-3ed1-3ee7-adef" name="Charged Tendrils" hidden="false">
+      <description>At the end of Siphon the Veil, each unit with one or more instances of this Manifestation allows the owner to store one additional Veil Token, up to a maximum of 6.</description>
+    </rule>
+    <rule id="cc45-50dd-97b5-5f44" name="Centipede Legs (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains +1′′ Advance Rate.</description>
+    </rule>
+    <rule id="69cb-edb7-a8e1-9e2c" name="Centipede Legs" hidden="false">
+      <description>The model gains +1′′ Advance Rate.</description>
+    </rule>
+    <rule id="1b6a-bf48-2d0c-1b89" name="Brimstone Secretions" hidden="false">
+      <description>Attacks made against the model no longer are Divine Attacks (if they were).</description>
+    </rule>
+    <rule id="b464-caac-eb5a-e188" name="Cloven Hooves" hidden="false">
+      <description>The model gains Impact Hits (D3). These Impact Hits are resolved with Strength 5 and Armour Penetration 2.</description>
+    </rule>
+    <rule id="a361-9ff9-d38c-2ae8" name="Brimstone Secretions (Guiding)" hidden="false">
+      <description>Dominant. Attacks made against the model and against R&amp;F models in its unit no longer are Divine Attacks (if they were).</description>
+    </rule>
+    <rule id="1b87-097f-c091-4721" name="Sorcerous Antennae" hidden="false">
+      <description>At the start of Siphon the Veil in each of your Magic Phases, choose a single model part in each unit with one or more instances of this Manifestation. The chosen model part gains Channel (1) until the end of the Magic Phase.</description>
+    </rule>
+    <rule id="2d09-c66a-79ff-4849" name="Hammer Hand" hidden="false">
+      <description>The model gains +1 Attack Value.</description>
+    </rule>
+    <rule id="5322-fd75-3892-9134" name="Withering Vapour" hidden="false">
+      <description>The bearer gains a Breath Attack (Str 3, AP 2).</description>
+    </rule>
+    <rule id="856b-4f84-b1d7-6eab" name="Mirrored Scales (Guiding)" hidden="false">
+      <description>Dominant. Each Close Combat Attack allocated towards the bearer and R&amp;F models in its unit that rolls a natural ‘1’ on its to-hit roll is distributed onto the attacking model’s Health Pool.</description>
+    </rule>
+    <rule id="9b4d-89d1-b96c-e25b" name="Dextrous Tentacles (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains +1 Agility.</description>
+    </rule>
+    <rule id="20d1-921b-231c-5964" name="Greenfire Eyes" hidden="false">
+      <description>One use only. Must be activated when the model’s unit fails its first Charge Range roll. The unit must reroll the Charge Range roll.</description>
+    </rule>
+    <rule id="280f-0f0b-5ea6-a75c" name="Roaming Hands" hidden="false">
+      <description>When the unit is Engaged with an enemy unit’s Flank or Rear Facing, the model gains +1 Strength and +1 Armour Penetration.</description>
+    </rule>
+    <rule id="28b0-b249-7513-c1c8" name="Mesmerising Plumage" hidden="false">
+      <description>Dominant. Enemy units in base contact with one or more models with this Manifestation suffer −1 Offensive Skill and −1 Defensive Skill.</description>
+    </rule>
+    <rule id="5305-baaf-a522-1b32" name="Divining Snout (Guiding)" hidden="false">
+      <description>Dominant. When Charging a unit that contains more than one Special Item, the model and each R&amp;F model in its unit gains +2′′ Advance Rate for Charge Range rolls and must reroll failed Charge Range rolls. The effects only apply in the Charge Phase and only if all models in the unit are affected by Divining Snout.</description>
+    </rule>
+    <rule id="853b-f9ad-f26b-60f6" name="Divining Snout" hidden="false">
+      <description>When Charging a unit that contains more than one Special Item, the model gains +2′′ Advance Rate for Charge Range rolls and must reroll failed Charge Range rolls. The effects only apply in the Charge Phase and only if all models in the unit are affected by Divining Snout.</description>
+    </rule>
+    <rule id="2a42-39f9-fdfc-c751" name="Smothering Coils (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains +1 to-wound with Close Combat Attacks against models with Scoring.</description>
+    </rule>
+    <rule id="02ac-94df-710c-04f7" name="Smothering Coils" hidden="false">
+      <description>The model gains +1 to-wound with Close Combat Attacks against models with Scoring.</description>
+    </rule>
+    <rule id="332d-f18e-f808-ee41" name="Grasping Proboscis (Guiding)" hidden="false">
+      <description>Dominant. At the end of each Round of Combat during which the model’s unit was Engaged in Combat, and the model and R&amp;F model in the bearer’s unit caused at least three Health Point losses by Close Combat Attacks, you gain D3 Veil Token to your Veil Token pool.</description>
+    </rule>
+    <rule id="e980-5c7d-2eed-185f" name="Grasping Proboscis" hidden="false">
+      <description>At the end of each Round of Combat during which the model’s unit was Engaged in Combat, and the model caused at least three Health Point losses by Close Combat Attacks, you gain D3 Veil Token to your Veil Token pool.</description>
+    </rule>
+    <rule id="a327-0702-2d00-a321" name="Unhinging Jaw (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit must reroll failed to-wound rolls from Close Combat Attacks against Large or Gigantic models.</description>
+    </rule>
+    <rule id="4039-deb4-6680-d42a" name="Unhinging Jaw" hidden="false">
+      <description>The model must reroll failed to-wound rolls from Close Combat Attacks against Large or Gigantic models.</description>
+    </rule>
+    <rule id="e33b-baf7-0483-6ca0" name="Digestive Vomit (Guiding)" hidden="false">
+      <description>Dominant. One use only. Must be activated the first time the bearer’s unit performs a Post-Combat Pivot or a Post-Combat Reform. The model and each R&amp;F model in
+its unit gains +1 Strength and +1 Armour Penetration until the end of the game.</description>
+    </rule>
+    <rule id="7479-f430-568c-f382" name="Digestive Vomit" hidden="false">
+      <description>One use only. Must be activated the first time the bearer’s unit performs a Post-Combat Pivot or a Post-Combat Reform. The model gains +1 Strength and +1 Armour Penetration until the end of the game.</description>
+    </rule>
+    <rule id="ef3b-cd0e-ac78-b679" name="Broodmother (Guiding)" hidden="false">
+      <description>Dominant. At the end of each Round of Combat during which the model’s unit was Engaged in Combat, and during which the model and R&amp;F models in the bearer’s
+unit caused at least three Health Point losses with Close Combat Attacks, the unit Raises D3 Health Points.</description>
+    </rule>
+    <rule id="5864-c9bc-5aa0-2996" name="Broodmother" hidden="false">
+      <description>Dominant. At the end of each Round of Combat during which the model’s unit was Engaged in Combat, and during which the model caused at least three Health Point losses with Close Combat Attacks, the unit Raises D3 Health Points.</description>
+    </rule>
+    <rule id="03ec-e4ff-5b7e-009e" name="Venom Sacs (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Poison Attacks. If the model’s Close Combat Attacks or those of R&amp;F models in its unit already were Poison
+Attacks from another source than this Manifestation, the attack will automatically wound on successful to-hit rolls of 5+, instead of 6+.</description>
+    </rule>
+    <rule id="38b8-6e18-7a60-c9cf" name="Venom Sacs" hidden="false">
+      <description>The model gains Poison Attacks. If the model’s Close Combat Attacks or those of R&amp;F models in its unit already were Poison Attacks from another source than this Manifestation, the attack will automatically wound on successful to-hit rolls of 5+, instead of 6+.</description>
+    </rule>
+    <rule id="1b39-4678-0f67-af7a" name="Piercing Spike (Guiding)" hidden="false">
+      <description>Dominant. Close Combat Attacks made by the model and each R&amp;F model in its unit gain +1 Armour Penetration.</description>
+    </rule>
+    <rule id="4f01-a1c0-875f-0af5" name="Piercing Spike" hidden="false">
+      <description>Close Combat Attacks made by the model gain +1 Armour Penetration.</description>
+    </rule>
+    <rule id="e889-67b0-7efc-9d09" name="Roaming Hands (Guiding)" hidden="false">
+      <description>Dominant. When the unit is Engaged with an enemy unit’s Flank or Rear Facing, the model and each R&amp;F model in its unit gains +1 Strength and +1 Armour Penetration.</description>
+    </rule>
+    <rule id="fad0-dcaf-7a4b-0e0d" name="Incendiary Ichor (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Aegis (2+, against Flaming Attacks). All Melee Attacks (including Special Attacks) and Shooting Attacks made by the model with Incendiary Ichor and each R&amp;F model in its unit become Flaming Attacks. The bearer and each R&amp;F model in its unit automatically fails all Fortitude Saves.</description>
+    </rule>
+    <rule id="62b3-5cc4-e382-0ea9" name="Segmented Shell (Guiding)" hidden="false">
+      <description>Dominant. When the model or a R&amp;F model in its unit suffers a wound from an attack with Multiple Wounds, the number of wounds that it is multiplied into (due to
+Multiple Wounds) is reduced by 1, to a minimum of 1.</description>
+    </rule>
+    <rule id="fbee-3c55-4196-5a18" name="Segmented Shell" hidden="false">
+      <description>When the model suffers a wound from an attack with Multiple Wounds, the number of wounds that it is multiplied into (due to Multiple Wounds) is reduced by 1, to a minimum of 1.</description>
+    </rule>
+    <rule id="6c21-6c4d-93b5-7fee" name="Aura of Despair" publicationId="3f95-f87e-5df2-4102" page="5" hidden="false">
+      <description>Dominant. Enemy units suffer −2′′ Advance Rate to a minimum of 1′′ when rolling for Charge Range against units with at least one model with this Manifestation.</description>
+    </rule>
+    <rule id="5ed6-5249-9ce8-cde8" name="Chilling Yawn" hidden="false">
+      <description>Dominant. Enemy units in base contact with one or more models with this Manifestation suffer −2 Agility.</description>
+    </rule>
+    <rule id="d52b-8bbc-273f-c6cc" name="Horns of Hubris (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Vanguard (6′′).</description>
+    </rule>
+    <rule id="ec0d-9a79-f1ff-21b6" name="Horns of Hubris" hidden="false">
+      <description>The model gains Vanguard (6′′).</description>
+    </rule>
+    <rule id="c7b6-f47e-fed1-71e5" name="Bronze Backbone (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Hatred.</description>
+    </rule>
+    <rule id="b20f-b5d9-40cf-f241" name="Bronze Backbone" hidden="false">
+      <description>The model gains Hatred.</description>
+    </rule>
+    <rule id="a698-7ce7-9a73-e5db" name="Stiff Upper Lip" hidden="false">
+      <description>Discipline Tests taken by units with at least one model with this Manifestation are subject to Minimised Roll.</description>
+    </rule>
+    <rule id="b0ee-64ce-7e01-f781" name="Hot Blood (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Devastating Charge (+2 Agi).</description>
+    </rule>
+    <rule id="8e5e-e260-1cab-aadf" name="Hot Blood" hidden="false">
+      <description>The model gains Devastating Charge (+2 Agi).</description>
+    </rule>
+    <rule id="c5dc-a2e2-a42a-794c" name="Incendiary Ichor" hidden="false">
+      <description>The model gains Aegis (2+, against Flaming Attacks). All Melee Attacks (including Special Attacks) and Shooting Attacks made by the model with Incendiary Ichor become Flaming Attacks. The bearer automatically fails all Fortitude Saves.</description>
+    </rule>
+    <rule id="f061-bc6e-b687-8fef" name="Red Haze (Guiding)" hidden="false">
+      <description>Dominant. The model’s Close Combat Attacks and those of R&amp;F models in its unit gain +1 Strength and +1 Armour Penetration, but each of its Close Combat Attacks and those of R&amp;F models in its unit with a natural to-hit roll of ‘1’ is distributed onto the attacking model’s Health Pool.</description>
+    </rule>
+    <rule id="b434-337b-bd50-4c7b" name="Red Haze" hidden="false">
+      <description>The model’s Close Combat Attacks gain +1 Strength and +1 Armour Penetration, but each of its Close Combat Attacks with a natural to-hit roll of ‘1’ is distributed onto the attacking model’s Health Pool.</description>
+    </rule>
+    <rule id="345a-6276-7db8-c575" name="Whipcrack Tail (Guiding)" hidden="false">
+      <description>Dominant. The model and each R&amp;F model in its unit gains Lightning Reflexes.</description>
+    </rule>
+    <rule id="90cf-6591-ffa0-a360" name="Whipcrack Tail" hidden="false">
+      <description>The model gains Lightning Reflexes.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="c6d3-8078-cdfc-c72d" name="Dark Fire" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
@@ -6050,7 +6500,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <characteristic name="Aeg" typeId="9820-1785-03cb-9eae">5+</characteristic>
       </characteristics>
     </profile>
-    <profile id="f548-7a9f-b4f1-a1d9" name="Tillers" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
+    <profile id="f548-7a9f-b4f1-a1d9" name="Tiller" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
       <characteristics>
         <characteristic name="Att" typeId="e9a7-9590-af60-1be6">2</characteristic>
         <characteristic name="Off" typeId="b767-2d7a-52d9-f1ba">4</characteristic>
@@ -6060,7 +6510,7 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <characteristic name="Rules" typeId="4713-eeae-87ae-0ef2"/>
       </characteristics>
     </profile>
-    <profile id="dca4-19c6-fbb5-c514" name="Draft Beasts" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
+    <profile id="dca4-19c6-fbb5-c514" name="Draft Beast" hidden="false" typeId="946f-2c1a-ffab-293b" typeName="3 Offensive">
       <characteristics>
         <characteristic name="Att" typeId="e9a7-9590-af60-1be6">1</characteristic>
         <characteristic name="Off" typeId="b767-2d7a-52d9-f1ba">3</characteristic>
@@ -6088,398 +6538,6 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <characteristic name="AP" typeId="6779-0c09-2d7f-5077">1</characteristic>
         <characteristic name="Agi" typeId="b053-1905-7bef-a4b3">3</characteristic>
         <characteristic name="Rules" typeId="4713-eeae-87ae-0ef2">Devastating Charge (+2 Str, Battle Focus)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="374e-8aba-0d4d-0a3e" name="Aura of Despair" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Sloth</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Enemy units suffer -2&quot; Advance Rate to a minimum of 1 when rolling for Charge Range against units with at least one model with this  Manifestation.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5947-f429-4d50-d9e4" name="Horns of Hubris" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Pride</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Vanguard (6&quot;).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="fe57-2a39-b340-be5b" name="Stiff Upper Lip" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Pride</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Discipline Tests taken by units with at least one model with this Manifestation are subject to Minimised Roll.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1b0d-583c-f2dc-a8b9" name="Bronze Backbone - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Hatred. If the model&apos;s unit loses a Round of Combat, the model and each R&amp;F model in its unit must reroll failed to-hit rolls in the following Round of Combat.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d083-446d-226f-ca9a" name="Dexterous Tentacles - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains +1 Agility.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6aa6-b9cc-f638-b413" name="Living Shield - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Parry.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="062b-7ae0-791e-6834" name="Whipcrack Tail" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Wrath</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Lightning Reflexes.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3bdd-051c-9412-b08f" name="Red Haze" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Wrath</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">This Manifestation may be activated at the start of any Round of Combat. All models in the same unit must activate it if one model does. When activated, the model&apos;s Close Combat Attacks gain +1 Strength and +1 Armour Penetration, but each of its attacks with a natural to-hit roll of &apos;1&apos; is distributed onto the bearer&apos;s unit. The effects last until the end of the Round of Combat.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d1b9-8c8d-7b33-8ce6" name="Darkhide" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Scout with the following exception: It must be deployed fully inside the owner&apos;s Deployment Zone.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ae7e-8e5f-18d9-efda" name="Mark of the Eternal Champion" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">This Manifestation can only be taken by single model units or units with a Champion. If given to a unit with a Champion, only the Champion is affected by the Manifestation. If the affected model is not a Wizard, it gains Wizard Apprentice and must select Spear of Infinity (Hereditary Spell). If the affected model is already a Wizard, it knows Spear of Infinity (Hereditary Spell) in addition to its other spells and cannot select it during Spell Selection.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="8b7f-fd15-9dd2-c5bc" name="Aura of Despair - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Sloth</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Enemy units suffer -2&quot; Advance Rate to a minimum of 1 when rolling for Charge Range against units with at least one model with this  Manifestation.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="419e-b011-81ee-46e0" name="Segmented Shell - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Sloth</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">When the bearer or a R&amp;F model in its unit suffers a wound from an attack with Multiple Wounds, the number of wounds that it is multiplied into (due to Multiple Wounds) is reduced by 1, to a minimum of 1.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5a18-3066-5ef7-78cb" name="Brimstone Secretions" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Attacks made against the model no longer are Divine Attacks (if they were).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1a63-b441-86fe-e7cc" name="Venom Sacs" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Envy</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Poison Attacks. If the model&apos;s Close Combat Attacks already were Poison Attacks from another source than this Manifestation, the attack will automatically wound on successful to-hit rolls of 5+, instead of 6+.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="533b-99fe-e5f6-c690" name="Mesmerising Plumage - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Lust</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Friendly units (including the bearer&apos;s unit) Engaged in the same Combat as one or more models with this Manifestation gain +1 Offensive Skill and +1 Defensive Skill while Engaged in that Combat.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="45cc-c307-bf76-7fa5" name="Unhinging Jaw" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Gluttony</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model must reroll failed to-wound rolls from Close Combat Attacks against Large or Gigantic models.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="98dd-b179-183f-1584" name="Hot Blood" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Lust</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Devastating Charge (+2 Agi).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f9a8-5640-83ee-537b" name="Greenfire Eyes" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Envy</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">One use only. May be activated when the model&apos;s unit fails a Charge Range roll. If all models in the unit activate their Greenfire Eyes, the Charge Range roll may be rerolled.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3da7-ab68-e450-c0a0" name="Kaleidoscopic Flesh - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Hard Target (1).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="2b0d-a81b-2ea1-9bff" name="Centipede Legs - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains +1&quot; Advance Rate.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="66d2-a5fd-3618-3c2c" name="Grasping Proboscis - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Greed</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">At the end of each Round of Combat during which the model&apos;s unit was Engaged in Combat, roll a D6 and add the number of unsaved wounds caused by Close Combat Attacks from models with Grasping Proboscis and R&amp;F model in the bearer&apos;s unit. On a score of 6 or more, you gain one Veil Token to your Veil Token pool.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="548c-152b-4142-38fa" name="Digestive Vomit - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Gluttony</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">One use only. Must be activated the first time the bearer&apos;s unit performs a Post-Combat Pivot or a Post-Combat Reform. The model and each R&amp;F model in its unit gains +1 Strength and +1 Armour Penetration until the end of the game.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="15b2-fc73-594c-a626" name="Divining Snout - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit must reroll failed Charge Range rolls when rolling for Charge Range against a unit that contains one Special Item. In addition, if the Charged unit contains more than one Special Item, all models with Divining Snout also gain +2&quot; Advance Rate for the Charge Range roll. The effects only apply if all models in the unit are affected by Divining Snout.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="275c-9f9a-579d-995c" name="Roaming Hands - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Lust</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">When the unit is Engaged with an enemy unit&apos;s Flank or Rear Facing, the model and each R&amp;F model in its unit gains +1 Strength and +1 Armour Penetration.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="cbcf-6fb2-2b18-0588" name="Broodmother - Dominant (Guiding)" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Gluttony</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Cannot be taken by Gigantic models. At the end of each Round of Combat during which the model&apos;s unit was Engaged in Combat, roll a D6 and add the number of unsaved wounds caused by Close Combat Attacks from models with Broodmother and R&amp;F models in the bearer&apos;s unit. On a score of 7 or more, the unit Raises D3 Health Points.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="159b-a9c9-24f9-cc23" name="Charged Tendrils" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">At the end of Siphon the Veil, the owner may store one additional Veil Token, up to a maximum of 6.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d6b1-3259-aae4-a420" name="Hammerhand" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The bearer gains +1 Attack Value.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="555a-cfa9-c3f4-66ae" name="Third Eye" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">When a Learned Spell that targets the model or its unit is successfully cast, the bearer may cast that spell as a Bound Spell with Power Level (5/8) in the following Magic Phase.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="c946-edc7-b517-5792" name="Withering Vapour" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Breath Attack (Str 3, AP 2).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9e7a-d929-cea6-7230" name="Horns of Hubris - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Pride</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Vanguard (6&quot;).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="068a-d6ab-ebd3-face" name="Dexterous Tentacles" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains +1 Agility.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="b052-61f3-8b16-0758" name="Incendiary Ichor" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Wrath</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Aegis (2+, against Flaming Attacks). All Melee Attacks (including Special Attacks) and Shooting Attacks made by models with Incendiary Ichor become Flaming Attacks.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5690-6771-c5d6-ad4a" name="Red Haze - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Wrath</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">This Manifestation may be activated at the start of any Round of Combat. All models in the same unit must activate it if one model does. When activated, the model&apos;s Close Combat Attacks and those of R&amp;F models in its unit gain +1 Strength and +1 Armour Penetration, but each of its attacks with a natural to-hit roll of &apos;1&apos; is distributed onto the bearer&apos;s unit. The effects last until the end of the Round of Combat.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5659-3a16-3d07-276f" name="Chilling Yawn - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Sloth</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Enemy units in base contact with one or more models with this Manifestation suffer -3 Agility.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="990c-770f-02ff-28ae" name="Unnatural Roots" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">When a unit with one or more instances of this Manifestation rolls a Break Test or Combat Reform test, the Combat Score difference counts as 2 less, to a minimum of 0 (this has no effect on other units Engaged in the same Combat).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="448f-eb64-18ae-6c53" name="Venom Sacs - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Envy</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Poison Attacks. If the model&apos;s Close Combat Attacks or those of R&amp;F models in its unit already were Poison Attacks from another source than this Manifestation, the attack will automatically wound on successful to-hit rolls of 5+, instead of 6+.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="640e-2ebb-fea5-4916" name="Unhinging Jaw - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Gluttony</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit must reroll failed to-wound rolls from Close Combat Attacks against Large or Gigantic models.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5276-35d7-e194-1c84" name="Kaleidoscopic Flesh" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Hard Target (1).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="99c3-cab1-f8dc-41b0" name="Grasping Proboscis" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Greed</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">At the end of each Round of Combat during which the model&apos;s unit was Engaged in Combat, roll a D6 and add the number of unsaved wounds caused by Close Combat Attacks from models with Grasping Proboscis. On a score of 6 or more, you gain one Veil Token to your Veil Token pool.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1cf0-1f6a-8148-b789" name="Divining Snout" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Greed</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model {and each R&amp;F model in its unit} must reroll failed Charge Range rolls when rolling for Charge Range against a unit that contains one Special Item. In addition, if the Charged unit contains more than one Special Item, all models with Divining Snout also gain +2&quot; Advance Rate for the Charge Range roll. The effects only apply if all models in the unit are affected by Divining Snout.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="715c-ac30-1343-90c4" name="Broodmother - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Gluttony</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Cannot be taken by Gigantic models. At the end of each Round of Combat during which the model&apos;s unit was Engaged in Combat, roll a D6 and add the number of unsaved wounds caused by Close Combat Attacks from models with Broodmother. On a score of 7 or more, the unit Raises D3 Health Points.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="400c-0a14-47ec-0756" name="Tarskin - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Enemy units in base contact with one or more models with this Manifestation suffer -1 Attack Value.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="def6-73b3-1c44-3b86" name="Cloven Hooves" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Impact Hits (D3). These Impact Hits are resolved with Strength 5 and Armour Penetration 2.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="7c39-709a-2feb-0e90" name="Bronze Backbone" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Hatred. If the model&apos;s unit loses a Round of Combat, the model must reroll failed to-hit rolls in the following Round of Combat.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="a0e1-88ec-09a7-f1db" name="Whipcrack Tail - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Wrath</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Lightning Reflexes.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="804f-4ec2-1ed3-fcde" name="Segmented Shell" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Sloth</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">When the bearer suffers a wound from an attack with Multiple Wounds, the number of wounds that it is multiplied into (due to Multiple Wounds) is reduced by 1, to a minimum of 1.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d366-a144-4be1-ba02" name="Smothering Coils" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Greed</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains +1 to-wound with Close Combat Attacks against models with Scoring.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="1740-af97-a2e8-1692" name="Centipede Legs" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains +1&quot; Advance Rate.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="4517-2fff-ee9d-830f" name="Roaming Hands" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Lust</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">When the unit is Engaged with an enemy unit&apos;s Flank or Rear Facing, the model gains +1 Strength and +1 Armour Penetration.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="b20b-ff41-3dc0-b3bb" name="Iron Husk" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Cannot be taken by Gigantic models. The model gains +1 Resilience.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3851-e1b3-6ebf-7af1" name="Living Shield" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains Parry.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9ecb-1a25-a271-56c6" name="Brimstone Secretions - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Attacks made against the model and against R&amp;F models in friendly units within 6&quot; of the model no longer are Divine Attacks (if they were).</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ef28-7c48-3994-acec" name="Digestive Vomit" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Gluttony</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">One use only. Must be activated the first time the bearer&apos;s unit performs a Post-Combat Pivot or a Post-Combat Reform. The model gains +1 Strength and +1 Armour Penetration until the end of the game.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3677-cea0-dbd2-72b0" name="Sorcerous Antennae" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">During Siphon the Veil of each of your Magic Phases, each unit with one or more instances of this Manifestation adds a Veil Token to your Veil Token pool.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ef40-b248-3ee0-1813" name="Chitinous Scales" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Chaos</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model gains +2 Armour, to a maximum of 3.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d008-1244-6ad8-8b67" name="Hot Blood - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Lust</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">The model and each R&amp;F model in its unit gains Devastating Charge (+2 Agi).</characteristic>
       </characteristics>
     </profile>
     <profile id="aa87-31a3-9d33-f27d" name="Spear of Infinity" hidden="false" typeId="654a-9b5c-962c-4f80" typeName="X Spell">
@@ -6535,20 +6593,6 @@ gains +1 Health Point. When the model has 18 Health Points, all units within 9&q
         <characteristic name="Type" typeId="b6ee-c0b1-7832-0e4f">Damage Hex Missile</characteristic>
         <characteristic name="Duration" typeId="ada6-44ac-7daa-aa57">Instant</characteristic>
         <characteristic name="Effect" typeId="7839-02e6-d607-a978">The target suffers &lt;D6&gt; {D6+1} hits with Strength &lt;D6&gt; {D6+1}, Armour Penetration &lt;2&gt; {3}, and Magical Attacks.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f085-9726-08c0-c5cf" name="Piercing Spike" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Envy</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">no</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Close Combat Attacks against enemy models with an Armour value of 3 or higher made by the model &lt;and each R&amp;F model in its unit&gt; gain +1 Strength.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="47b0-596f-051b-c9ec" name="Piercing Spike - Dominant" hidden="false" typeId="cd63-b670-ea21-438d" typeName="7 Manifestation">
-      <characteristics>
-        <characteristic name="Sin" typeId="2370-1857-1c8d-6a2c">Envy</characteristic>
-        <characteristic name="Guiding" typeId="aa84-02c9-7d6d-3550">yes</characteristic>
-        <characteristic name="Description" typeId="8ab6-438f-59da-7237">Close Combat Attacks against enemy models with an Armour value of 3 or higher made by the model &lt;and each R&amp;F model in its unit&gt; gain +1 Strength.</characteristic>
       </characteristics>
     </profile>
     <profile id="6c28-3dd0-4de4-86e0" name="Smite the Unbeliever" hidden="false" typeId="654a-9b5c-962c-4f80" typeName="X Spell">


### PR DESCRIPTION
* Vanadra's Scourge follows pattern for Wizard Level
* All manifestation rule texts updated to version 2.2.2
* All unit entry names updated to version 2.2.2
* All Manifestations are now implemented as rules and show up when selected. Removed the representation of Manifestations as Profile Types.
* Updated rule description of Morphlings

Fixes #351 