### PR TITLE
2.1.5 update: Empire of Sonnstahl

### DIFF
--- a/empireOfSonnstahl.cat
+++ b/empireOfSonnstahl.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1aa5-c442-6972-b551" name="Empire of Sonnstahl 2.1" revision="18" battleScribeVersion="2.02" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1aa5-c442-6972-b551" name="Empire of Sonnstahl 2.1.5" revision="19" battleScribeVersion="2.03" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="ecde-c284-9850-23e1" name="Imperial Armoury" hidden="false"/>
     <categoryEntry id="77b5-bf3a-88ad-b176" name="Imperial Auxiliaries" hidden="false"/>
@@ -38,7 +38,7 @@
     </forceEntry>
   </forceEntries>
   <selectionEntries>
-    <selectionEntry id="028f-4f2d-1812-7479" name="Marshal" hidden="false" collective="false" type="unit">
+    <selectionEntry id="028f-4f2d-1812-7479" name="Marshal" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="5b47-5103-55ff-7bb0" name="Marshal Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -70,7 +70,7 @@
             <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Plate Armour</characteristic>
           </characteristics>
         </profile>
         <profile id="e64c-7109-d36e-da14" name="Marshal Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
@@ -89,7 +89,7 @@
         <categoryLink id="e1e4-9de2-97a0-2d81" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="fde5-8f86-48d4-a53b" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="fde5-8f86-48d4-a53b" name="Battle Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -101,13 +101,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcd0-4261-a9f1-c9ca" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5407-426b-86f9-618f" name="Battle Standard Bearer" hidden="false" collective="false" targetId="53e0-007c-21bc-d3cc" type="selectionEntry"/>
+            <entryLink id="5407-426b-86f9-618f" name="Battle Standard Bearer" hidden="false" collective="false" import="true" targetId="53e0-007c-21bc-d3cc" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="d418-0b46-3c6c-756e" name="Army General" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d418-0b46-3c6c-756e" name="Army General" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -125,18 +125,18 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1ba-9c3b-9d41-748e" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4ee8-d126-eb7b-9be0" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+            <entryLink id="4ee8-d126-eb7b-9be0" name="Army General" hidden="false" collective="false" import="true" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e9d8-2ed3-ece1-c7a4" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e9d8-2ed3-ece1-c7a4" name="Special Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7816-20a6-272e-9e2c" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="995d-6d2c-4fda-9f42" name="Special Equipment" hidden="false" collective="false">
+            <selectionEntryGroup id="995d-6d2c-4fda-9f42" name="Special Equipment" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="set" field="a607-da89-c200-ea41" value="100">
                   <conditions>
@@ -152,9 +152,35 @@
               <constraints>
                 <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a607-da89-c200-ea41" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2fc6-1bc3-fca1-dddc" name="Artefacts" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8046-f44c-622f-6c9f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="bcea-a277-f46c-18ba" name="Artefacts" hidden="false" collective="false" import="true" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="4b2e-d2de-956f-eb22" name="EoS Artefacts (Marshal, Knight Commander)" hidden="false" collective="false" import="true" targetId="e5c7-5ee2-643d-103a" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8b7a-01b2-cd6d-2916" name="Banner Enchantments" hidden="true" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5640-1a67-abd4-af21" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="039a-268d-1b05-d565" name="Banner Enchantments" hidden="false" collective="false" import="true" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                    <entryLink id="21f7-bc03-0129-469f" name="EoS Banner Enchantments (BSB)" hidden="false" collective="false" import="true" targetId="dd59-21e0-a27a-3303" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="86a4-9b90-8003-f8bf" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="4a99-27b4-0816-465d" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup">
+                <entryLink id="4a99-27b4-0816-465d" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
@@ -163,27 +189,7 @@
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="6500-6a5e-7bb3-1b50" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
-                <entryLink id="65da-7dc4-7008-4f5d" name="Banner Enchantments" hidden="true" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="2">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="e9d8-2ed3-ece1-c7a4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a99-27b4-0816-465d" type="equalTo"/>
-                            <condition field="selections" scope="e9d8-2ed3-ece1-c7a4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="86a4-9b90-8003-f8bf" type="equalTo"/>
-                            <condition field="selections" scope="e9d8-2ed3-ece1-c7a4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6500-6a5e-7bb3-1b50" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
+                <entryLink id="6500-6a5e-7bb3-1b50" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -191,7 +197,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="59ac-a985-3c55-5413" name="Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="59ac-a985-3c55-5413" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d4d-3f43-746d-f60f" type="max"/>
           </constraints>
@@ -202,7 +208,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="eb00-4e0e-2023-9da1" name="Pistol (2+)" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="eb00-4e0e-2023-9da1" name="Pistol (2+)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bfc-cc3a-c719-904d" type="max"/>
           </constraints>
@@ -219,12 +225,12 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ad71-6323-cad9-6e5c" name="Profession" hidden="false" collective="false">
+        <selectionEntryGroup id="ad71-6323-cad9-6e5c" name="Profession" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5544-9632-cf4a-c98f" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d2d7-60b7-0057-5521" name="Great Tactician" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d2d7-60b7-0057-5521" name="Great Tactician" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80e9-68d2-c385-eac5" type="max"/>
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="778c-4e97-963f-b476" type="max"/>
@@ -238,7 +244,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5221-22b7-accf-79b7" name="Imperial Prince" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5221-22b7-accf-79b7" name="Imperial Prince" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -251,7 +257,7 @@
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b6bc-8719-1285-c0a2" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c1ff-1633-4cc4-db98" name="The Light of ​​Sonnstahl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+                <profile id="c1ff-1633-4cc4-db98" name="The Light of Sonnstahl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
                   <characteristics>
                     <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
                     <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon wound automatically, always have Armour Penetration 10, and Magical Attacks.</characteristic>
@@ -259,7 +265,7 @@
                 </profile>
               </profiles>
               <rules>
-                <rule id="7427-c5c7-ee71-3dd5" name="Imperial​ ​Prince" hidden="false">
+                <rule id="7427-c5c7-ee71-3dd5" name="Imperial Prince" hidden="false">
                   <description>General Only. The model part gains +1 Attack Value, and is equipped with a Hand Weapon enchanted with The Light of Sonnstahl. An Imperial Prince may only take up to 50 pts of Special Equipment.</description>
                 </rule>
               </rules>
@@ -269,12 +275,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="93ff-9719-4dbd-7a44" name="Melee Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="93ff-9719-4dbd-7a44" name="Melee Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e00-fcae-19e0-05a5" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7320-4510-ac1c-8b03" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7320-4510-ac1c-8b03" name="Paired Weapons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3be3-fe8b-e518-6780" type="max"/>
               </constraints>
@@ -285,7 +291,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="eeb0-b91d-78be-cd07" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eeb0-b91d-78be-cd07" name="Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37eb-4457-95b0-c0d9" type="max"/>
               </constraints>
@@ -296,7 +302,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0f0f-0572-09a3-006c" name="Halberd" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0f0f-0572-09a3-006c" name="Halberd" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0da-7910-fb04-d230" type="max"/>
               </constraints>
@@ -307,7 +313,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a3ec-d371-66fd-ebb1" name="Lance" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a3ec-d371-66fd-ebb1" name="Lance" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -327,30 +333,29 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b1dd-4694-0073-7783" name="Mount" hidden="false" collective="false">
+        <selectionEntryGroup id="b1dd-4694-0073-7783" name="Mount" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bf7-23a7-a47a-3427" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="2a16-6e2b-2809-008e" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="55.0"/>
-              </modifiers>
+            <entryLink id="2a16-6e2b-2809-008e" name="Horse" hidden="false" collective="false" import="true" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bf5-7ff9-c539-5dfe" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="b5f4-2ce4-8055-6aa7" name="Pegasus" hidden="false" collective="false" targetId="cacf-1879-9a46-9c66" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="55.0"/>
-              </modifiers>
+            <entryLink id="b5f4-2ce4-8055-6aa7" name="Pegasus" hidden="false" collective="false" import="true" targetId="cacf-1879-9a46-9c66" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b73c-76f7-17f8-3903" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="9cc7-9306-891c-5887" name="Great Griffon" hidden="false" collective="false" targetId="0ceb-e9be-fa78-150f" type="selectionEntry">
+            <entryLink id="9cc7-9306-891c-5887" name="Great Griffon" hidden="false" collective="false" import="true" targetId="0ceb-e9be-fa78-150f" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="140.0"/>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
                     <condition field="selections" scope="028f-4f2d-1812-7479" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fde5-8f86-48d4-a53b" type="equalTo"/>
@@ -363,10 +368,12 @@
               <categoryLinks>
                 <categoryLink id="6fe4-ae8b-2fe7-f317" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
               </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="140.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="15b4-bc63-ae8e-3b1b" name="Dragon" hidden="false" collective="false" targetId="ca5d-3e42-5f9e-8e71" type="selectionEntry">
+            <entryLink id="15b4-bc63-ae8e-3b1b" name="Dragon" hidden="false" collective="false" import="true" targetId="ca5d-3e42-5f9e-8e71" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="440.0"/>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
                     <condition field="selections" scope="028f-4f2d-1812-7479" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5221-22b7-accf-79b7" type="equalTo"/>
@@ -379,6 +386,9 @@
               <categoryLinks>
                 <categoryLink id="373b-0f5e-74a3-d789" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
               </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="440.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -387,7 +397,7 @@
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="160.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="11c8-5e24-f965-a22b" name="Knight Commander" hidden="false" collective="false" type="unit">
+    <selectionEntry id="11c8-5e24-f965-a22b" name="Knight Commander" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="15fc-335c-5598-26cb" name="Knight Commander Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -412,7 +422,7 @@
             <characteristic name="Def" typeId="160d-4624-273f-2114">6</characteristic>
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Plate Armour</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -428,30 +438,40 @@
         <categoryLink id="496b-f0d6-9b2c-b239" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="d6e6-5758-aec0-1cf5" name="Army General" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d6e6-5758-aec0-1cf5" name="Army General" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a667-b05b-f30a-174b" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="e418-6953-4307-838f" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+            <entryLink id="e418-6953-4307-838f" name="Army General" hidden="false" collective="false" import="true" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8293-0c1c-c0f9-660d" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8293-0c1c-c0f9-660d" name="Special Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95e6-731e-4b93-941c" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="d775-ecf5-6ca3-d17a" name="Special Equipment" hidden="false" collective="false">
+            <selectionEntryGroup id="d775-ecf5-6ca3-d17a" name="Special Equipment" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc0f-a94e-f3de-c30b" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a9e5-94de-b8ba-cf64" name="Artefacts" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f03-6ed9-fc96-4de2" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="bbb6-fe46-04c3-93c2" name="Artefacts" hidden="false" collective="false" import="true" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="8974-5a20-6d99-c146" name="EoS Artefacts (M, KC)" hidden="false" collective="false" import="true" targetId="e5c7-5ee2-643d-103a" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="7e9f-e4d1-6798-a262" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="812f-e66a-e990-83cc" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
-                <entryLink id="07dc-120c-cc32-eb28" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+                <entryLink id="812f-e66a-e990-83cc" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="07dc-120c-cc32-eb28" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -459,7 +479,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c04c-0180-7ac5-bd26" name="Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c04c-0180-7ac5-bd26" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53ee-679e-8b1f-5479" type="max"/>
           </constraints>
@@ -472,12 +492,12 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="62aa-5036-3bcb-908a" name="Melee Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="62aa-5036-3bcb-908a" name="Melee Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="800a-d15c-d730-075a" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f164-7caa-e2fb-d479" name="Cavalry Pick" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f164-7caa-e2fb-d479" name="Cavalry Pick" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b09-015d-f8be-08d4" type="max"/>
               </constraints>
@@ -488,7 +508,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e896-c62f-a29b-cf2d" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e896-c62f-a29b-cf2d" name="Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e441-a660-a1fb-13b9" type="max"/>
               </constraints>
