### PR TITLE
Update KoE: Rules and Damsel

### DIFF
--- a/kingdomOfEquitaine2.cat
+++ b/kingdomOfEquitaine2.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="204b-f298-c044-edc2" name="Kingdom of Equitaine 2022.2 Alpha 4" revision="9" battleScribeVersion="2.03" authorName="DarkSky &amp; Dienben" authorContact="" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="55" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="204b-f298-c044-edc2" name="Kingdom of Equitaine 2022.2 Alpha 4" revision="11" battleScribeVersion="2.03" authorName="DarkSky &amp; Dienben" authorContact="" library="false" gameSystemId="aa64-1e8e-66fc-9abf" gameSystemRevision="55" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>WIP from T9A-FB-Kingdom of Equitaine 2nd Edition, version 2023 beta 2 – May 8, 2023
 Known issue:
 - Ordo sergent: cost of Great Weapon is not 1pt per model</readme>
@@ -201,7 +201,7 @@ The model’s Health Points are set to 8, and its base size is changed to 75×10
             <characteristic name="Adv" typeId="b0d9-2dab-f10b-9b13">4&quot;</characteristic>
             <characteristic name="Mar" typeId="db10-a838-f72f-3ed6">8&quot;</characteristic>
             <characteristic name="Dis" typeId="be28-67a6-2280-9eaf">7</characteristic>
-            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d">Orison(1)</characteristic>
+            <characteristic name="Rules" typeId="8f96-9d74-2aaa-da9d">Beloved, Wizard Apprentice</characteristic>
           </characteristics>
         </profile>
         <profile id="7a3d-d2e9-3f50-0fe0" name="Damsel Offensive" hidden="false" typeId="154c-6605-1486-e1da" typeName="3 Offensive">
@@ -220,7 +220,7 @@ The model’s Health Points are set to 8, and its base size is changed to 75×10
             <characteristic name="Def" typeId="2f91-bb43-b822-ba6c">3</characteristic>
             <characteristic name="Res" typeId="60b8-9f24-3829-8c84">3</characteristic>
             <characteristic name="Arm" typeId="2d2a-d351-541b-27f1">0</characteristic>
-            <characteristic name="Aeg" typeId="0931-3c5e-6bbd-6c1c">5+</characteristic>
+            <characteristic name="Aeg" typeId="0931-3c5e-6bbd-6c1c">6+</characteristic>
             <characteristic name="Rules" typeId="0648-d066-1f9b-29ed">Honesty</characteristic>
           </characteristics>
         </profile>
@@ -283,7 +283,7 @@ While the model is joined to a unit with at least one Full Rank, it gains Stand 
                   </constraints>
                   <entryLinks>
                     <entryLink id="ae6e-2121-8af9-b23b" name="Weapon Enchantments" hidden="false" collective="false" import="true" targetId="f853-d3c3-4165-d5ab" type="selectionEntryGroup"/>
-                    <entryLink id="5ff4-aeb7-36ce-bde6" name="2022 KoE Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
+                    <entryLink id="5ff4-aeb7-36ce-bde6" name="KoE Weapon Enchantments" hidden="false" collective="false" import="true" targetId="b1ad-c078-481f-9e34" type="selectionEntryGroup"/>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="90d7-166c-b6e6-dc66" name="Artefacts" hidden="false" collective="false" import="true">
@@ -459,7 +459,7 @@ While the model is joined to a unit with at least one Full Rank, it gains Stand 
         <entryLink id="c364-9f0a-18df-597c" name="Army General" hidden="false" collective="false" import="true" targetId="d664-b973-594c-5971" type="selectionEntry"/>
         <entryLink id="0d16-09e5-3f99-a559" name="Sainted" hidden="false" collective="false" import="true" targetId="60d5-4889-6942-b867" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
+            <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -2223,7 +2223,6 @@ While joined by a model with Sainted or a General with Courage, the model’s un
       <infoLinks>
         <infoLink id="71a1-3030-8f4d-4a37" name="Lance Formation" hidden="false" targetId="b53e-e733-517e-8c2d" type="rule"/>
         <infoLink id="c20c-6758-ed60-3452" name="Courage" hidden="false" targetId="e242-3ed9-fea8-8646" type="rule"/>
-        <infoLink id="ffbf-d1c0-3060-907a" name="Daring" hidden="false" targetId="51ae-3dd0-334a-7809" type="rule"/>
         <infoLink id="d5a5-ab83-2415-2df1" name="Unstable" hidden="false" targetId="b642-5b33-158d-421b" type="rule"/>
         <infoLink id="c263-3b7e-6330-6f8d" name="Great Weapon" hidden="false" targetId="ce6c-6fd5-c795-da76" type="profile"/>
         <infoLink id="4d28-54cb-dc9d-e82d" name="Harnessed" hidden="false" targetId="3d09-e862-b7b5-fc26" type="rule"/>
