### PR TITLE
Fix #516

### DIFF
--- a/warriorsOfTheDarkGods.cat
+++ b/warriorsOfTheDarkGods.cat
@@ -48,6 +48,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="c0ea-a5c4-68cd-e0f0" name="Exalted Herald Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -162,6 +163,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="ad2c-ac0a-b33f-0481" name="Chosen Lord Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -568,6 +570,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="77b2-f23b-7176-88a2" name="Doomlord Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -753,6 +756,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="580a-c784-47fc-fc19" name="Sorcerer Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -824,11 +828,7 @@
                 <entryLink id="b1ae-b0eb-839c-e313" name="Artefacts" hidden="false" collective="false" import="true" targetId="17df-ad66-db37-0a37" type="selectionEntryGroup"/>
                 <entryLink id="d717-8f60-e3f1-efa2" name="Banner Enchantments" hidden="true" collective="false" import="true" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="6de7-3d7b-8973-aa1c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5734-ced8-7f12-7815" type="equalTo"/>
-                      </conditions>
-                    </modifier>
+                    <modifier type="set" field="hidden" value="false"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
@@ -1072,6 +1072,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="69db-ce5a-7d76-92b0" name="Barbarian Chief Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -1326,6 +1327,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="0139-a047-4999-c646" name="Feldrak Ancestor Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -1482,6 +1484,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="de64-a276-b042-654d" name="Warriors Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -1731,6 +1734,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="2aac-39b8-d117-f47e" name="Fallen Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -1765,6 +1769,9 @@
           <infoLinks>
             <infoLink id="e1b2-ebce-e7d6-b50d" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1799,6 +1806,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="401c-9645-5826-7a8d" name="Barbarian Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -1984,6 +1992,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="c287-473a-282f-5d55" name="Warrior Knight Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -2223,6 +2232,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="4584-b35e-76e3-2b01" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2326,6 +2336,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="e31b-83c7-0a76-153b" name="Chosen Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -2554,6 +2565,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="88ce-5683-6812-8ff5" name="Chosen Knight Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -2723,6 +2735,7 @@
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">7&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="4ae3-59bc-1403-6d42" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -2877,6 +2890,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="c04e-aea7-a47d-fcd7" name="Forsworn Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3075,6 +3089,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3D6&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="5465-ce6a-eb7f-df91" name="Wretched One Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3145,6 +3160,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="acbe-c9a3-29b8-3d36" name="Barbarian Horseman Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3313,6 +3329,7 @@
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">10&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">20&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="bcc9-7ed1-85c7-c66b" name="Flayer Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3520,6 +3537,7 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="9e80-b450-02bd-22c3" name="Warhounds Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3592,6 +3610,7 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
                 <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
                 <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
                 <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+                <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
               </characteristics>
             </profile>
             <profile id="c8b7-3a01-160f-2aa7" name="Feldrak Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3717,6 +3736,7 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">3D6&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">-</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="71c2-3e31-5119-d934" name="Forsaken One Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3782,6 +3802,7 @@ During their owner’s first Player Turn, Warhounds gain +8” March Rate and De
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="df00-8668-7886-12ae" name="Giant Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -3906,6 +3927,7 @@ Whenever the model loses a Health Point, it gains +1 Attack Value. Whenever it g
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="9aa5-ccae-4c28-a278" name="Feldrak Elder Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4002,6 +4024,7 @@ Whenever the model loses a Health Point, it gains +1 Attack Value. Whenever it g
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">5</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="71d6-5aab-a405-570d" name="Hellmaw Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4123,6 +4146,7 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">20&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="881b-18fd-6b19-56e9" name="Chimera Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4202,6 +4226,7 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="0035-279f-f7a7-fca3" name="Battleshrine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4222,8 +4247,8 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
         </profile>
         <profile id="b2e4-7bb4-ec85-1e50" name="Wretched One (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
           <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a"></characteristic>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"></characteristic>
+            <characteristic name="Att" typeId="8265-800f-bc87-d00a"/>
+            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"/>
             <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
             <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
             <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