@@ -499,7 +519,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2d39-1ca3-f6ac-a7cf" name="Halberd" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2d39-1ca3-f6ac-a7cf" name="Halberd" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0414-31de-6ecb-af85" type="max"/>
               </constraints>
@@ -510,7 +530,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2871-3cac-8e68-ae22" name="Lance" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2871-3cac-8e68-ae22" name="Lance" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f80c-60d7-6762-cb8f" type="max"/>
               </constraints>
@@ -523,24 +543,24 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c682-a874-5805-a375" name="Mount" hidden="false" collective="false" defaultSelectionEntryId="d277-2cd7-b6fe-cea5">
+        <selectionEntryGroup id="c682-a874-5805-a375" name="Mount" hidden="false" collective="false" import="true" defaultSelectionEntryId="d277-2cd7-b6fe-cea5">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="916b-cd49-2cc7-20fe" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fbf-e4ab-435a-bcab" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d277-2cd7-b6fe-cea5" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+            <entryLink id="d277-2cd7-b6fe-cea5" name="Horse" hidden="false" collective="false" import="true" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed4-d376-0cc4-4b22" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="4b80-f9ad-c35f-e6ef" name="Young Griffon" hidden="false" collective="false" targetId="f733-dce6-f27c-3607" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="35.0"/>
-              </modifiers>
+            <entryLink id="4b80-f9ad-c35f-e6ef" name="Young Griffon" hidden="false" collective="false" import="true" targetId="f733-dce6-f27c-3607" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c1c-c937-81c5-e61e" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -549,7 +569,7 @@
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1e69-caa4-e244-5abf" name="Prelate" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1e69-caa4-e244-5abf" name="Prelate" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="70a4-51ec-742c-c2b2" name="Prelate Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -565,16 +585,16 @@
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Divine Attacks</characteristic>
           </characteristics>
         </profile>
-        <profile id="a6a9-c6ea-0733-7d84" name="Prelate​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+        <profile id="a6a9-c6ea-0733-7d84" name="Prelate Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
           <characteristics>
             <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
             <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Heavy Armour</characteristic>
           </characteristics>
         </profile>
         <profile id="6fa3-cd9e-db9c-262a" name="Prelate Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
@@ -607,30 +627,40 @@
         <categoryLink id="14f6-6e1b-4c73-05de" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b0a4-448c-5f26-9a6a" name="Army General" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b0a4-448c-5f26-9a6a" name="Army General" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02f-d6fa-268e-1218" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7940-11db-ed88-3130" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+            <entryLink id="7940-11db-ed88-3130" name="Army General" hidden="false" collective="false" import="true" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7d8f-4c02-e412-6f62" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7d8f-4c02-e412-6f62" name="Special Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="35c1-79f3-2a4b-4728" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="1c42-6ac9-b3f9-f55a" name="Special Equipment" hidden="false" collective="false">
+            <selectionEntryGroup id="1c42-6ac9-b3f9-f55a" name="Special Equipment" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="24fd-8af8-0c78-001c" scope="parent" value="200.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c5c5-271d-fdea-a2b4" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3289-bb4e-99c2-5376" name="Artefacts" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4324-dac2-69f8-5f2b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="03f0-d975-488f-a130" name="Artefacts" hidden="false" collective="false" import="true" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="87cf-347a-af9d-5ee7" name="EoS Artefacts (Prelate, Inquisitor, Artificer)" hidden="false" collective="false" import="true" targetId="834d-a309-413c-9419" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="8c34-d099-9736-77c1" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="2681-8e4d-0ab9-7b2e" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
-                <entryLink id="1fe5-1652-8aaa-0cdf" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+                <entryLink id="2681-8e4d-0ab9-7b2e" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="1fe5-1652-8aaa-0cdf" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -638,7 +668,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a389-48a0-8d18-9ad7" name="Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a389-48a0-8d18-9ad7" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a74e-eae7-aeaa-febd" type="max"/>
           </constraints>
@@ -649,7 +679,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="36bd-7551-d73e-6fed" name="Plate Armour" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="36bd-7551-d73e-6fed" name="Plate Armour" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08d8-9fab-a366-9365" type="max"/>
           </constraints>
@@ -662,12 +692,12 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3b3e-118c-271b-fefe" name="Melee Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="3b3e-118c-271b-fefe" name="Melee Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b3d-5520-3218-eab0" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8488-3294-a7a4-b39c" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8488-3294-a7a4-b39c" name="Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b98f-d60f-a871-8087" type="max"/>
               </constraints>
@@ -678,7 +708,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a256-ae1f-b845-ab2a" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a256-ae1f-b845-ab2a" name="Paired Weapons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f412-c6d2-79f9-5e4a" type="max"/>
               </constraints>
@@ -691,29 +721,29 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="19de-5012-e602-b644" name="Mount" hidden="false" collective="false">
+        <selectionEntryGroup id="19de-5012-e602-b644" name="Mount" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="03d9-f645-0466-01fb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="37bc-7e78-2a50-fd78" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="35.0"/>
-              </modifiers>
+            <entryLink id="37bc-7e78-2a50-fd78" name="Horse" hidden="false" collective="false" import="true" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde7-636f-1da8-a260" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="54a5-a274-d7de-da1f" name="Altar of Battle" hidden="false" collective="false" targetId="8d97-387f-45ee-5f63" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="350.0"/>
-              </modifiers>
+            <entryLink id="54a5-a274-d7de-da1f" name="Altar of Battle" hidden="false" collective="false" import="true" targetId="8d97-387f-45ee-5f63" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6721-c00f-df72-7c50" type="max"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="b628-16ae-ab0c-18f6" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
               </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="350.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -722,7 +752,7 @@
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="53b0-be9b-6101-a832" name="Wizard" hidden="false" collective="false" type="unit">
+    <selectionEntry id="53b0-be9b-6101-a832" name="Wizard" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="bb96-8de6-a655-a3e0" name="Wizard Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -762,23 +792,23 @@
         <categoryLink id="c095-565e-dfa5-99c3" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="77d5-33d9-cfa8-78ea" name="Army General" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="77d5-33d9-cfa8-78ea" name="Army General" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a444-f949-f053-53bc" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fc32-fedd-5074-be71" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+            <entryLink id="fc32-fedd-5074-be71" name="Army General" hidden="false" collective="false" import="true" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a0ee-cbd3-b553-1141" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a0ee-cbd3-b553-1141" name="Special Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4426-c74b-6f64-eaec" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="9c56-3b42-463a-fd9d" name="Special Equipment" hidden="false" collective="false">
+            <selectionEntryGroup id="9c56-3b42-463a-fd9d" name="Special Equipment" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="set" field="bfb0-cc48-e20b-85c6" value="200">
                   <conditions>
@@ -789,10 +819,20 @@
               <constraints>
                 <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfb0-cc48-e20b-85c6" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9341-c21f-c2a9-a1c7" name="Artefacts" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5e-2aeb-be9c-346d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="843e-0adf-67c7-2d63" name="Artefacts" hidden="false" collective="false" import="true" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="3eed-91f7-313d-7259" name="EoS Artefacts (Wizard)" hidden="false" collective="false" import="true" targetId="9fb0-1e1a-4d75-6614" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="b100-5cde-7bfa-2913" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="c9d4-ad50-1603-a4ed" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
-                <entryLink id="287b-3747-47c2-486a" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+                <entryLink id="c9d4-ad50-1603-a4ed" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="287b-3747-47c2-486a" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -800,7 +840,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="68d0-f364-1f9b-c844" name="Light Armour" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="68d0-f364-1f9b-c844" name="Light Armour" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596c-0751-ae31-aa10" type="max"/>
           </constraints>
@@ -813,55 +853,55 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3638-a7bd-58cc-b465" name="Mount" hidden="false" collective="false">
+        <selectionEntryGroup id="3638-a7bd-58cc-b465" name="Mount" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="56a4-999f-a81f-412c" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d61c-571c-a807-7ae4" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="10.0"/>
-              </modifiers>
+            <entryLink id="d61c-571c-a807-7ae4" name="Horse" hidden="false" collective="false" import="true" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e0-7097-d525-5b14" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="0bd8-d6f3-2cfd-c290" name="Arcane Engine" hidden="false" collective="false" targetId="6944-42d1-8941-6450" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="190.0"/>
-              </modifiers>
+            <entryLink id="0bd8-d6f3-2cfd-c290" name="Arcane Engine" hidden="false" collective="false" import="true" targetId="6944-42d1-8941-6450" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c22-df46-4497-bc1e" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="734c-36a5-bf1b-2191" name="Pegasus" hidden="false" collective="false" targetId="cacf-1879-9a46-9c66" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="30.0"/>
-              </modifiers>
+            <entryLink id="734c-36a5-bf1b-2191" name="Pegasus" hidden="false" collective="false" import="true" targetId="cacf-1879-9a46-9c66" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49c3-6422-aeee-0737" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="e1d7-8a59-0b79-d7e1" name="Great Griffon" hidden="false" collective="false" targetId="0ceb-e9be-fa78-150f" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="85.0"/>
-              </modifiers>
+            <entryLink id="e1d7-8a59-0b79-d7e1" name="Great Griffon" hidden="false" collective="false" import="true" targetId="0ceb-e9be-fa78-150f" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d29-4197-785d-6e4e" type="max"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="91db-ae46-9515-6b33" name="Sunna&apos;s Fury (local)" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="false"/>
               </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="85.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f2f0-fed2-03ca-70e7" name="Wizard Level" hidden="false" collective="false" defaultSelectionEntryId="f9bd-97e5-61e0-01aa">
+        <selectionEntryGroup id="f2f0-fed2-03ca-70e7" name="Wizard Level" hidden="false" collective="false" import="true" defaultSelectionEntryId="f9bd-97e5-61e0-01aa">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ab3-de94-d645-53d1" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f77-2970-8735-ad4d" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f9bd-97e5-61e0-01aa" name="Wizard Apprentice" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f9bd-97e5-61e0-01aa" name="Wizard Apprentice" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb93-c7ee-39b8-9f37" type="max"/>
               </constraints>
@@ -872,7 +912,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6062-c823-724f-4b60" name="Wizard Adept" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6062-c823-724f-4b60" name="Wizard Adept" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1aa-57f5-6f54-9e83" type="max"/>
               </constraints>
@@ -883,7 +923,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9846-7ae9-7020-e330" name="Wizard Master" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9846-7ae9-7020-e330" name="Wizard Master" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8787-b19b-150c-e5e1" type="max"/>
               </constraints>
@@ -896,7 +936,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4598-de87-7a2a-8e9a" name="Path of Magic" hidden="false" collective="false">
+        <selectionEntryGroup id="4598-de87-7a2a-8e9a" name="Path of Magic" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -909,7 +949,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="934a-d251-eff0-8376" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7866-df55-6d30-979c" name="Alchemy" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7866-df55-6d30-979c" name="Alchemy" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d32-dab4-05f8-b602" type="max"/>
               </constraints>
@@ -917,7 +957,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d114-6659-4145-ff89" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d114-6659-4145-ff89" name="Pyromancy" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f77-0a28-fe4c-7176" type="max"/>
               </constraints>
@@ -925,7 +965,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="946d-b325-86b9-e176" name="Divination" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="946d-b325-86b9-e176" name="Divination" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4532-33f0-a70c-b3fd" type="max"/>
               </constraints>
@@ -933,7 +973,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d66e-1363-fb49-a8aa" name="Cosmology" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d66e-1363-fb49-a8aa" name="Cosmology" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00ed-964c-5fe5-d230" type="max"/>
               </constraints>
@@ -943,7 +983,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8668-98bd-ba71-2a7a" name="Path of Magic" hidden="true" collective="false">
+        <selectionEntryGroup id="8668-98bd-ba71-2a7a" name="Path of Magic" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -956,7 +996,7 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d985-6786-556d-7c13" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="36e2-4760-044a-a673" name="Alchemy" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="36e2-4760-044a-a673" name="Alchemy" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c92a-7976-3e39-1455" type="max"/>
               </constraints>
