### PR TITLE
Update KoE Ordo Sergeant

### DIFF
--- a/kingdomOfEquitaine2.cat
+++ b/kingdomOfEquitaine2.cat
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="204b-f298-c044-edc2" name="Kingdom of Equitaine 2022.2 Alpha 4" revision="4" battleScribeVersion="2.03" authorName="DarkSky" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="54" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="204b-f298-c044-edc2" name="Kingdom of Equitaine 2022.2 Alpha 4" revision="9" battleScribeVersion="2.03" authorName="DarkSky &amp; Dienben" authorContact="" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="55" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <readme>WIP from T9A-FB-Kingdom of Equitaine 2nd Edition, version 2023 beta 2 – May 8, 2023
+Known issue:
+- Ordo sergent: cost of Great Weapon is not 1pt per model</readme>
+  <publications>
+    <publication id="8057-6cef-3ef5-d288" name="T9A-FB-Kingdom of Equitaine 2nd Edition, version 2023 beta 2 – May 8, 2023" shortName="Kingdom of Equitaine 2nd Edition – May 8, 2023">
+      <comment>T9A-FB-Kingdom of Equitaine</comment>
+    </publication>
+  </publications>
   <profileTypes>
     <profileType id="5280-86a1-d490-10b8" name="2 Defensive Koe">
       <characteristicTypes>
@@ -1113,14 +1121,14 @@ The Folk Hero model part must choose at least 1 and up to 2 different Heroic Tra
         <cost name="pts" typeId="24fd-8af8-0c78-001c" value="-40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8204-565a-6f6b-6a0d" name="Ordo Sergeants" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="8204-565a-6f6b-6a0d" name="Ordo Sergeants" publicationId="8057-6cef-3ef5-d288" page="12" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="bba9-6480-8cc8-5821" name="Ordo Sergeant Global" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
+        <profile id="bba9-6480-8cc8-5821" name="Ordo Sergeant Global" page="" hidden="false" typeId="8292-1fb8-8251-29a9" typeName="1 Global">
           <characteristics>
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">8&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">16&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"></characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d">Ordo Minister, Scoring</characteristic>
           </characteristics>
         </profile>
         <profile id="8528-915a-f698-332d" name="Ordo Sergeant Defensive" hidden="false" typeId="5280-86a1-d490-10b8" typeName="2 Defensive Koe">
@@ -1165,19 +1173,25 @@ The Folk Hero model part must choose at least 1 and up to 2 different Heroic Tra
         <infoLink id="f7a4-1b91-c6ac-787e" name="Honesty" hidden="false" targetId="b124-6c67-9a2d-a06d" type="rule"/>
         <infoLink id="1e16-f40f-0722-a709" name="Hatred" hidden="false" targetId="13c5-ce89-60ad-c572" type="rule"/>
         <infoLink id="9cf1-e45a-6af1-8293" name="Heavy Armour" hidden="false" targetId="37ab-dde5-6b99-7c67" type="profile"/>
+        <infoLink id="a7e5-10b5-29aa-8d2d" name="Ordo Minister" publicationId="8057-6cef-3ef5-d288" page="12" hidden="false" targetId="97b7-021c-aeef-e076" type="rule"/>
+        <infoLink id="85e7-63cc-cef5-7084" name="Scoring" publicationId="8057-6cef-3ef5-d288" page="12" hidden="false" targetId="188e-05fb-8a95-60c8" type="rule"/>
+        <infoLink id="5d7c-adda-402a-9ab3" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1ef9-4cc6-fc0b-d2af" name="New CategoryLink" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="20f8-38f3-3102-9253" name="Ordo Sergeant" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="20f8-38f3-3102-9253" name="Ordo Sergeant" publicationId="8057-6cef-3ef5-d288" page="12" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5ea3-b181-e6f7-207f" type="min"/>
             <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6edc-79a1-9117-1e79" type="max"/>
             <constraint field="selections" scope="roster" value="30.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24da-528b-3217-02b5" type="max"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="0e78-bd2d-8e28-3a0f" name="Core" hidden="false" targetId="4bcd-01c8-ce5e-7108" primary="false"/>