@@ -4280,6 +4305,9 @@ Only a single unit may exit the same Gateway Marker in each Player Turn.</descri
           <infoLinks>
             <infoLink id="fd34-005d-2dc3-3cdf" name="Beacon of the Dark Gods" hidden="false" targetId="2f11-4959-f8a3-c84e" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -4433,6 +4461,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">20&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="411a-b59a-c9be-3868" name="Chimera Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4506,6 +4535,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="360c-580c-4028-e829" name="Wasteland Behemoth Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4572,6 +4602,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="6217-a8fd-24d9-404e" name="Black Steed Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -4619,6 +4650,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="e627-1efe-c11a-8100" name="Chassis Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -4682,6 +4714,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="f157-e198-938c-b37b" name="Karkadan Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -4729,6 +4762,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">10&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">20&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="9ba1-70d6-72c7-4c01" name="Shadow Chaser Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -4777,6 +4811,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground C, Fly 6&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground C, March 18&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="d2fd-ddd6-40f6-b7e4" name="Scythed Skywheel Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -4831,6 +4866,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">C</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">C</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="40de-fe33-2de1-8fb3" name="War Dais Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -4880,6 +4916,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">Ground 8&quot;, Fly 6&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">Ground 16&quot;, 12&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="6a30-59d0-1fa7-6353" name="Wasteland Dragon Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4949,6 +4986,7 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&apos;&apos;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&apos;&apos;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="f02f-6098-ee5d-753c" name="Battleshrine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
@@ -4999,6 +5037,9 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
           <infoLinks>
             <infoLink id="b3e7-ee03-2db2-b939" name="Keeper of the Beacon" hidden="false" targetId="f32d-b75a-8a59-8e8e" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/warriorsOfTheDarkGods.cat
+++ b/warriorsOfTheDarkGods.cat
@@ -828,7 +828,11 @@
                 <entryLink id="b1ae-b0eb-839c-e313" name="Artefacts" hidden="false" collective="false" import="true" targetId="17df-ad66-db37-0a37" type="selectionEntryGroup"/>
                 <entryLink id="d717-8f60-e3f1-efa2" name="Banner Enchantments" hidden="true" collective="false" import="true" targetId="ec38-a844-0013-74ac" type="selectionEntryGroup">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false"/>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="6de7-3d7b-8973-aa1c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2179-8bca-59a3-9600" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                 </entryLink>
               </entryLinks>
@@ -951,6 +955,88 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15f4-fcf5-e851-94b4" type="max"/>
           </constraints>