@@ -2399,7 +2398,6 @@ While joined by a model with Sainted or a General with Courage, the model’s un
         <infoLink id="dd2c-f68d-3d52-8b3e" name="Unstable" hidden="false" targetId="b642-5b33-158d-421b" type="rule"/>
         <infoLink id="545d-1035-6220-9a22" name="Scout" hidden="false" targetId="1c9f-ec16-529b-e3ca" type="rule"/>
         <infoLink id="f678-b585-b0c1-18d8" name="Ordeal" hidden="false" targetId="cfb7-648a-9b76-fca4" type="rule"/>
-        <infoLink id="c0c9-ff88-bb5c-4dd9" name="Daring" hidden="false" targetId="51ae-3dd0-334a-7809" type="rule"/>
         <infoLink id="48c4-db91-0fc5-1399" name="Paired Weapons" hidden="false" targetId="06d7-e62c-0123-95ec" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -3372,13 +3370,13 @@ Failed to−wound rolls of Close Combat Attacks against which the target has a S
         <profile id="1e85-c4a8-906f-ec6c" name="Castellan&apos;s Crest" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
             <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
-            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Cavalry models only.
-The bearer’s unit adds +1 to its side’s Combat Score if the unit has at least 3 Full Ranks.</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">0–3 per Army. Cavalry models only
+One use only. May be activated immediately beforedeclaring a Charge with the bearer or the bearer’sunit in the Charge Phase. Failed Charge Range rollsof the bearer or the bearer’s unit must be rerolleduntil the end of the phase. Other Characters Chargingout of the bearer’s unit are not affected.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="30.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="53f6-5304-550b-2534" name="Mortal Reminder" hidden="false" collective="false" import="true" type="upgrade">
@@ -3395,7 +3393,7 @@ The bearer’s unit adds +1 to its side’s Combat Score if the unit has at leas
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="459f-0da5-6ee8-5c27" name="Tristan&apos;s Resolve" hidden="false" collective="false" import="true" type="upgrade">
@@ -3412,7 +3410,7 @@ The bearer’s unit adds +1 to its side’s Combat Score if the unit has at leas
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="60.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d35-8fd4-a6c8-6b1a" name="Uther&apos;s Mettle" hidden="false" collective="false" import="true" type="upgrade">
@@ -3424,10 +3422,7 @@ The bearer’s unit adds +1 to its side’s Combat Score if the unit has at leas
         <profile id="bc58-6f8a-1821-3a7b" name="Uther&apos;s Mettle" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
             <characteristic name="Type" typeId="d779-a728-a38c-8340">Enchantment: Lance or Light Lance.</characteristic>
-            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Attacks made with this weapon ignore Parry. At the start of the Initiative Step in which the wielder’s Close Combat Attacks will be performed, nominate one enemy unit Engaged with the wielder’s Front Facing. The wielder gains +1 Attack Value, up to a maximum of +5:
-• For each rank of the nominated unit after the first if the wielder’s model is Engaged with the unit’s Front or Rear Facing.
-• For each file of the nominated unit after the first if the wielder’s model is Engaged with the unit’s Flank Facing.
-The additional attacks must be allocated towards non-Champion R&amp;F models of the nominated unit. If this is not possible, the additional attacks are ignored.</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Once per Round of Combat, unless fighting a Duel,after one or more successful to-hit rolls made withthis weapon against an enemy model, the target’sunit suffers 1 hit with Area Attack (1×5) in the sameInitiative Step as the initial Close Combat Attack. Thehits from the Area Attack have the same Strength, ArmourPenetration, and Attack Attributes as the initialClose Combat Attack. This is considered a SpecialAttack.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3443,7 +3438,7 @@ The additional attacks must be allocated towards non-Champion R&amp;F models of 
       <profiles>
         <profile id="16f7-1a4a-3c4c-de71" name="Prayer-Etched" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
-            <characteristic name="Type" typeId="d779-a728-a38c-8340">Enchantment: Heavy Armour</characteristic>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340">Enchantment: Suit of Armour</characteristic>
             <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The wearer gains +1 Armour and Aegis (+1, max. 4+).</characteristic>
           </characteristics>
         </profile>
@@ -3496,13 +3491,13 @@ The bearer gains Fear while Engaged in Combat. Enemy units in base contact with 
         <profile id="4895-0d32-75d9-f6cf" name="Relic Shroud" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
             <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