+          </categoryLinks>
           <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="21.0"/>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="20.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1195,7 +1209,7 @@ The Folk Hero model part must choose at least 1 and up to 2 different Heroic Tra
           </constraints>
           <entryLinks>
             <entryLink id="3261-51f6-ca50-dfd9" name="Banner Enchantments (Unit)" hidden="false" collective="false" import="true" targetId="4eb1-cabb-a838-a005" type="selectionEntryGroup"/>
-            <entryLink id="c039-e916-3554-f520" name="2022 KoE Banner Enchantments (Core)" hidden="false" collective="false" import="true" targetId="d2b3-2992-90c7-c460" type="selectionEntryGroup"/>
+            <entryLink id="c039-e916-3554-f520" name="KoE Banner Enchantments (Core)" hidden="false" collective="false" import="true" targetId="d2b3-2992-90c7-c460" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c06d-99ff-a8d3-2363" name="Melee Weapon" hidden="false" collective="false" import="true">
@@ -1208,8 +1222,15 @@ The Folk Hero model part must choose at least 1 and up to 2 different Heroic Tra
               <modifiers>
                 <modifier type="append" field="name" value="and Shield"/>
               </modifiers>
+              <infoLinks>
+                <infoLink id="fefc-f53f-92c7-3be8" name="Shield" hidden="false" targetId="1da1-0128-4bf2-cf8d" type="profile"/>
+              </infoLinks>
             </entryLink>
-            <entryLink id="4cdf-a46e-3343-2fa1" name="Great Weapon" hidden="false" collective="false" import="true" targetId="2837-ec0d-956f-690a" type="selectionEntry"/>
+            <entryLink id="4cdf-a46e-3343-2fa1" name="Great Weapon" publicationId="8057-6cef-3ef5-d288" page="12" hidden="false" collective="false" import="true" targetId="2837-ec0d-956f-690a" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="1.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1217,7 +1238,7 @@ The Folk Hero model part must choose at least 1 and up to 2 different Heroic Tra
         <entryLink id="4816-6ac8-3e0f-1e58" name="Command Group" hidden="false" collective="false" import="true" targetId="b4c3-e840-1bd5-b746" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="62.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="80.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="106a-d83a-b38c-aa72" name="Lowborn Levies" hidden="false" collective="false" import="true" type="unit">
@@ -1782,6 +1803,9 @@ The model gains Bodyguard (Sainted or General with Courage).
 In addition, unless Charging out of the unit, Characters joined to units with one or more models with Knights of the Court gain Devastating Charge (+1′′ Adv).</description>
             </rule>
           </rules>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2340,7 +2364,7 @@ While joined by a model with Sainted or a General with Courage, the model’s un
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"></characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="bc69-9889-2141-cb24" name="Hooded Man Defensive" hidden="false" typeId="5280-86a1-d490-10b8" typeName="2 Defensive Koe">
@@ -2350,7 +2374,7 @@ While joined by a model with Sainted or a General with Courage, the model’s un
             <characteristic name="Res" typeId="60b8-9f24-3829-8c84">3</characteristic>
             <characteristic name="Arm" typeId="2d2a-d351-541b-27f1">0</characteristic>
             <characteristic name="Aeg" typeId="0931-3c5e-6bbd-6c1c">6+</characteristic>
-            <characteristic name="Rules" typeId="0648-d066-1f9b-29ed"></characteristic>
+            <characteristic name="Rules" typeId="0648-d066-1f9b-29ed"/>
           </characteristics>
         </profile>
         <profile id="de22-162a-0f27-6bb2" name="Hooded Man Size" hidden="false" typeId="7733-ad26-4b46-6a5a" typeName="0 Size">