+          <selectionEntries>
+            <selectionEntry id="2179-8bca-59a3-9600" name="Battleshrine" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a19-a2b4-67d1-2a7c" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="93c5-a1df-7974-8647" name="Wretched One (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
+                  <characteristics>
+                    <characteristic name="Att" typeId="8265-800f-bc87-d00a"/>
+                    <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"/>
+                    <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
+                    <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
+                    <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
+                    <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Grind Attacks (D6+1), Harnessed</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="172c-f7c3-481d-7f83" name="Battleshrine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+                  <characteristics>
+                    <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&apos;&apos;</characteristic>
+                    <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&apos;&apos;</characteristic>
+                    <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
+                    <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
+                  </characteristics>
+                </profile>
+                <profile id="6462-4871-8fe5-5773" name="Battleshrine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
+                  <characteristics>
+                    <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
+                    <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
+                    <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
+                    <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
+                    <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Aegis (5+)</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="3aa5-1748-4f9d-9812" name="Battleshrine Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
+                  <characteristics>
+                    <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
+                    <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Construct</characteristic>
+                    <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×100</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="067d-5d3b-0a68-b379" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (5+)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="42cd-c05d-e41c-1294" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
+                <infoLink id="7078-9aeb-221c-5c53" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
+                <infoLink id="ad97-4394-539b-29be" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (D6+1)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="380f-9570-26a1-96ca" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
+                <infoLink id="02ed-9906-b47b-d724" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" (1)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="6074-718d-4963-74dd" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
+                <infoLink id="2648-afbb-8bd0-e3d8" name="Trophy Rack" hidden="false" targetId="a06f-390d-cf8b-795d" type="rule"/>
+              </infoLinks>
+              <selectionEntries>
+                <selectionEntry id="8c3e-d745-a8c3-13ac" name="Keeper of the Beacon" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eada-02b8-4764-0960" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e330-fc08-7fd3-e656" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f861-042e-ab60-290b" name="Keeper of the Beacon" hidden="false" targetId="f32d-b75a-8a59-8e8e" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <entryLinks>
             <entryLink id="6edb-01f0-367f-f69c" name="Black Steed" hidden="false" collective="false" import="true" targetId="4851-37d7-9820-f20b" type="selectionEntry">
               <modifiers>
@@ -1002,14 +1088,6 @@
               <categoryLinks>
                 <categoryLink id="fde9-41df-000e-506a" name="Legendary Beasts (local)" hidden="false" targetId="1fbe-4213-4620-8ebc" primary="false"/>
               </categoryLinks>
-            </entryLink>
-            <entryLink id="5734-ced8-7f12-7815" name="Battleshrine" hidden="false" collective="false" import="true" targetId="1b4a-aa28-6744-2c55" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="24fd-8af8-0c78-001c" value="280"/>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8730-668c-12e8-4307" type="max"/>
-              </constraints>
             </entryLink>
             <entryLink id="adfe-bf3c-5479-e6a8" name="War Dais" hidden="false" collective="false" import="true" targetId="b168-546c-9ddc-a9b9" type="selectionEntry">
               <modifiers>
@@ -4967,83 +5045,6 @@ The model part gains Lightning Reflexes and +1 Agility. Close Combat Attacks all
       </constraints>
       <costs>
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1b4a-aa28-6744-2c55" name="Battleshrine (Mount)" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="b7f9-5c50-b902-8af9" name="Wretched One (2) Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
-          <characteristics>
-            <characteristic name="Att" typeId="8265-800f-bc87-d00a"/>
-            <characteristic name="Off" typeId="7d3b-bb95-3d29-26f7"/>
-            <characteristic name="Str" typeId="4d4a-2100-804f-99e5">4</characteristic>
-            <characteristic name="AP" typeId="7a8c-adb0-d1b8-a1b6">0</characteristic>
-            <characteristic name="Agi" typeId="2a23-367f-8828-c297">1</characteristic>
-            <characteristic name="Rules" typeId="44e9-6a3e-7471-8b36">Grind Attacks (D6+1), Harnessed</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="8faf-d47e-32ac-48fe" name="Battleshrine Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
-          <characteristics>
-            <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">5&apos;&apos;</characteristic>
-            <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">10&apos;&apos;</characteristic>
-            <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">C</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
-          </characteristics>
-        </profile>
-        <profile id="f02f-6098-ee5d-753c" name="Battleshrine Defensive" hidden="false" typeId="e7d3-5099-e669-c365" typeName="2 Defensive">
-          <characteristics>
-            <characteristic name="HP" typeId="f381-7850-7fa8-3440">5</characteristic>
-            <characteristic name="Def" typeId="160d-4624-273f-2114">C</characteristic>
-            <characteristic name="Res" typeId="ec15-bc66-645e-db5d">5</characteristic>
-            <characteristic name="Arm" typeId="597b-8735-3dd1-0e70">C+1</characteristic>
-            <characteristic name="Rules" typeId="91c5-9d30-bda7-cf14">Aegis (5+)</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="f5a0-b2c8-cefe-2311" name="Battleshrine Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
-          <characteristics>
-            <characteristic name="Height" typeId="0d1d-aeaf-8f31-fd17">Large</characteristic>
-            <characteristic name="Type" typeId="1176-4910-e04b-f1c5">Construct</characteristic>
-            <characteristic name="Base" typeId="7bbb-3d47-ed57-284d">50×100</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="b3f1-0108-3090-a3d4" name="Aegis" hidden="false" targetId="4966-e452-f252-6176" type="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (5+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="c484-93c2-8ecc-1252" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
-        <infoLink id="4f8f-858c-0ec7-7904" name="Fear" hidden="false" targetId="ed2a-e8b3-cc1a-cce0" type="rule"/>
-        <infoLink id="54c1-04ee-5445-d66a" name="Grind Attacks" hidden="false" targetId="1728-908f-7383-29d6" type="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (D6+1)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="e24d-1896-e97a-1195" name="War Platform" hidden="false" targetId="ccef-5d47-fa0a-8bdf" type="rule"/>
-        <infoLink id="de9f-f5af-6397-4835" name="Channel" hidden="false" targetId="5a46-f1e8-f840-a1de" type="rule">
-          <modifiers>
-            <modifier type="append" field="name" value=" (1)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="d989-779d-4c03-0ccb" name="Towering Presence" hidden="false" targetId="9ca4-65be-33fc-5d47" type="rule"/>
-        <infoLink id="c695-825d-7066-d278" name="Trophy Rack" hidden="false" targetId="a06f-390d-cf8b-795d" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="55ab-53bb-ff6c-6606" name="Keeper of the Beacon" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="984b-a2d9-3160-d109" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2e7-8ec4-2937-dd5d" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="b3e7-ee03-2db2-b939" name="Keeper of the Beacon" hidden="false" targetId="f32d-b75a-8a59-8e8e" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="688c-1c93-1305-530a" name="Immortal Gauntlets" hidden="false" collective="false" import="true" type="upgrade">

--- a/warriorsOfTheDarkGods.cat
+++ b/warriorsOfTheDarkGods.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.1.5" revision="52" battleScribeVersion="2.03" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9cd6-2c84-c59e-7dd1" name="Warriors of the Dark Gods 2.1.5" revision="53" battleScribeVersion="2.03" authorName="Mikel2311, DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="25f6-6ecf-2669-118b" name="8 Manifestation">
       <characteristicTypes>


### PR DESCRIPTION
This is not a fix but a workaround as it seems there's a regression bug in BS. This makes banner enchantments hidden = false so user can create armies with their own validation at least