@@ -964,7 +1004,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f5d6-8f26-943b-75e8" name="Pyromancy" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f5d6-8f26-943b-75e8" name="Pyromancy" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8302-b2d0-c705-a496" type="max"/>
               </constraints>
@@ -972,7 +1012,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5819-5021-d5f8-7bfc" name="Divination" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5819-5021-d5f8-7bfc" name="Divination" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a5-a26e-4c1e-5d2b" type="max"/>
               </constraints>
@@ -980,7 +1020,7 @@
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="006f-f9b2-0e83-5294" name="Cosmology" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="006f-f9b2-0e83-5294" name="Cosmology" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b881-418d-78db-f6e7" type="max"/>
               </constraints>
@@ -995,7 +1035,14 @@
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="125.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cc6a-e224-1943-b715" name="Inquisitor" hidden="false" collective="false" type="unit">
+    <selectionEntry id="cc6a-e224-1943-b715" name="Inquisitor" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="77b5-bf3a-88ad-b176">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8a-8440-1956-3324" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="bc46-5c2c-1579-ecff" name="Inquisitor Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -1011,7 +1058,7 @@
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Lethal Strike, Multiple Wounds (D3)</characteristic>
           </characteristics>
         </profile>
         <profile id="768a-0c71-91fe-487a" name="Inquisitor Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -1020,7 +1067,7 @@
             <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Plate Armour</characteristic>
           </characteristics>
         </profile>
         <profile id="8c6c-c8e7-59cd-8cab" name="Inquisitor Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
@@ -1055,19 +1102,29 @@
         <categoryLink id="49e6-3fa8-3976-858f" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4d18-6cd0-60d5-a2c9" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4d18-6cd0-60d5-a2c9" name="Special Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e7c-9509-5e1b-5c9b" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="303d-e830-732d-2ba5" name="Special Equipment" hidden="false" collective="false">
+            <selectionEntryGroup id="303d-e830-732d-2ba5" name="Special Equipment" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3e12-6ef3-5dc5-f85f" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="88f7-2871-8ba6-4324" name="Artefacts" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="942e-9536-03de-7e20" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="3386-8b6b-6eae-e244" name="Artefacts" hidden="false" collective="false" import="true" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="49cb-cc62-7911-7693" name="EoS Artefacts (P, I, A)" hidden="false" collective="false" import="true" targetId="834d-a309-413c-9419" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="364c-0bac-6393-c475" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="c9e1-57fc-250b-1553" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
-                <entryLink id="2f59-070d-63a0-cc5c" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+                <entryLink id="c9e1-57fc-250b-1553" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="2f59-070d-63a0-cc5c" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -1075,7 +1132,7 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="fcc9-feb6-6464-a2ff" name="Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="fcc9-feb6-6464-a2ff" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7310-00b0-9ef1-8321" type="max"/>
           </constraints>
@@ -1086,25 +1143,14 @@
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9547-6d94-0629-94b9" name="Blessed Steel" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c511-b3ae-22a6-383c" type="max"/>
-          </constraints>
-          <rules>
-            <rule id="0920-2fa8-b273-5161" name="Blessed Steel" hidden="false">
-              <description>Attack Attribute - Close Combat.
-The model part gains +2 Agility. Close Combat Attacks made by the model part gain +1 Strength and +1 Armour Penetration.</description>
-            </rule>
-          </rules>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b7ab-45e0-7344-94f6" name="Close Combat Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="b7ab-45e0-7344-94f6" name="Melee Weapon" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5dec-f949-1abf-fb0d" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry id="652b-d679-c4b4-9ba1" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="652b-d679-c4b4-9ba1" name="Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a376-8e15-e4ec-5dea" type="max"/>
               </constraints>
@@ -1115,7 +1161,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9af2-f82c-1873-be78" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9af2-f82c-1873-be78" name="Paired Weapons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e3d-babf-cdcf-127d" type="max"/>
               </constraints>
@@ -1126,7 +1172,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="aa2c-fc29-a4f1-0015" name="Halberd" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="aa2c-fc29-a4f1-0015" name="Halberd" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a73a-9566-1201-9705" type="max"/>
               </constraints>