@@ -2409,6 +2433,9 @@ The model gains Hard Target (1) and Skirmisher and loses Daring and Unstable.</d
             </infoLink>
             <infoLink id="ccf4-507d-856d-bbaf" name="Skirmisher" hidden="false" targetId="2ce4-ece5-068c-4d20" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2537,7 +2564,7 @@ Catapult (4×4), Range 12–72″, Shots 1, Str 4, AP 1. The model’s Height is
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (8&quot;)</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (16&quot;)</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"></characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="9b7f-4b6c-aacf-2da8" name="Pegasus Knight Defensive" hidden="false" typeId="5280-86a1-d490-10b8" typeName="2 Defensive Koe">
@@ -2652,7 +2679,7 @@ Catapult (4×4), Range 12–72″, Shots 1, Str 4, AP 1. The model’s Height is
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">7&quot; (10&quot;)</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">14&quot; (14&quot;)</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">8</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"></characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="b759-a236-3168-5f7b" name="Sky Herald Defensive" hidden="false" typeId="5280-86a1-d490-10b8" typeName="2 Defensive Koe">
@@ -2891,7 +2918,7 @@ The model may perform a Sweeping Attack. The enemy unit suffers 1 hit with Stren
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">6&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">12&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">9</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"></characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d"/>
           </characteristics>
         </profile>
         <profile id="a733-c506-2d69-3589" name="The Lady&apos;s Courtier Defensive" hidden="false" typeId="5280-86a1-d490-10b8" typeName="2 Defensive Koe">
@@ -3101,6 +3128,9 @@ The Fey Rider gains +1 Attack Value for each enemy model in base contact with it
 The Fey Rider gains Bastard Sword. The model gains Stubborn, Aegis (4+, against Melee Attacks), and counts as a Champion for the purpose of Issuing and Accepting Duels.</description>
                 </rule>
               </rules>
+              <costs>
+                <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -3994,6 +4024,9 @@ While using this Shield, the bearer must reroll Armour Save rolls of ‘1’.</d
       <infoLinks>
         <infoLink id="8d30-6bf7-69ec-677a" name="Prepared Position" hidden="false" targetId="bdc9-a3c1-fc59-8ad2" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -4281,9 +4314,10 @@ The model gains the following rules:
 • The model may take a single Banner Enchantment from this Army Book, for which it is considered to have a Special Item allowance with no limit.
 • When calculating Combat Score, the model adds +1 to its side’s Combat Score.</description>
     </rule>
-    <rule id="97b7-021c-aeef-e076" name="Ordo Minister" hidden="false">
-      <description>0–2 Models/Army.
-At the start of each friendly Magic Phase, each unit containing one or more models with Ordo Minister may remove a single token from the Blessing Token pool. If so, the unit, or a model inside the model’s unit, may Raise 1 Health Point.</description>
+    <rule id="97b7-021c-aeef-e076" name="Ordo Minister" publicationId="8057-6cef-3ef5-d288" page="3" hidden="false">
+      <description>At the start of each friendly Magic Phase, you may apply the following rules to each unit containing one or more models with Ordo Minister:
+• The unit, or a model inside the unit, may Raise 1 Health Point.
+• In order to Raise a Health Point of a Champion or Character, 1 Blessing Token has to be removed from the owner’s Blessing Token pool.</description>
     </rule>
     <rule id="029c-f026-e2f4-072d" name="Orisons" hidden="false">
       <description>Each Kingdom of Equitaine army has a pool of Blessing Tokens that can never contain more than 6 tokens. At the start of step 7 of the Pre-Game Sequence (Spell Selection), add 1 Blessing Token per 3000 Army Points to the pool, rounding fractions up.
@@ -4305,7 +4339,7 @@ their models with Courage ignore friendly units consisting entirely of models wi
 Tests.</description>
     </rule>
     <rule id="b124-6c67-9a2d-a06d" name="Honesty" hidden="false">
-      <description>The model gains Aegis (5+).</description>
+      <description>The model gains Aegis (5+, against Magical Attacks).</description>
     </rule>
     <rule id="cfb7-648a-9b76-fca4" name="Ordeal" hidden="false">
       <description>The model gains Aegis (5+) while its unit is Engaged in the same Combat as at least one other friendly unit.</description>


### PR DESCRIPTION
Fix:
- Honesty rule
- Ordo Sergeants:
	- Add Harnessed rules
	- Add Ordo Minister Rule
	- Add Scoring rule
	- Update cost
	- add shield in case of lance & Shield

Added:
	- Publication: T9A-FB-Kingdom of Equitaine 2nd Edition, version 2023 beta 2 – May 8, 2023
	- Ordo Minister Rule

Known issues:
- Ordo Sergeants:
	- 1 point per Sergent is no taken into account when selecting Great Weapon