### PR TITLE
Fix #537 - DH missing runes

### DIFF
--- a/dwarvenHolds.cat
+++ b/dwarvenHolds.cat
@@ -3603,50 +3603,41 @@ Shooting Attacks with this weapon are affected by all Runic Weapon Enchantments 
             <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
           </costs>
         </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="249a-d8a5-c50c-ec77" name="Dominant Talismanic Runes" hidden="false" collective="false" import="true">
+        <selectionEntry id="c2c3-b939-ad2a-24be" name="Rune of Devouring - Runic Smiths only - Dominant" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4183-3a53-e61a-a60e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a81-e6f1-c44f-f4b9" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25c7-d260-7417-93ad" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="d2e1-5875-4d27-8aec" name="Rune of Denial" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04e2-a2c4-207f-b302" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b3d-808d-7f79-87c7" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="02ea-1b24-d581-c1de" name="Rune of Denial" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-                  <characteristics>
-                    <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
-                    <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The bearer may choose to use this Rune instead of making a Dispel Attempt. The spell is automatically dispelled.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bf71-9aed-fffb-7632" name="Rune of Devouring - Runic Smiths only" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f537-a5bb-01e4-a4b1" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4431-8871-78a8-621d" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="7cba-13e1-8d0f-794e" name="Rune of Devouring" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
-                  <characteristics>
-                    <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
-                    <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The player may choose to use this Rune instead of making a Dispel Attempt. The spell is cast as normal but is afterwards lost and the Caster may not cast it again for the rest of the game.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+          <profiles>
+            <profile id="8b99-adfa-5e7a-7df9" name="Rune of Devouring" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The player may choose to use this Rune instead of performing a Dispelling Attempt. The spell is cast as normal but the Caster may not cast it again for the rest of the game. Spells dispelled by the Rune of Revocation and Attribute Spells are not affected.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="201c-cefe-b1b2-17c8" name="Rune of Denial - Dominant" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9952-6e8e-cd2f-52c7" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb01-ff7d-4aa6-6d53" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7856-338a-80d1-a445" name="Rune of Denial" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
+              <characteristics>
+                <characteristic name="Type" typeId="d779-a728-a38c-8340">Talismanic Rune</characteristic>
+                <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The bearer may choose to use this Rune instead of making a Dispel Attempt. The spell is automatically dispelled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="90.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="82ba-77be-be53-fcef" name="Runic Banner Enchantments" hidden="false" collective="false" import="true">
       <constraints>


### PR DESCRIPTION
Dominant runes were there but in its own group which was missed. I moved runes back to where expected for now. Dominant fix will be applied in its own 