-            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">0–2 per Army. Models with Courage or Honesty only.
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">Models with Courage or Honesty only.
 The bearer of one or more Relic Shrouds can cast Breath of the Lady (Hereditary Spell) as a Bound Spell with Power Level (4/8).</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="55.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="86b1-c2ca-0b33-db3e" name="Banner of Elan" hidden="false" collective="false" import="true" type="upgrade">
@@ -3522,7 +3517,7 @@ The bearer of one or more Relic Shrouds can cast Breath of the Lady (Hereditary 
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="25.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="15.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="03c0-5e8c-a596-2d19" name="Banner of Roland" hidden="false" collective="false" import="true" type="upgrade">
@@ -3534,12 +3529,12 @@ The bearer of one or more Relic Shrouds can cast Breath of the Lady (Hereditary 
         <profile id="97c0-f1a5-1cdd-6a45" name="Banner of Roland" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
             <characteristic name="Type" typeId="d779-a728-a38c-8340">Banner Enchantment</characteristic>
-            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Aegis (+1, max. 4+, against Ranged Attacks). In addition, enemy units cannot choose Stand and Shoot as a Charge Reaction against Charges declared by the bearer’s unit.</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s unit gains Devastating Charge(Aegis (5+)). In addition, enemy units cannot chooseStand and Shoot as a Charge Reaction against Chargesdeclared by the bearer’s unit</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="50.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="40.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5567-de34-b22b-9ef5" name="Black Knight&apos;s Tabard" hidden="false" collective="false" import="true" type="upgrade">
@@ -3564,12 +3559,12 @@ The bearer of one or more Relic Shrouds can cast Breath of the Lady (Hereditary 
         <profile id="030c-4124-f378-9d52" name="Black Knight&apos;s Tabard" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
             <characteristic name="Type" typeId="d779-a728-a38c-8340">Artefact</characteristic>
-            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">The bearer’s model gains Immune (Multiple Wounds (X))</characteristic>
+            <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">One use only. The first time the bearer’s model suffersan unsaved wound from an attack with MultipleWounds (X), the model gains Immune (MultipleWounds (X)) until the end of the phase.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="45.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c7d8-de96-8d9e-b7b7" name="Sacred Chalice" hidden="false" collective="false" import="true" type="upgrade">
@@ -3597,13 +3592,13 @@ The bearer of one or more Relic Shrouds can cast Breath of the Lady (Hereditary 
       <profiles>
         <profile id="9252-c6c2-4516-cfe8" name="Divine Judgement" hidden="false" typeId="5bba-441c-01cb-6187" typeName="7 Artefact">
           <characteristics>
-            <characteristic name="Type" typeId="d779-a728-a38c-8340">Enchantment: Lance.</characteristic>
+            <characteristic name="Type" typeId="d779-a728-a38c-8340">Enchantment: Lance or Light Lance.</characteristic>
             <characteristic name="Effect" typeId="9f42-950f-d2ed-9247">After the wielder completes a Charge, attacks made with this weapon gain +2 Strength and +2 Armour Penetration until the wielder is no longer Engaged in Combat.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="65.0"/>
+        <cost name="pts" typeId="24fd-8af8-0c78-001c" value="70.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4728-58d3-5610-5c09" name="Mount: Destrier" hidden="false" collective="false" import="true" type="upgrade">
@@ -4046,7 +4041,7 @@ While using this Shield, the bearer must reroll Armour Save rolls of ‘1’.</d
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b98c-a11a-7cc1-4893" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="4db2-f78f-2b5a-649d" name="°Prayer-Etched" hidden="false" collective="false" import="true" targetId="53cd-6978-d265-0062" type="selectionEntry"/>
+        <entryLink id="4db2-f78f-2b5a-649d" name="Prayer-Etched" hidden="false" collective="false" import="true" targetId="53cd-6978-d265-0062" type="selectionEntry"/>
         <entryLink id="c5ba-d797-4319-60c2" name="Percival&apos;s Panoply" hidden="false" collective="false" import="true" targetId="3105-f1cd-ab4e-d511" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
@@ -4280,7 +4275,7 @@ The model is a Wizard Adept that chooses Witchcraft as its Path of Magic. If on 
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2a4-7866-19e5-65e3" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="4c1e-0ac0-8e0b-b81f" name="°Black Knight&apos;s Tabard" hidden="false" collective="false" import="true" targetId="5567-de34-b22b-9ef5" type="selectionEntry"/>
+        <entryLink id="4c1e-0ac0-8e0b-b81f" name="Black Knight&apos;s Tabard" hidden="false" collective="false" import="true" targetId="5567-de34-b22b-9ef5" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="8bbc-d5f3-def5-46a6" name="KoE Banner Enchantments (BSB)" hidden="false" collective="false" import="true">
@@ -4308,10 +4303,9 @@ The model gains Fight in Extra Rank. In addition, if the model is Standard, it g
       <description>During Army List creation, the unit gains a Gallantry value that corresponds to the value stated in brackets (X). Multiple instances of Gallantry (X) in the same unit do not stack. The sum of the Gallantry values of all units on the Army List is restricted to 1 per 650 Army Points, rounding fractions up.</description>
     </rule>
     <rule id="5ec3-3134-4ec5-5d04" name="Knight Banneret" hidden="false">
-      <description>0–2 Models/Army.
-The model gains the following rules:
+      <description>The model gains the following rules:
 • The model gains +1 Health Point, up to a maximum of 3.
-• The model may take a single Banner Enchantment from this Army Book, for which it is considered to have a Special Item allowance with no limit.
+• The model may take a single Banner Enchantment from this Army Book, for which it is considered to have aSpecial Item allowance with no limit.
 • When calculating Combat Score, the model adds +1 to its side’s Combat Score.</description>
     </rule>
     <rule id="97b7-021c-aeef-e076" name="Ordo Minister" publicationId="8057-6cef-3ef5-d288" page="3" hidden="false">
@@ -4333,10 +4327,8 @@ A single unit can only be the target of one Orison per Player Turn, unless speci
 Model parts without Harnessed gain Fearless, and +1 Attack value. In addition, the model is always under the effect of Orison of Shielding, Orison of Striking, and Orison of Discipline. This does not prevent the model’s unit from being the target of an Orison, but the model does not benefit from this additional Orison.</description>
     </rule>
     <rule id="e242-3ed9-fea8-8646" name="Courage" hidden="false">
-      <description>The model gains Aegis (5+) with the following restriction: The effect can only be used against wounds
-against which the model cannot take or would automatically fail its any Armour Saves. Units with more than half of
-their models with Courage ignore friendly units consisting entirely of models with Ordeal for the purpose of Panic
-Tests.</description>
+      <description>The model gains Aegis (5+) with the following restriction: The effect can only be used against wounds against which the model cannot take or would automatically fail its any Armour Saves. 
+Units with more than half of their models with Courage ignore friendly units consisting entirely of models with Ordeal for the purpose of Panic Tests.</description>
     </rule>
     <rule id="b124-6c67-9a2d-a06d" name="Honesty" hidden="false">
       <description>The model gains Aegis (5+, against Magical Attacks).</description>
@@ -4348,14 +4340,13 @@ Tests.</description>
       <description>At the start of step 7 of the Pre-Game Sequence (Spell Selection), add 1 Blessing Token to your Blessing Token pool for each model with Ordained on your Army List.</description>
     </rule>
     <rule id="bdc9-a3c1-fc59-8ad2" name="Prepared Position" hidden="false">
-      <description>When deploying the unit, you may place a Wall Terrain Feature with its centre within 2′′ of the unit but not in contact with any other Terrain Feature except Open Terrain. This Wall is up to 1′′ deep and up to 8′′ wide and follows the normal rules for Walls, with the exception that it contributes to Soft Cover instead of Hard Cover.</description>
+      <comment>0–3 Units/Army.</comment>
+      <description>0–3 Units/Army
+When deploying the unit, you may place a Wall Terrain Feature fully within 1″ of the unit’s Front Facing but not in contact with any other Terrain Feature except Open Terrain. This Wall is up to 1″ deep and its length cannot exceed the width of the unit, up to a maximum of 12″. It follows the normal rules for Walls, with the exception that it contributes to Soft Cover instead of Hard Cover.</description>
     </rule>
     <rule id="6bf0-ebd9-7d87-80fb" name="Mount Support" hidden="false">
       <description>Close Combat
 The model part ignores Harnessed for the purpose of Supporting Attacks.</description>
-    </rule>
-    <rule id="51ae-3dd0-334a-7809" name="Daring" hidden="false">
-      <description>Units with more than half of their models with Daring cannot voluntarily declare Flee as a Charge Reaction and must reroll failed Panic Tests.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Update Rules:
	- Prepared Position
	- Knight Banneret
	- Courage
	- Divine Judgement
	- Uther's mettle
	- Prayer−Etched
	- Relic Shroud
	- Banner of Roland
	- Castellan's Crest
	- Black Knight's Tabard

Updated Profile:
	- Damsel	

Price Update
	- Divine Judgement 
	- Tristan’s Resolve
	- Relic Shroud
	- Banner of Roland
	- Castellan’s Crest
	- Banner of Elan
	- Black Knight’s Tabard
	

Removed:
	- Daring Rule