@@ -1139,12 +1185,12 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="91c0-f4af-fbbc-5bad" name="Shooting Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="91c0-f4af-fbbc-5bad" name="Shooting Weapons" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37b9-12d8-4ad9-e956" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9c35-72ab-d2f8-a93d" name="Crossbow (2+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9c35-72ab-d2f8-a93d" name="Crossbow (2+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b9-87bf-50ea-bb10" type="max"/>
               </constraints>
@@ -1159,7 +1205,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="50e5-0833-8e67-6411" name="Brace of Pistols (3+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="50e5-0833-8e67-6411" name="Brace of Pistols (3+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="228c-0c05-6aed-137e" type="max"/>
               </constraints>
@@ -1174,7 +1220,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0718-9858-b705-3f92" name="Repeater Pistol (3+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0718-9858-b705-3f92" name="Repeater Pistol (3+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="911f-a493-bc51-c5fe" type="max"/>
               </constraints>
@@ -1191,22 +1237,58 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="02ac-6d04-c3a7-099a" name="Holy Alloy" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="c8bc-4797-af7e-d943" name="Blessed Steel" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cd5-65d7-7281-edd8" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="683e-8db6-96c3-5aec" name="Blessed Steel" hidden="false">
+                  <description>Attack Attribute - Close Combat.
+The model part gains +2 Agility. Close Combat Attacks made by the model part gain +1 Strength and +1 Armour Penetration.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0f8a-8440-1956-3324" name="Silver Shots" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a78-84d5-ffb4-258b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="94f6-4bd2-050b-6f8a" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="6a81-f8ad-0a81-7b6b" name="Silver Shots" hidden="false">
+                  <description>Attack Attribute - Shooting.
+The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-wound rolls.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4fa0-1c53-8045-9348" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
+        <entryLink id="4fa0-1c53-8045-9348" name="Horse" hidden="false" collective="false" import="true" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="70"/>
+            <modifier type="append" field="name" value=" and Light Troops"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af01-9279-253c-fbb9" type="max"/>
           </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="75.0"/>
+          </costs>
         </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="115.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bb34-a3af-2ede-80dd" name="Artificer" hidden="false" collective="false" type="unit">
+    <selectionEntry id="bb34-a3af-2ede-80dd" name="Artificer" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="487c-ba82-ce2b-6101" name="Artificer Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -1231,7 +1313,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Light Armour</characteristic>
           </characteristics>
         </profile>
         <profile id="f261-17d3-0ff9-cd89" name="Artificer Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
@@ -1260,19 +1342,29 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <categoryLink id="7a50-1ca3-b741-6b4b" name="Imperial Armoury (local)" hidden="false" targetId="ecde-c284-9850-23e1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="acb5-4d20-6d87-978e" name="Special Equipment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="acb5-4d20-6d87-978e" name="Special Equipment" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3151-47d2-7ea2-6ea3" type="max"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="1f63-ccda-0dfe-5757" name="Special Equipment" hidden="false" collective="false">
+            <selectionEntryGroup id="1f63-ccda-0dfe-5757" name="Special Equipment" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="24fd-8af8-0c78-001c" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8acc-8ee9-29ca-9a89" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="fa9c-c23f-b950-787e" name="Artefacts" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14be-6be3-5c40-bcf6" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4fa2-bfa2-d791-9809" name="Artefacts" hidden="false" collective="false" import="true" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
+                    <entryLink id="2916-e285-d832-3bb9" name="EoS Artefacts (Marshal, Knight Commander)" hidden="false" collective="false" import="true" targetId="e5c7-5ee2-643d-103a" type="selectionEntryGroup"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="3538-4191-0fdb-038c" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="ca41-5928-7054-336b" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
-                <entryLink id="102a-4dc8-587c-5d70" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
+                <entryLink id="ca41-5928-7054-336b" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
+                <entryLink id="102a-4dc8-587c-5d70" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -1280,12 +1372,12 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7b16-d5b5-bfc7-0d24" name="Army General" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7b16-d5b5-bfc7-0d24" name="Army General" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7266-cf91-0be5-442a" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c8ba-d7b9-a993-809d" name="Army General" hidden="false" collective="false" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
+            <entryLink id="c8ba-d7b9-a993-809d" name="Army General" hidden="false" collective="false" import="true" targetId="60e0-a887-6970-1fc7" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
@@ -1293,12 +1385,12 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="699c-0158-b18c-f9f2" name="Shooting Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="699c-0158-b18c-f9f2" name="Shooting Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85e8-68b5-5daa-d8c7" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8161-a98e-2da1-252b" name="Repeater Pistols (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8161-a98e-2da1-252b" name="Repeater Pistols (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e8-5cd5-bed6-93b9" type="max"/>
               </constraints>
@@ -1313,7 +1405,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ded9-49da-1019-69e0" name="Handgun (3+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ded9-49da-1019-69e0" name="Handgun (3+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e38-b74f-d688-c1b9" type="max"/>
               </constraints>
@@ -1328,7 +1420,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="bcbb-3880-0076-5494" name="Long Rifle (3+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bcbb-3880-0076-5494" name="Long Rifle (3+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="451c-9803-4008-cea8" type="max"/>
               </constraints>
@@ -1343,7 +1435,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="904b-b913-f084-71a6" name="Repeater Gun (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="904b-b913-f084-71a6" name="Repeater Gun (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f9-a7b3-d0d9-2dad" type="max"/>
               </constraints>
@@ -1362,20 +1454,20 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a068-123b-131c-9790" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="15.0"/>
-          </modifiers>
+        <entryLink id="a068-123b-131c-9790" name="Horse" hidden="false" collective="false" import="true" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a7a-8b86-9708-9109" type="max"/>
           </constraints>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
+          </costs>
         </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="120.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cd21-fe43-e8e5-42de" name="Heavy Infantry" hidden="false" collective="false" type="unit">
+    <selectionEntry id="cd21-fe43-e8e5-42de" name="Heavy Infantry" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="eff9-7de6-dbeb-e40e" name="Parent​ ​Unit" hidden="false" targetId="f5ec-3ab9-9101-55c4" type="rule">
           <modifiers>
@@ -1403,7 +1495,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <categoryLink id="9826-5abf-f8d8-8c7b" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0367-6d81-4202-fd07" name="Heavy Infantry" hidden="false" collective="false" type="model">
+        <selectionEntry id="0367-6d81-4202-fd07" name="Heavy Infantry" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="50.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3ea-5d47-26f1-c150" type="max"/>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4f3-3752-65de-ff9f" type="min"/>
@@ -1429,7 +1521,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
                 <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
                 <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Light Armour, Shield</characteristic>
               </characteristics>
             </profile>
             <profile id="a168-aca4-9b5d-29e0" name="Heavy Infantry Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -1447,7 +1539,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8b27-15c1-7bc9-5a3e" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8b27-15c1-7bc9-5a3e" name="Banner Enchantment" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1458,25 +1550,29 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b12b-636e-fd90-95c6" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="557c-89e8-6710-b11a" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c6cc-8319-f94c-9565" name="Banner Enchantment" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52e5-ff32-28bd-14e0" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1a3c-b11c-b571-72c0" name="EoS Banner Enchantments (Parent Units)" hidden="false" collective="false" import="true" targetId="32c1-e3dd-aba1-d769" type="selectionEntryGroup"/>
+                <entryLink id="f68a-ab2e-eda4-8e2b" name="Banner Enchantments" hidden="false" collective="false" import="true" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="985e-e09e-e995-fb70" name="Melee Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="985e-e09e-e995-fb70" name="Melee Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f96-209d-9876-c20d" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ef6c-8a23-6a35-6874" name="Spear" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ef6c-8a23-6a35-6874" name="Spear" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="1.0">
                   <repeats>
@@ -1494,7 +1590,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6853-60b8-71f0-c03d" name="Halberd" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6853-60b8-71f0-c03d" name="Halberd" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="1.0">
                   <repeats>
@@ -1516,13 +1612,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f440-0d40-8d87-43c4" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="f440-0d40-8d87-43c4" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6217-1fc8-7a46-c411" name="Light Infantry" hidden="false" collective="false" type="unit">
+    <selectionEntry id="6217-1fc8-7a46-c411" name="Light Infantry" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="8db3-ce37-642c-9bbb" name="Support Unit" hidden="false" targetId="490a-c098-12b6-5697" type="rule"/>
         <infoLink id="de3e-e557-4f96-3f48" name="Scoring" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
@@ -1532,7 +1628,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <categoryLink id="e611-46b3-5976-d6fb" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="52a4-3d10-5048-5e66" name="Light Infantry" hidden="false" collective="false" type="model">
+        <selectionEntry id="52a4-3d10-5048-5e66" name="Light Infantry" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2fd-e5e8-a956-a5cd" type="max"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5060-3705-414c-ac92" type="min"/>
@@ -1576,7 +1672,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e026-d748-f05e-120d" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e026-d748-f05e-120d" name="Banner Enchantment" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1587,20 +1683,24 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a29-7686-2a95-f307" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="fd6a-9af7-5633-d522" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="23a8-84f0-94f6-e4d7" name="Banner Enchantment" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="608c-82c7-a0b1-42db" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d0a9-40f1-0ffe-301b" name="EoS Banner Enchantments" hidden="false" collective="false" import="true" targetId="1818-95b1-17ee-cc01" type="selectionEntryGroup"/>
+                <entryLink id="4e37-22a0-3ac6-770f" name="Banner Enchantments" hidden="false" collective="false" import="true" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="291a-d489-fe1f-50b6" name="Champion Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="291a-d489-fe1f-50b6" name="Champion Weapon" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1612,7 +1712,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6cb-a235-adec-be10" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4aa9-2e34-9704-a752" name="Long Rifle (3+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4aa9-2e34-9704-a752" name="Long Rifle (3+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="921f-2e51-20ab-2a6f" type="max"/>
               </constraints>
@@ -1627,7 +1727,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3a7a-c10b-ebe9-d1e7" name="Repeater Gun (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3a7a-c10b-ebe9-d1e7" name="Repeater Gun (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="422b-33de-d0bf-2258" type="max"/>
               </constraints>
@@ -1644,13 +1744,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d01a-0f08-c894-da01" name="Shooting Weapon" hidden="false" collective="false" defaultSelectionEntryId="9d04-4af4-0da4-185e">
+        <selectionEntryGroup id="d01a-0f08-c894-da01" name="Shooting Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d04-4af4-0da4-185e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="036a-4ee2-660e-6b8d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e4-1763-dace-4120" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9d04-4af4-0da4-185e" name="Crossbow (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9d04-4af4-0da4-185e" name="Crossbow (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="3285-61f9-ad3f-05b1" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
                   <modifiers>
@@ -1662,7 +1762,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1634-90ea-3999-20d2" name="Handgun (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1634-90ea-3999-20d2" name="Handgun (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="fd49-7e0f-c2a0-e6ed" name="Handgun" hidden="false" targetId="b092-dbc5-4c60-9a80" type="profile">
                   <modifiers>
@@ -1678,13 +1778,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8be2-58f8-e737-f847" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="8be2-58f8-e737-f847" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2cb4-3838-613c-723a" name="State Militia" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2cb4-3838-613c-723a" name="State Militia" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f7c-d5a8-60f4-c11a" type="max"/>
       </constraints>
@@ -1705,13 +1805,14 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           </modifiers>
         </infoLink>
         <infoLink id="52ec-05ca-ce17-28f4" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+        <infoLink id="c32c-38ef-be82-8066" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dc9c-06fd-a0f4-a0b3" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
         <categoryLink id="1468-2b81-e9d0-290a" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="e036-5a83-75f4-8eb6" name="State Militia" hidden="false" collective="false" type="model">
+        <selectionEntry id="e036-5a83-75f4-8eb6" name="State Militia" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="25.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b63e-54d8-cfb1-2604" type="max"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7283-c866-be6b-eb2d" type="min"/>
@@ -1747,7 +1848,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Bow (4+), Paired Weapons, Pistol (4+)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -1755,7 +1856,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="8.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9388-27ad-26f8-f692" name="Skirmishers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9388-27ad-26f8-f692" name="Irregulars" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="increment" field="24fd-8af8-0c78-001c" value="1.0">
               <repeats>
@@ -1764,7 +1865,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="2cb4-3838-613c-723a" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e036-5a83-75f4-8eb6" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -1773,6 +1874,12 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           </constraints>
           <infoLinks>
             <infoLink id="a60c-acc5-6776-9bec" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+            <infoLink id="e1e5-896d-c6f9-b0e2" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
+            <infoLink id="5d20-8676-3fb9-689a" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule">
+              <modifiers>
+                <modifier type="append" field="name" value=" (1)"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
@@ -1780,13 +1887,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="dbd8-09c3-04db-baf3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="dbd8-09c3-04db-baf3" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="994f-59e8-ca5c-eced" name="Electoral Cavalry" hidden="false" collective="false" type="unit">
+    <selectionEntry id="994f-59e8-ca5c-eced" name="Electoral Cavalry" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a463-1cb5-99ba-0332" type="max"/>
       </constraints>
@@ -1799,7 +1906,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <categoryLink id="1d58-71d4-a327-1b65" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="aac5-f506-0a44-23a0" name="Knight" hidden="false" collective="false" type="model">
+        <selectionEntry id="aac5-f506-0a44-23a0" name="Knight" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8127-420c-e175-4751" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b29-bbce-6931-fc0f" type="min"/>
@@ -1832,7 +1939,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
                 <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
                 <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">2</characteristic>
-                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Plate Armour</characteristic>
               </characteristics>
             </profile>
             <profile id="23a5-00fa-ec29-c9a9" name="Horse Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -1842,7 +1949,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
               </characteristics>
             </profile>
             <profile id="d841-4177-bbaf-b41a" name="Knight Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -1877,29 +1984,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="26.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2a01-37e3-f9b2-3b95" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="994f-59e8-ca5c-eced" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d364-11ff-9faa-ddb0" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="fdc4-740a-1099-0b59" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6d56-4c57-7b29-6de8" name="Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6d56-4c57-7b29-6de8" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="increment" field="24fd-8af8-0c78-001c" value="5.0">
               <repeats>
@@ -1917,7 +2002,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8be5-6fb8-7f1f-3f0e" name="Knightly Orders" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8be5-6fb8-7f1f-3f0e" name="Knightly Orders" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="increment" field="24fd-8af8-0c78-001c" value="8.0">
               <repeats>
@@ -1938,14 +2023,54 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="63f7-567e-ba30-4d5d" name="Banner Enchantment" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f82-6955-3d8a-01ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3104-4963-4baf-bc7d" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c69e-8bb3-6153-4efa" name="Banner Enchantment" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1341-08f3-49a6-4e63" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="73af-c6bd-0312-7652" name="Banner Enchantments" hidden="false" collective="false" import="true" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+                <entryLink id="47ac-4222-a6d5-e632" name="EoS Banner Enchantments (Parent Units)" hidden="true" collective="false" import="true" targetId="32c1-e3dd-aba1-d769" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="90e3-9346-465e-f17a" name="EoS Banner Enchantments" hidden="false" collective="false" import="true" targetId="1818-95b1-17ee-cc01" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="994f-59e8-ca5c-eced" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8be5-6fb8-7f1f-3f0e" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4155-806d-ca25-390e" name="Close Combat Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="4155-806d-ca25-390e" name="Close Combat Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5806-73ba-1c42-4c90" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="94e5-4c04-ee9c-319a" name="Lance" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="94e5-4c04-ee9c-319a" name="Lance" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="4.0">
                   <repeats>
@@ -1963,7 +2088,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="528f-4eea-3844-0aa9" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="528f-4eea-3844-0aa9" name="Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="2.0">
                   <repeats>
@@ -1986,7 +2111,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0e1f-df25-9e0d-9b77" name="Cavalry Pick" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0e1f-df25-9e0d-9b77" name="Cavalry Pick" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -2008,13 +2133,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="329a-9dd5-ed28-6791" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="329a-9dd5-ed28-6791" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e284-efdf-ac17-ba70" name="Imperial Guard" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e284-efdf-ac17-ba70" name="Imperial Guard" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="30c1-f5fb-d768-c02d" name="Parent​ ​Unit" hidden="false" targetId="f5ec-3ab9-9101-55c4" type="rule"/>
         <infoLink id="9f73-af7a-9339-4ab9" name="Bodyguard" hidden="false" targetId="1d4a-2ada-4edb-0363" type="rule"/>
@@ -2025,7 +2150,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <categoryLink id="03f9-1f1c-0511-ccf8" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1099-6f76-ef83-8b96" name="Imperial Guard" hidden="false" collective="false" type="model">
+        <selectionEntry id="1099-6f76-ef83-8b96" name="Imperial Guard" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="40.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46af-4244-35e6-502c" type="max"/>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b719-ffbd-d73f-bc60" type="min"/>
@@ -2051,7 +2176,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
                 <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
                 <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Plate Armour</characteristic>
               </characteristics>
             </profile>
             <profile id="4c2f-fcba-f612-1237" name="Imperial Guard Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2069,7 +2194,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ae51-4103-3617-8898" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ae51-4103-3617-8898" name="Banner Enchantment" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2080,26 +2205,30 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8a5a-f215-3621-5d8f" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="60ea-836e-e056-4fab" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="81e2-96ee-5c06-1ec2" name="Banner Enchantment" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aa8-296a-8491-5ae5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b844-aa6c-08e5-781d" name="EoS Banner Enchantments (Parent Units)" hidden="false" collective="false" import="true" targetId="32c1-e3dd-aba1-d769" type="selectionEntryGroup"/>
+                <entryLink id="9341-854a-f48c-b3cd" name="Banner Enchantments" hidden="false" collective="false" import="true" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b72a-4779-82d8-cd37" name="Equipment" hidden="false" collective="false" defaultSelectionEntryId="c8ae-e8cd-c0d8-22a4">
+        <selectionEntryGroup id="b72a-4779-82d8-cd37" name="Equipment" hidden="false" collective="false" import="true" defaultSelectionEntryId="c8ae-e8cd-c0d8-22a4">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c32-cc03-3ff8-d379" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f21-85d6-1e8c-8106" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c8ae-e8cd-c0d8-22a4" name="Shield" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c8ae-e8cd-c0d8-22a4" name="Shield" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="8a66-a5cc-6fb1-68b0" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
               </infoLinks>
@@ -2107,7 +2236,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="fdae-7803-db15-33dd" name="Great Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="fdae-7803-db15-33dd" name="Great Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="3.0">
                   <repeats>
@@ -2126,13 +2255,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3496-5e04-8294-efc3" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="3496-5e04-8294-efc3" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-130.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e18c-3280-0d47-8b63" name="Knights of the Sun Griffon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e18c-3280-0d47-8b63" name="Knights of the Sun Griffon" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0224-b90b-8cdb-c4d3" type="max"/>
       </constraints>
@@ -2147,7 +2276,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <categoryLink id="83e3-a360-62ad-7262" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8e78-cdf8-2353-9755" name="Knight of the Sun Griffon​" hidden="false" collective="false" type="model">
+        <selectionEntry id="8e78-cdf8-2353-9755" name="Knight of the Sun Griffon​" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d423-bd89-3e00-a066" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8e7-e221-3fe9-3891" type="min"/>
@@ -2173,7 +2302,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Def" typeId="160d-4624-273f-2114">4</characteristic>
                 <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
                 <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
-                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Plate Armour, Shield</characteristic>
               </characteristics>
             </profile>
             <profile id="a5a4-acef-ad0f-6b38" name="Knight Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2193,7 +2322,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2201,7 +2330,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="83.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7612-f40e-9eb2-f996" name="Banner Enchantment" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7612-f40e-9eb2-f996" name="Banner Enchantment" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2212,26 +2341,30 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d08-a084-a71f-a19e" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="4fa2-22f4-31b9-fb9a" name="Banner Enchantments" hidden="false" collective="false" targetId="c931-0039-b6cd-89b2" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="set" field="0bb4-1b2d-c3b8-aea4" value="1"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="22f2-8d86-e46c-7e8c" name="Banner Enchantment" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7a0-af41-7e0c-c5ae" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="7982-51dd-cb71-8c22" name="EoS Banner Enchantments" hidden="false" collective="false" import="true" targetId="1818-95b1-17ee-cc01" type="selectionEntryGroup"/>
+                <entryLink id="e4f8-e0ed-f2e6-2a7b" name="Banner Enchantments" hidden="false" collective="false" import="true" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6226-30bc-afd0-4839" name="Close Combat Weapon" hidden="false" collective="false" defaultSelectionEntryId="0674-5c98-3cc9-3a7c">
+        <selectionEntryGroup id="6226-30bc-afd0-4839" name="Close Combat Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0674-5c98-3cc9-3a7c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7c5-32c0-6552-5b05" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31fb-2792-5240-7346" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="eeed-0424-dd23-5702" name="Lance" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eeed-0424-dd23-5702" name="Lance" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="10.0">
                   <repeats>
@@ -2246,7 +2379,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0674-5c98-3cc9-3a7c" name="Halberd" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0674-5c98-3cc9-3a7c" name="Halberd" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="c98d-1104-3397-666b" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
               </infoLinks>
@@ -2258,13 +2391,13 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="62b8-45ab-4c72-7c13" name="Command Group" hidden="false" collective="false" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
+        <entryLink id="62b8-45ab-4c72-7c13" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="41.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a7dd-0b66-d973-431e" name="Imperial Rangers" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a7dd-0b66-d973-431e" name="Imperial Rangers" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fbd-740d-4551-66f8" type="max"/>
       </constraints>
@@ -2284,12 +2417,18 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
           </modifiers>
         </infoLink>
         <infoLink id="7d3f-8712-1893-b9a1" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
+        <infoLink id="db76-a59f-66fe-cb15" name="Hard Target" hidden="false" targetId="69d6-4d15-1fc4-13d3" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4eca-b973-1b4a-cbe0" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="de39-0fc7-3c5e-809c" name="New CategoryLink" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8b8a-5853-9792-0286" name="Imperial Ranger" hidden="false" collective="false" type="model">
+        <selectionEntry id="8b8a-5853-9792-0286" name="Imperial Ranger" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d2d-b879-c5e3-0cc3" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c591-0a1e-5e99-c1b6" type="min"/>
@@ -2315,7 +2454,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
                 <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
                 <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Hard Target (1)</characteristic>
               </characteristics>
             </profile>
             <profile id="74dc-7bf6-ca6d-6aff" name="Imperial Ranger Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2325,7 +2464,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Beast Hunters, Bow (4+)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2333,7 +2472,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="11.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4a2b-c06f-9a49-11b7" name="Champion" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4a2b-c06f-9a49-11b7" name="Champion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1862-0173-68e8-a6ae" type="max"/>
           </constraints>
@@ -2346,7 +2485,7 @@ The model part gains +2 Agility. Close Combat Attacks made by the model part gai
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e0e1-5d93-be07-31b0" name="Reiters​" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e0e1-5d93-be07-31b0" name="Reiters​" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="74cf-1f9b-f0f8-4348" type="max"/>
       </constraints>
@@ -2375,7 +2514,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <categoryLink id="afc7-2bad-fa99-85d6" name="New CategoryLink" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="25e2-52e6-5a70-ea68" name="Reiter" hidden="false" collective="false" type="model">
+        <selectionEntry id="25e2-52e6-5a70-ea68" name="Reiter" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af72-bc10-a245-14eb" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f516-17e4-716b-c48b" type="min"/>
@@ -2402,7 +2541,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <characteristic name="Def" typeId="160d-4624-273f-2114">3</characteristic>
                 <characteristic name="Res" typeId="ec15-bc66-645e-db5d">3</characteristic>
                 <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">1</characteristic>
-                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+                <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Light Armour</characteristic>
               </characteristics>
             </profile>
             <profile id="2d20-6286-b525-716d" name="Horse Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2412,7 +2551,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
               </characteristics>
             </profile>
             <profile id="6ae0-032f-bf73-cf6f" name="Reiter Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2422,7 +2561,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Fire on Impact</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2430,7 +2569,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="23.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="791b-d7b5-c7af-f7a5" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="791b-d7b5-c7af-f7a5" name="Heavy Armour" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="increment" field="24fd-8af8-0c78-001c" value="3.0">
               <repeats>
@@ -2447,13 +2586,13 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4b96-da38-7eea-a609" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="3362-89ad-3f9b-78ab">
+        <selectionEntryGroup id="4b96-da38-7eea-a609" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="3362-89ad-3f9b-78ab">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c748-a25a-8992-9e3d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abd9-bd6a-222c-1a39" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d1f7-f1bd-f31b-37de" name="Brace of Pistols (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d1f7-f1bd-f31b-37de" name="Brace of Pistols (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="5.0">
                   <repeats>
@@ -2475,7 +2614,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0264-fc40-7fb3-8d44" name="Repeater Gun (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0264-fc40-7fb3-8d44" name="Repeater Gun (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="24fd-8af8-0c78-001c" value="5.0">
                   <repeats>
@@ -2497,7 +2636,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="57a0-8f67-1424-4d79" name="Light Lance and Shield" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="57a0-8f67-1424-4d79" name="Light Lance and Shield" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e13e-1b8a-88e5-74db" type="max"/>
               </constraints>
@@ -2509,7 +2648,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3362-89ad-3f9b-78ab" name="Pistol (3+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3362-89ad-3f9b-78ab" name="Pistol (3+)" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="0b4b-f700-0057-19f6" name="Pistol" hidden="false" targetId="12c1-3184-6230-c142" type="profile">
                   <modifiers>
@@ -2523,14 +2662,14 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9912-7648-05eb-6d08" name="Command Group" hidden="false" collective="false">
+        <selectionEntryGroup id="9912-7648-05eb-6d08" name="Command Group" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="ce1f-7f6a-bd8a-c413" name="Champion" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ce1f-7f6a-bd8a-c413" name="Champion" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f91-5b8b-301e-75be" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="d8a0-e1c6-ffe2-6713" name="Repeater Pistol (4+)" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="d8a0-e1c6-ffe2-6713" name="Repeater Pistol (4+)" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4821-e699-4bd5-37cc" type="max"/>
                   </constraints>
@@ -2550,7 +2689,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="961f-b9b4-54ad-f0c5" name="Musician" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="961f-b9b4-54ad-f0c5" name="Musician" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32ff-756e-cf9b-5040" type="max"/>
               </constraints>
@@ -2565,7 +2704,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1dca-cb02-030a-ef74" name="Artillery" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1dca-cb02-030a-ef74" name="Artillery" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6176-b01f-f219-cc1d" type="max"/>
       </constraints>
@@ -2584,7 +2723,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Move or Fire</characteristic>
           </characteristics>
         </profile>
         <profile id="39cd-f8b0-2563-c7a2" name="Artillery Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -2611,13 +2750,13 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <categoryLink id="a436-6e21-c5ed-e563" name="New CategoryLink" hidden="false" targetId="ecde-c284-9850-23e1" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bdc8-69c7-c94b-d115" name="Must become one" hidden="false" collective="false">
+        <selectionEntryGroup id="bdc8-69c7-c94b-d115" name="Artillery Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b32-155c-0894-b687" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29f3-f085-411c-16e6" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9aa4-a175-5a2b-d960" name="Cannon​​ (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9aa4-a175-5a2b-d960" name="Cannon​​ (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f34-3f08-9ded-0cab" type="max"/>
               </constraints>
@@ -2645,7 +2784,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="245.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a1bf-8bbf-2437-9757" name="Volley Gun (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a1bf-8bbf-2437-9757" name="Volley Gun (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7dd0-6d9c-a298-1f57" type="max"/>
               </constraints>
@@ -2664,7 +2803,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="55c3-ea0c-777b-00ce" name="Mortar (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="55c3-ea0c-777b-00ce" name="Mortar (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3027-d35d-ae43-1130" type="max"/>
               </constraints>
@@ -2683,7 +2822,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="190.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="095f-c036-8c94-0b45" name="Imperial Rocketeer (4+)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="095f-c036-8c94-0b45" name="Imperial Rocketeer (4+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6778-42ff-6d35-83a4" type="max"/>
               </constraints>
@@ -2709,7 +2848,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="23fa-443a-7d84-7fc2" name="Arcane Engine" hidden="false" collective="false" type="unit">
+    <selectionEntry id="23fa-443a-7d84-7fc2" name="Arcane Engine" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d1c-8555-899f-a986" type="max"/>
       </constraints>
@@ -2728,7 +2867,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="4d52-0b8e-6cca-dd7c" name="Arcane Engine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -2752,15 +2891,15 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         </profile>
         <profile id="dadf-986f-4395-e434" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
           <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"></characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"></characteristic>
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"></characteristic>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Impact Hits (D6), Inanimate</characteristic>
           </characteristics>
         </profile>
-        <profile id="151a-05dd-de0b-bfaf" name="Arcane Engine" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+        <profile id="151a-05dd-de0b-bfaf" name="Arcane Engine Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
           <characteristics>
             <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
             <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Construct</characteristic>
@@ -2788,13 +2927,13 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <categoryLink id="ac79-cc5c-06a6-bcbb" name="New CategoryLink" hidden="false" targetId="f8f1-3d4f-12bf-73cd" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c4a3-d099-ece3-6059" name="Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="c4a3-d099-ece3-6059" name="Arcane Instrument" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc99-c06e-982d-7c60" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94aa-cc17-6830-b0e1" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="75ca-3095-8c52-8471" name="Arcane Shield" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="75ca-3095-8c52-8471" name="Arcane Shield" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc35-f630-a416-2516" type="max"/>
               </constraints>
@@ -2803,11 +2942,8 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                   <description>Friendly units within 6&quot; of the model gains Distracting. The Arcane Engine can cast Perception of Strength from Cosmology as a Bound Spell with Power Level (4/8).</description>
                 </rule>
               </rules>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="95d3-4682-f3f3-9e1e" name="Foresight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="95d3-4682-f3f3-9e1e" name="Foresight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfcc-fc55-da7b-634f" type="max"/>
               </constraints>
@@ -2817,7 +2953,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 </rule>
               </rules>
               <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2827,7 +2963,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="280.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9362-c4d4-f0fe-84e7" name="Flagellants" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9362-c4d4-f0fe-84e7" name="Flagellants" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9514-182f-3593-a8d2" type="max"/>
       </constraints>
@@ -2844,12 +2980,13 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <infoLink id="733d-2cf1-f60e-414b" name="Frenzy" hidden="false" targetId="b6f2-241f-8379-3327" type="rule"/>
         <infoLink id="8d92-20bc-716e-1765" name="Battle Focus" hidden="false" targetId="cc29-65f2-796b-52e2" type="rule"/>
         <infoLink id="4eea-a8da-d85b-014c" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
+        <infoLink id="3611-6db8-b50a-30f1" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fe74-3905-a70f-a0de" name="New CategoryLink" hidden="false" targetId="bc79-f1f0-5d7d-cd9b" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4cf4-4e59-2140-83dc" name="Flagellant" hidden="false" collective="false" type="model">
+        <selectionEntry id="4cf4-4e59-2140-83dc" name="Flagellant" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47a8-b710-fc02-6826" type="min"/>
             <constraint field="selections" scope="parent" value="30.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bf9-eff8-e360-3a03" type="max"/>
@@ -2885,7 +3022,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
                 <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
                 <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
                 <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+                <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Battle Focus, Great Weapon</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2893,7 +3030,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="17.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8b09-082d-f0fb-a8f2" name="Champion" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8b09-082d-f0fb-a8f2" name="Champion" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfaa-00c2-59ce-fda3" type="max"/>
           </constraints>
@@ -2906,7 +3043,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-65.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="92cc-2df6-7b8c-4b24" name="Steam Tank" hidden="false" collective="false" type="unit">
+    <selectionEntry id="92cc-2df6-7b8c-4b24" name="Steam Tank" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="553b-90bc-f2f9-b376" type="max"/>
       </constraints>
@@ -2920,12 +3057,12 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         </profile>
         <profile id="3ea8-b372-c6fe-a0a1" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
           <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"></characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"></characteristic>
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Breath Attack (Str 2, AP 3), Grind Attacks (3D3), Steam Cannon (3+)</characteristic>
           </characteristics>
         </profile>
         <profile id="8eb3-29fc-a15f-6d49" name="Steam Tank Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -2939,12 +3076,12 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         </profile>
         <profile id="264f-e284-9a23-4447" name="Steel Ram Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
           <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"></characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"></characteristic>
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">7</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">4</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"></characteristic>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Impact Hits (2D3), Inanimate</characteristic>
           </characteristics>
         </profile>
         <profile id="5e30-5c14-f241-2f87" name="Steam Cannon (3+)" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
@@ -2994,6 +3131,7 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
             <modifier type="append" field="name" value=" (2D3)"/>
           </modifiers>
         </infoLink>
+        <infoLink id="f1f4-4c71-965c-58f5" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a5b2-dc0c-02b3-b74e" name="Imperial Armoury (local)" hidden="false" targetId="ecde-c284-9850-23e1" primary="false"/>
@@ -3003,216 +3141,9 @@ A charging model part with Fire on Impact! using a Pistol, a Brace of Pistols, o
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="490.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="53f6-c4b8-4420-0d89" name="Inquisitor (Silver Shots)" hidden="false" collective="false" type="unit">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a98b-7228-5c28-bbe4" type="max"/>
-      </constraints>
-      <profiles>
-        <profile id="c705-d0a3-f8a8-123d" name="Inquisitor​ Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
-          <characteristics>
-            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
-            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
-            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="2652-a8be-34ef-e8ef" name="Inquisitor​ Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
-          <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">2</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">5</characteristic>
-            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
-            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
-          </characteristics>
-        </profile>
-        <profile id="b560-8fc4-5aec-5a86" name="Inquisitor​ Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
-          <characteristics>
-            <characteristic name="HP" typeId="f381-7850-7fa8-3440">3</characteristic>
-            <characteristic name="Def" typeId="160d-4624-273f-2114">5</characteristic>
-            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">4</characteristic>
-            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">0</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
-          </characteristics>
-        </profile>
-        <profile id="a10b-e198-d08f-5638" name="Inquisitor Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
-          <characteristics>
-            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Standard</characteristic>
-            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Infantry</characteristic>
-            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">20×20</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="a0c1-fed8-c82f-0de8" name="Silver Shots" hidden="false">
-          <description>Attack Attribute - Shooting.
-The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-wound rolls.</description>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="bfde-fa63-fcd2-2a3d" name="Plate Armour" hidden="false" targetId="85fa-68ac-214d-2f4b" type="profile"/>
-        <infoLink id="5517-77a8-8dc7-7e5e" name="Fearless" hidden="false" targetId="0ab3-2e1b-8c2b-a7fe" type="rule"/>
-        <infoLink id="2b54-7008-d1bb-b151" name="Not a Leader" hidden="false" targetId="f611-6165-ada9-0d7d" type="rule"/>
-        <infoLink id="55b7-a067-d479-f74e" name="Lethal Strike" hidden="false" targetId="f433-7645-0332-97a4" type="rule"/>
-        <infoLink id="5f58-d4bf-6571-45bd" name="Multiple Wounds" hidden="false" targetId="2ea2-3a42-de1e-bc0a" type="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (D3)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="eabb-3bb6-8481-969e" name="Light Troops" hidden="false" targetId="8b75-3cd5-bd70-6210" type="rule">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="53f6-c4b8-4420-0d89" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b403-cb82-ea15-3b55" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="5823-7885-c1c7-ecfc" name="New CategoryLink" hidden="false" targetId="953d-22cd-7ee1-36dc" primary="true"/>
-        <categoryLink id="a988-3b01-6d75-5209" name="Imperial Auxiliaries (local)" hidden="false" targetId="77b5-bf3a-88ad-b176" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6965-ce4c-e264-2d0a" name="Special Equipment" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d99e-c69a-9b66-c433" type="max"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d1dd-ffee-4176-f37a" name="Special Equipment" hidden="false" collective="false">
-              <constraints>
-                <constraint field="24fd-8af8-0c78-001c" scope="parent" value="100.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf60-af6b-1635-bcd2" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="30a9-c058-f831-8c82" name="Artefacts" hidden="false" collective="false" targetId="b0ad-eb3e-4b5c-29c0" type="selectionEntryGroup"/>
-                <entryLink id="e7c1-314e-bc7c-265c" name="Weapon Enchantments" hidden="false" collective="false" targetId="b7c0-c16c-b10e-715e" type="selectionEntryGroup"/>
-                <entryLink id="5d6e-8d7c-43ad-10d9" name="Armour Enchantments" hidden="false" collective="false" targetId="98d6-19e5-b41f-5703" type="selectionEntryGroup"/>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2278-3552-d27e-4be6" name="Shield" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e64-628d-3970-31c8" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="acac-8d60-ae83-206e" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4b08-1f6d-feb5-279b" name="Close Combat Weapons" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="c76d-f5cb-0c51-d02d" name="Great Weapon" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a10-b0f3-76a5-6538" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="3b1d-d230-1014-eb6f" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1a34-e0c6-a9e5-f2be" name="Paired Weapons" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d07-0b92-9195-f026" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="ca4b-75a5-9911-10ac" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1817-25a5-db63-6d17" name="Halberd" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bd-e626-761d-e389" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="2dd2-3960-b372-874a" name="Halberd" hidden="false" targetId="680b-8e56-dff9-240c" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d060-6761-317f-eb27" name="Shooting Weapons" hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="672b-f023-8032-7c8a" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="f8cf-300a-5043-0089" name="Crossbow (2+)" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b003-bd68-9ddc-998a" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="114a-21c9-a169-de85" name="Crossbow" hidden="false" targetId="fdf6-3c15-644b-1ced" type="profile">
-                  <modifiers>
-                    <modifier type="append" field="name" value=" (2+)"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7561-de75-393d-e503" name="Brace of Pistols (3+)" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="398d-1ebc-a29a-8a2e" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="644d-0ae1-30aa-52f4" name="Brace of Pistols" hidden="false" targetId="0a78-70b9-c34e-5752" type="profile">
-                  <modifiers>
-                    <modifier type="append" field="name" value=" (3+)"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e143-fb35-43f2-f63b" name="Repeater Pistol (3+)" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c8-c990-92e3-d52f" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="3e08-5e15-955d-ee52" name="Repeater Pistol" hidden="false" targetId="ceb6-ffaa-c9f3-a019" type="profile">
-                  <modifiers>
-                    <modifier type="append" field="name" value=" (3+)"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="b403-cb82-ea15-3b55" name="Horse" hidden="false" collective="false" targetId="10e6-5007-fc0c-e82a" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="24fd-8af8-0c78-001c" value="75.0"/>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cda-8d4a-30fb-070a" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="180.0"/>
-      </costs>
-    </selectionEntry>
   </selectionEntries>
   <sharedSelectionEntries>
-    <selectionEntry id="10e6-5007-fc0c-e82a" name="Horse" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="10e6-5007-fc0c-e82a" name="Horse" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="3cd3-fa7c-d9e3-a065" name="Horse Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -3228,7 +3159,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="3fb8-deb2-4a68-929a" name="Horse Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3240,6 +3171,13 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
           </characteristics>
         </profile>
+        <profile id="df01-fb24-ab95-e18a" name="Horse Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Standard</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Cavalry</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">25×50</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <infoLinks>
         <infoLink id="a074-a310-5eee-6605" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
@@ -3248,12 +3186,12 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cacf-1879-9a46-9c66" name="Pegasus" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="cacf-1879-9a46-9c66" name="Pegasus" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="90fb-367a-8527-c30c" name="Pegasus Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
-            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 7&quot;, Fly 8&quot;</characteristic>
-            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 14&quot;, Fly 16&quot;</characteristic>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (16&quot;)</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
           </characteristics>
         </profile>
@@ -3264,7 +3202,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">1</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="f284-8e39-4d04-19dd" name="Pegasus Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3276,6 +3214,13 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
           </characteristics>
         </profile>
+        <profile id="dd4c-60ae-3435-37b9" name="Pegasus Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Cavalry</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">40×40</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <infoLinks>
         <infoLink id="6d86-203c-8493-95ad" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
@@ -3284,7 +3229,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f733-dce6-f27c-3607" name="Young Griffon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f733-dce6-f27c-3607" name="Young Griffon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="7f3f-9ed3-1579-5203" name="Young Griffon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -3300,7 +3245,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">4</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="f410-be14-02b6-1629" name="Young Griffon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3312,6 +3257,13 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
           </characteristics>
         </profile>
+        <profile id="7173-1494-576d-aa9b" name="Young Griffon Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Cavalry</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×75</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <infoLinks>
         <infoLink id="da47-9202-57b1-c1ef" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
@@ -3321,12 +3273,12 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0ceb-e9be-fa78-150f" name="Great Griffon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0ceb-e9be-fa78-150f" name="Great Griffon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0ecb-630c-a410-944f" name="Great Griffon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
-            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 7&quot;, Fly 8&quot;</characteristic>
-            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 14&quot;, Fly 16&quot;</characteristic>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (8&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (16&quot;)</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
           </characteristics>
         </profile>
@@ -3337,7 +3289,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">5</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="5c08-aa4f-2bbb-0b7b" name="Great Griffon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3347,6 +3299,13 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
             <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+          </characteristics>
+        </profile>
+        <profile id="fd74-47dd-adcf-4b4b" name="Great Griffon Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Cavalry</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×100</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3359,15 +3318,15 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ca5d-3e42-5f9e-8e71" name="Dragon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ca5d-3e42-5f9e-8e71" name="Dragon" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="41ed-1978-8365-ba01" type="max"/>
       </constraints>
       <profiles>
         <profile id="51be-2a26-9fe7-ccd0" name="Dragon Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
-            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 6&quot;, Fly 7&quot;</characteristic>
-            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 12&quot;, Fly 14&quot;</characteristic>
+            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot; (7&quot;)</characteristic>
+            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot; (14&quot;)</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
           </characteristics>
         </profile>
@@ -3378,7 +3337,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">6</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">3</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Breath Attack (Str 4, AP 1, Flaming Attacks), Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="cce9-b8f4-1992-f0f7" name="Dragon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3388,6 +3347,13 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">6</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">4</characteristic>
             <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+          </characteristics>
+        </profile>
+        <profile id="f43f-2e12-703b-e6be" name="Dragon Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Gigantic</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Beast</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×100</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3403,7 +3369,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6944-42d1-8941-6450" name="Arcane Engine" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6944-42d1-8941-6450" name="Arcane Engine" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="9a63-293f-1639-cd4d" name="Arcane Engine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
@@ -3419,7 +3385,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
         <profile id="a28f-53b3-67e5-6b58" name="Arcane Engine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3443,12 +3409,19 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         </profile>
         <profile id="bb25-217c-91dd-f971" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
           <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"></characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"></characteristic>
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"></characteristic>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Impact Hits (D6), Inanimate</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="e663-f249-fa62-9a3a" name="Arcane Engine Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Construct</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×100</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3469,13 +3442,13 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         </infoLink>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e360-520d-5691-dcf9" name="Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="e360-520d-5691-dcf9" name="Arcane Instrument" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="329b-d367-8e95-de8e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f54-3eac-02f0-0cd8" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e378-ad9a-9196-d17a" name="Arcane Shield" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e378-ad9a-9196-d17a" name="Arcane Shield" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ee0-56f8-9aec-5e4c" type="max"/>
               </constraints>
@@ -3488,7 +3461,7 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
                 <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d3f6-9f45-8606-55bc" name="Foresight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d3f6-9f45-8606-55bc" name="Foresight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9443-0d87-2d77-459a" type="max"/>
               </constraints>
@@ -3508,12 +3481,12 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8d97-387f-45ee-5f63" name="Altar of Battle" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8d97-387f-45ee-5f63" name="Altar of Battle" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b146-a4ee-df82-a2c8" type="max"/>
       </constraints>
       <profiles>
-        <profile id="6aeb-dfa7-6f9e-0267" name="Altar​ ​of​ ​Battle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+        <profile id="6aeb-dfa7-6f9e-0267" name="Altar of Battle Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
@@ -3527,31 +3500,38 @@ The attack gains Multiple Wounds (D3), Lethal Strike, and must reroll failed to-
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">3</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">3</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Harnessed</characteristic>
           </characteristics>
         </profile>
-        <profile id="56c1-de65-fe71-ed3f" name="Altar​ ​of​ ​Battle Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+        <profile id="56c1-de65-fe71-ed3f" name="Altar of Battle Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
           <characteristics>
             <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
             <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
             <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
             <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14"/>
+            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Aegis (4+)</characteristic>
           </characteristics>
         </profile>
         <profile id="097e-e47e-25a1-fec0" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
           <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a">-</characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7">-</characteristic>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"></characteristic>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"></characteristic>
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">5</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">2</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">-</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36"/>
+            <characteristic name="Agi" typeId="2a23-367f-8828-c297"></characteristic>
+            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Impact Hits (D6), Inanimate</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1b22-4477-447c-0ac5" name="Altar of Battle Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+          <characteristics>
+            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
+            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Construct</characteristic>
+            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×100</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <rules>
-        <rule id="d009-c2a9-f946-bcd5" name="Holy​ ​Relic" hidden="false">
+        <rule id="d009-c2a9-f946-bcd5" name="Holy Relic" hidden="false">
           <description>All models in friendly units within 6&quot; of the bearer gain Hatred. Model parts with Harnessed are not affected.
 All Blessings Bound Spells cast by the rider have Type: Aura and Range 6&quot; (replaces Type: Caster’s Unit).
 The model can cast Unerring Strike from Divination as a Bound Spell with Power Level (4/8).</description>
@@ -3578,7 +3558,7 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="60e0-a887-6970-1fc7" name="Army General" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="60e0-a887-6970-1fc7" name="Army General" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0b6-d79f-6d3b-c644" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7d-dd32-dd7d-9feb" type="max"/>
@@ -3592,7 +3572,7 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="53e0-007c-21bc-d3cc" name="Battle Standard Bearer" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="53e0-007c-21bc-d3cc" name="Battle Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ac-d9b3-2e5d-a685" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="946c-19e4-caac-d0d4" type="min"/>
@@ -3605,20 +3585,131 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="815d-5561-3c9c-df3e" name="°Exemplar&apos;s Flame" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="7213-11c4-0241-9ddd" value="0.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a15-8ac5-586b-1b94" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3db5-8d52-cfe9-fbfa" type="equalTo"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02ee-20af-e439-e56f" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7213-11c4-0241-9ddd" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac1a-3bd5-77d2-b6cb" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f1b7-be19-7f59-138b" name="Exemplar&apos;s Flame" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+          <characteristics>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340">Wizards only. Dominant.</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Choose a single Parent Unit after Spell Selection (at step 8 of the Pre-Game Sequence). At the start of any friendly Melee Phase, if the bearer is within 18” of the chosen unit, the controlling player may choose to discard a single Veil Token from their Veil Token pool to grant all R&amp;F model in the chosen unit Lethal Strike and Magical Attacks until the end of the Phase.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d079-ee9c-d2c0-3680" name="Winter Cloak" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4b8-d3ad-765b-8c78" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8778-8197-a5e7-15b3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="35d8-9bab-4a52-f764" name="Winter Cloak" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+          <characteristics>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Distracting, Aegis (5+), and Aegis (2+, against Flaming Attacks).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6f99-10b3-9f3b-d560" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value=" (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f188-dd7f-7f0f-99da" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
+        <infoLink id="2eb8-d4bd-2e80-c8a4" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+          <modifiers>
+            <modifier type="append" field="name" value="(2+, against Flaming Attacks)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6d0-53e0-45e8-fddb" name="Mantle of Ullor" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2183-8e1d-d9c3-6a27" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f7a-c2fa-c82b-370a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="77ac-8869-d204-894d" name="Mantle of Ullor" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+          <characteristics>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Enemy units within 6&quot; of the bearer do not gain +1 Agility for Charging Momentum.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="517e-f867-01af-b7c2" name="Karadon&apos;s Courser (on Horse only)" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0a9-72c4-98f5-76b3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4377-1482-fa8e-754b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9731-91df-8b7d-d7dc" name="Karadon&apos;s Courser" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+          <characteristics>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340">Knight Commanders and Marshals mounted on Horse only.</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any friendly Player Turn. For the duration of this Player Turn, all friendly units within 6” of the bearer must reroll failed Charge Range rolls.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15b8-c697-8bc3-48b9" name="Locket of Sunna" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5220-c3e4-36cd-0f5c" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd95-0caf-d0ab-d35a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="218b-e998-7841-d3ef" name="Locket of Sunna" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+          <characteristics>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When fighting in a Duel, choose a single model part with neither Harnessed nor Inanimate that the bearer is fighting with.  The bearer must swap its Characteristic values of Strength, Armour Penetration, Resilience, Agility, and Attack Value with those of the chosen model part. This is done before applying other modifiers.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="c8f1-3b4d-c247-25ea" name="Weapon Enchantments - EoS" hidden="false" collective="false">
+    <selectionEntryGroup id="c8f1-3b4d-c247-25ea" name="EoS Weapon Enchantments" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d16-0a92-72b1-ae91" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="3b29-9455-2fff-c706" name="The Light of Sonnstahl" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3b29-9455-2fff-c706" name="The Light of Sonnstahl" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fe8-06a8-c838-0fbb" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78dd-1451-bda0-c1a4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="48d1-1427-d485-ff39" name="The Light of ​​Sonnstahl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+            <profile id="48d1-1427-d485-ff39" name="The Light of Sonnstahl" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
               <characteristics>
                 <characteristic name="Type" typeId="d779-a728-a38c-8340">Hand Weapon enchantment.</characteristic>
                 <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon wound automatically, always have Armour Penetration 10, and Magical Attacks.</characteristic>
@@ -3629,7 +3720,7 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="150.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="fb7f-0cdc-3f83-58a3" name="Death Warrant" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="fb7f-0cdc-3f83-58a3" name="Death Warrant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b68-c562-f664-5368" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f85c-cbaf-4555-29ce" type="max"/>
@@ -3649,7 +3740,7 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9fd6-43b0-e619-fa1a" name="Hammer of Witches" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9fd6-43b0-e619-fa1a" name="Hammer of Witches" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f71-65f9-5590-9250" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe61-fba0-2cec-cda7" type="max"/>
@@ -3668,222 +3759,22 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="ba32-8574-fdc2-2a91" name="Armour Enchantments - EoS" hidden="false" collective="false">
-      <modifiers>
-        <modifier type="set" field="1d6a-8a6d-6e0d-ad36" value="2">
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1d6a-8a6d-6e0d-ad36" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="6016-da9f-68db-372d" name="Blacksteel​" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f627-9b66-685e-0909" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="671b-086d-1435-d634" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="59f7-b13f-63d2-8249" name="Blacksteel​" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour enchantment.</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and Fear. If taken by a model on foot, the wearer gains an additional +1 Armour.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8efe-4463-a54c-b67b" name="Imperial Seal" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a7-fec3-6102-c131" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3729-ada6-7485-db0e" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="1bc0-7239-c448-1872" name="Imperial Seal" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour enchantment. Models on Foot Only</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +3 Armour and +1 Discipline. The wearer’s unit cannot voluntarily declare Flee as a Charge Reaction.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d059-f85a-e731-1bb1" name="Shield of Volund" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbef-bdef-8a41-49a2" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e6ac-578c-7048-fa31" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e44b-2051-7c2d-bc85" name="Shield of Volund" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, attacks against the bearer with Lethal Strike and/or Battle Focus lose these Attack Attributes.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <entryLinks>
-            <entryLink id="afe4-7ba9-ceb4-611c" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1cc6-87e4-05ec-b8d6" name="Witchfire Guard" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8788-3be3-22a2-cea1" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23d7-6180-837e-5824" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="6617-cd27-45dd-d87a" name="Witchfire Guard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (4+) against Magical Attacks.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <entryLinks>
-            <entryLink id="2bd6-e08d-7f11-eda6" name="Shield Enchantement" hidden="false" collective="false" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="834d-a309-413c-9419" name="Atefacts - EoS" hidden="false" collective="false">
+    <selectionEntryGroup id="834d-a309-413c-9419" name="EoS Artefacts (Prelate, Inquisitor, Artificer)" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30d5-3d00-2c00-d344" type="max"/>
       </constraints>
-      <selectionEntries>
-        <selectionEntry id="14ff-c20b-88f8-ccb3" name="Winter Cloak" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f24-9352-f700-7ef8" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58e5-54ae-5ca2-2a55" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="302b-fecb-81ef-5253" name="Winter Cloak" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Distracting, Aegis (5+), and Aegis (2+, against Flaming Attacks).</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="0b7d-bd28-7bf1-7b30" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
-              <modifiers>
-                <modifier type="append" field="name" value=" (5+)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="8e46-a3fd-7f58-5ac3" name="Distracting" hidden="false" targetId="056f-73ea-194b-1b49" type="rule"/>
-            <infoLink id="bcb1-c30f-50ef-5511" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
-              <modifiers>
-                <modifier type="append" field="name" value="(2+, against Flaming Attacks)"/>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3907-d67c-4902-fd03" name="Exemplar&apos;s Flame" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="051a-85ae-2c66-7368" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cedc-1e48-d8f9-ab64" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="3727-404e-a918-384a" name="Exemplar&apos;s Flame" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Wizards only. Dominant.</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Choose a single Parent Unit after Spell Selection (at step 8 of the Pre-Game Sequence). At the start of any friendly Melee Phase, if the bearer is within 18” of the chosen unit, the controlling player may choose to discard a single Veil Token from their Veil Token pool to grant all R&amp;F model in the chosen unit Lethal Strike and Magical Attacks until the end of the Phase.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e1a3-307a-ba39-b0d4" name="Locket of Sunna" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e8-7021-7296-4104" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a464-14f3-deeb-ca1d" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="db1d-6005-6df8-dce5" name="Locket of Sunna" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">When fighting in a Duel, choose a single model part with neither Harnessed nor Inanimate that the bearer is fighting with.  The bearer must swap its Characteristic values of Strength, Armour Penetration, Resilience, Agility, and Attack Value with those of the chosen model part. This is done before applying other modifiers.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="59d7-48fb-e8c5-3340" name="Mantle of Ullor" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="533d-e570-8dc6-482f" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29db-1391-af09-fba3" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="29dd-dacc-35ee-68cf" name="Mantle of Ullor" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Enemy units within 6&quot; of the bearer do not gain +1 Agility for Charging Momentum.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="35b1-4d99-c535-6586" name="Karadon&apos;s Courser" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed0a-f43c-7cf7-a0d1" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="edf2-5b34-9fc0-374f" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="f97c-2375-5e90-2fb3" name="Karadon&apos;s Courser" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Knight Commanders and Marshals mounted on Horse only.</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. May be activated at the start of any friendly Player Turn. For the duration of this Player Turn, all friendly units within 6” of the bearer must reroll failed Charge Range rolls.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <entryLinks>
+        <entryLink id="8715-8b71-8a5a-a640" name="Locket of Sunna" hidden="false" collective="false" import="true" targetId="15b8-c697-8bc3-48b9" type="selectionEntry"/>
+        <entryLink id="abcd-26f5-9aa1-da05" name="Mantle of Ullor" hidden="false" collective="false" import="true" targetId="e6d0-53e0-45e8-fddb" type="selectionEntry"/>
+        <entryLink id="28de-fc85-4b7e-524d" name="Winter Cloak" hidden="false" collective="false" import="true" targetId="d079-ee9c-d2c0-3680" type="selectionEntry"/>
+      </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="1818-95b1-17ee-cc01" name="Banner Enchantments - EoS" hidden="false" collective="false">
+    <selectionEntryGroup id="1818-95b1-17ee-cc01" name="EoS Banner Enchantments" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc21-b0c1-8041-011d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc21-b0c1-8041-011d" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="d88a-1dab-f22a-19f9" name="Banner of Unity" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b89-4817-ceb5-df30" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57f1-527d-8460-65a0" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="482e-62d4-4093-97e7" name="Banner of Unity" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-              <characteristics>
-                <characteristic name="Type" typeId="d779-a728-a38c-8340">Parent Units Only</characteristic>
-                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Whenever the bearer’s unit is targeted by an Order, an additional Order can be given (for free) to a single Support Unit within 8&quot; of the bearer’s unit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5366-4998-8b9b-e744" name="Household Standard" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5366-4998-8b9b-e744" name="Household Standard" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aab-38f5-646b-21dd" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b09-d919-1c16-e062" type="max"/>
@@ -3900,7 +3791,7 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f8e9-a3e5-a1e0-bc3e" name="Marksman’s Pennant" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f8e9-a3e5-a1e0-bc3e" name="Marksman’s Pennant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a66-1208-9576-9e57" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9552-3fe4-0ec3-e452" type="max"/>
@@ -3919,7 +3810,7 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="98d6-19e5-b41f-5703" name="Armour Enchantments" hidden="false" collective="false">
+    <selectionEntryGroup id="98d6-19e5-b41f-5703" name="Armour Enchantments" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="6e51-a7b5-42f1-6f1f" value="2">
           <conditions>
@@ -3931,36 +3822,227 @@ The model can cast Unerring Strike from Divination as a Bound Spell with Power L
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6e51-a7b5-42f1-6f1f" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="ee86-8621-10a6-876b" name="Armour Enchantments - EoS" hidden="false" collective="false" targetId="ba32-8574-fdc2-2a91" type="selectionEntryGroup"/>
-        <entryLink id="3002-aeb6-ca5d-e72a" name="Armour Enchantments" hidden="false" collective="false" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
+        <entryLink id="ee86-8621-10a6-876b" name="EoS Armour Enchantments" hidden="false" collective="false" import="true" targetId="000c-ef06-4dd1-7087" type="selectionEntryGroup"/>
+        <entryLink id="3002-aeb6-ca5d-e72a" name="Armour Enchantments" hidden="false" collective="false" import="true" targetId="4c4e-146b-a165-a891" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="b0ad-eb3e-4b5c-29c0" name="Artefacts" hidden="false" collective="false">
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8cca-78a8-6b6e-86ca" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="18b3-f897-4a24-a3af" name="Artefacts" hidden="false" collective="false" targetId="a755-929f-7067-ae6e" type="selectionEntryGroup"/>
-        <entryLink id="6676-45eb-a748-cfa5" name="Atefacts - EoS" hidden="false" collective="false" targetId="834d-a309-413c-9419" type="selectionEntryGroup"/>
-      </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="b7c0-c16c-b10e-715e" name="Weapon Enchantments" hidden="false" collective="false">
+    <selectionEntryGroup id="b7c0-c16c-b10e-715e" name="Weapon Enchantments" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dad5-3527-20f0-59c7" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="9efa-ce4f-ced5-2227" name="Weapon Enchantments" hidden="false" collective="false" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
-        <entryLink id="75bd-1d03-1407-90f2" name="Weapon Enchantments - EoS" hidden="false" collective="false" targetId="c8f1-3b4d-c247-25ea" type="selectionEntryGroup"/>
+        <entryLink id="9efa-ce4f-ced5-2227" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
+        <entryLink id="75bd-1d03-1407-90f2" name="Weapon Enchantments - EoS" hidden="false" collective="false" import="true" targetId="c8f1-3b4d-c247-25ea" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="c931-0039-b6cd-89b2" name="Banner Enchantments" hidden="false" collective="false">
+    <selectionEntryGroup id="9fb0-1e1a-4d75-6614" name="EoS Artefacts (Wizard)" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0bb4-1b2d-c3b8-aea4" type="max"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5691-d075-3d5f-8ead" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="91ee-1934-23f2-a6be" name="Banner Enchantments" hidden="false" collective="false" targetId="37cb-10cd-3c37-56dd" type="selectionEntryGroup"/>
-        <entryLink id="e7da-64e1-45b7-cc6d" name="Banner Enchantments - EoS" hidden="false" collective="false" targetId="1818-95b1-17ee-cc01" type="selectionEntryGroup"/>
+        <entryLink id="6536-fe89-3879-5e28" name="°Exemplar&apos;s Flame" hidden="false" collective="false" import="true" targetId="815d-5561-3c9c-df3e" type="selectionEntry"/>
+        <entryLink id="b923-c60a-1d38-484a" name="Locket of Sunna" hidden="false" collective="false" import="true" targetId="15b8-c697-8bc3-48b9" type="selectionEntry"/>
+        <entryLink id="e87e-a161-fecc-6596" name="Mantle of Ullor" hidden="false" collective="false" import="true" targetId="e6d0-53e0-45e8-fddb" type="selectionEntry"/>
+        <entryLink id="16be-ea7b-5b86-64eb" name="Winter Cloak" hidden="false" collective="false" import="true" targetId="d079-ee9c-d2c0-3680" type="selectionEntry"/>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e5c7-5ee2-643d-103a" name="EoS Artefacts (Marshal, Knight Commander)" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c74d-3a4e-3294-84fd" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="4aee-9553-9326-cc27" name="Karadon&apos;s Courser" hidden="false" collective="false" import="true" targetId="517e-f867-01af-b7c2" type="selectionEntry"/>
+        <entryLink id="5a71-0bfb-1fe7-e761" name="Locket of Sunna" hidden="false" collective="false" import="true" targetId="15b8-c697-8bc3-48b9" type="selectionEntry"/>
+        <entryLink id="f040-f047-7094-70d3" name="Mantle of Ullor" hidden="false" collective="false" import="true" targetId="e6d0-53e0-45e8-fddb" type="selectionEntry"/>
+        <entryLink id="2b3c-f671-0e93-4fc9" name="Winter Cloak" hidden="false" collective="false" import="true" targetId="d079-ee9c-d2c0-3680" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="32c1-e3dd-aba1-d769" name="EoS Banner Enchantments (Parent Units)" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af9c-babf-4b20-f6b6" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0934-625b-dd1f-3cba" name="Banner of Unity" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d93-b9d8-52f7-9182" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77e7-9ab3-a802-8927" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f637-1695-f08b-b759" name="Banner of Unity" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Parent Units Only</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Whenever the bearer’s unit is targeted by an Order, an additional Order can be given (for free) to a single Support Unit within 8&quot; of the bearer’s unit.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2209-a1db-1d0c-8519" name="Household Standard" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06b-053f-991c-a945" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="55d3-1c86-9195-4088" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6656-b0f8-af5c-943b" name="Household Standard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If the General is part of the bearer’s unit, its Commanding Presence range is increased by 6”.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="56f8-cc72-2a02-026e" name="Marksman’s Pennant" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b8-8fff-1963-99df" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4f81-36a3-1da3-db24" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c9c3-7d19-b3fb-8333" name="Marksman’s Pennant" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit does not suffer the -1 to hit penalty for Stand and Shoot Charge Reactions.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="dd59-21e0-a27a-3303" name="EoS Banner Enchantments (BSB)" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="09c8-c01b-b7f3-7227" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="7801-431b-315e-636d" name="Household Standard" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="470a-ef9b-ac9b-ab5c" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f08-a33e-cd60-87d0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dfd7-242b-44ab-9fa3" name="Household Standard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">If the General is part of the bearer’s unit, its Commanding Presence range is increased by 6”.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7215-b44c-f011-b656" name="Marksman’s Pennant" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e6-304b-edda-140e" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1ad-2dda-d556-8d3a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fd79-4e9b-7852-6111" name="Marksman’s Pennant" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340"/>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit does not suffer the -1 to hit penalty for Stand and Shoot Charge Reactions.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="000c-ef06-4dd1-7087" name="EoS Armour Enchantments" hidden="false" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="6634-2f53-5ba0-6ead" value="2.0">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="312f-8f87-7840-0442" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6634-2f53-5ba0-6ead" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="cbbd-71a4-03c3-1832" name="Blacksteel" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f7e-0762-9cae-3fc6" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2bfb-ccdb-d4ba-ee1f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="05cd-dbf8-1726-6b43" name="Blacksteel" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and Fear. If taken by a model on foot, the wearer gains an additional +1 Armour.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4d64-6fa2-839b-51fd" name="Imperial Seal (on Foot only)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b09e-a982-393a-049a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1a38-3180-6d90-0084" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e792-83da-0510-2a15" name="Imperial Seal" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Plate Armour enchantment. Models on Foot Only</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +3 Armour and +1 Discipline. The wearer’s unit cannot voluntarily declare Flee as a Charge Reaction.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="105.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d452-07df-e4af-bc40" name="Shield of Volund (not Gigantic)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1783-3940-5c8b-65d9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b1b-bf7f-20ee-b17e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="55dd-ee44-b37b-dab7" name="Shield of Volund" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">While using this Shield, attacks against the bearer with Lethal Strike and/or Battle Focus lose these Attack Attributes.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="93fa-f486-b021-fbf0" name="Shield Enchantement" hidden="false" collective="false" import="true" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7db1-cbd7-9b0b-32fe" name="Witchfire Guard" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87e9-8b0c-e40b-2de1" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1265-13e7-53a3-14be" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ad26-9911-dbb9-1a22" name="Witchfire Guard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Shield enchantment.</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer gains Aegis (4+) against Magical Attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="fc13-542e-5481-1445" name="Shield Enchantement" hidden="false" collective="false" import="true" targetId="312f-8f87-7840-0442" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="35.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
@@ -3997,7 +4079,7 @@ Brace For Impact! - The target gains Fight in Extra Rank.</description>
         <characteristic name="Attributes" typeId="048a-df92-bb5b-6de9"/>
       </characteristics>
     </profile>
-    <profile id="29fc-4011-201c-832c" name="Repeater ​Gun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
+    <profile id="29fc-4011-201c-832c" name="Repeater Gun" hidden="false" typeId="a00c-d586-ee68-ed21" typeName="6 Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="c2a8-bc01-360c-6aca">24&quot;</characteristic>
         <characteristic name="Shots" typeId="6867-dcc2-7874-e3b4">3</characteristic>


### PR DESCRIPTION
* Offensive profile rules
* Defensive profile rules
* Artefact restrictions
* Banner enchantment restrictions
* BS 2.03 adjustments
* Size profiles for mounts
* Merged Inquisitor into single entry

Fixes #453 